### PR TITLE
docs: teach the extension model with a four-step lesson

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ What it does:
 - **Agent skill.** An installable skill (Help ▸ Install Agent Skill…) teaches Claude Code or Codex the control model and the `agtermctl` commands, so an agent running inside agterm can build its own layout, run overlays, manage windows, and show images inline without you explaining the API.
 - **Agent status.** A coding agent reports its state (active, blocked, or completed) onto its session's row, so you can see which of many running agents needs you. Status hooks for Claude Code, Codex, Pi, OpenCode, and other agents install from Help ▸ Install Agent Status Hooks….
 
+A lot of "does it have X?" questions have the same answer: bind X yourself. A `command` line in `keymap.conf` turns any shell line into a key chord, and an overlay gives an interactive program a real terminal over the session, so a file manager, a git UI, or a database browser is one line away. Bigger workflows become scripts, which is what the [cookbook](cookbook/) collects. [Extend agterm](https://agterm.com/docs#extend) walks through both, and an agent with the bundled skill installed will write the line for you.
+
 For the real terminal work, rendering, VT parsing, and shell I/O, `agterm` embeds [Ghostty](https://ghostty.org)'s engine (libghostty); everything above is `agterm`'s own.
 
 ![agterm](docs/screenshots/main.png)
@@ -33,7 +35,7 @@ An agent's interactive prompt mid-session, with attention glyphs on the sessions
 
 ![Agent prompt](docs/screenshots/agent-prompt.png)
 
-A file manager in a floating overlay over the active session:
+The yazi file manager in a floating overlay over the active session, from one `command` line in `keymap.conf`:
 
 ![Floating overlay](docs/screenshots/floating-overlay.png)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ What it does:
 - **Agent skill.** An installable skill (Help ▸ Install Agent Skill…) teaches Claude Code or Codex the control model and the `agtermctl` commands, so an agent running inside agterm can build its own layout, run overlays, manage windows, and show images inline without you explaining the API.
 - **Agent status.** A coding agent reports its state (active, blocked, or completed) onto its session's row, so you can see which of many running agents needs you. Status hooks for Claude Code, Codex, Pi, OpenCode, and other agents install from Help ▸ Install Agent Status Hooks….
 
-A lot of "does it have X?" questions have the same answer: bind X yourself. A `command` line in `keymap.conf` turns any shell line into a key chord, and an overlay gives an interactive program a real terminal over the session, so a file manager, a git UI, or a database browser is one line away. Bigger workflows become scripts, which is what the [cookbook](cookbook/) collects. [Extend agterm](https://agterm.com/docs#extend) walks through both, and an agent with the bundled skill installed will write the line for you.
+A lot of "does it have X?" questions have the same answer: bind X yourself. A `command` line in `keymap.conf` turns any shell line into a key chord, and an overlay gives an interactive program a real terminal over the session, so a file manager, a git UI, or a database browser is one line away. Bigger workflows become scripts, which is what the [cookbook](cookbook/) collects.
+
+You are not meant to write those lines by hand. Install the agent skill (Help ▸ Install Agent Skill…) and ask the agent in your session for what you want, and it writes the line with the right syntax, targeting, and PATH handling. [Extend agterm](https://agterm.com/docs#extend) shows that, and teaches enough of the model to read and change what comes back.
 
 For the real terminal work, rendering, VT parsing, and shell I/O, `agterm` embeds [Ghostty](https://ghostty.org)'s engine (libghostty); everything above is `agterm`'s own.
 

--- a/docs/backlog/edit-keymap-menu-hides-the-extension-mechanism.md
+++ b/docs/backlog/edit-keymap-menu-hides-the-extension-mechanism.md
@@ -1,0 +1,24 @@
+---
+worth: later
+where: agterm/agtermApp+Menus.swift
+added: 2026-08-20
+---
+# File ▸ Edit Keymap… does not read as "add features"
+
+The seeded `keymap.conf` is the best explanation of custom commands anywhere in the project. It documents
+the `command` directive, the detached-no-TTY limit, the PATH rule, the context tokens, and ships the
+`agtermctl session overlay open 'zsh -lc lazygit'` pattern (`agtermCore/Sources/agtermCore/ConfigPaths.swift:39-116`).
+It is better than the public docs were before the `#extend` lesson, and a user reaches it only by opening
+a menu item named after key configuration.
+
+Both menu entries name the mechanism rather than what it is for: `File ▸ Edit Keymap…` and
+`Navigate ▸ Custom Commands`. A user looking for a file browser has no reason to open either. The docs
+side of this is fixed (the lesson, the nav rename, the screenshot captions); the in-app affordance is not.
+
+Worth considering, none of it obviously right: wording that advertises extension rather than
+configuration, a Help entry that points at the lesson, or seeding the palette with one commented example
+so `Custom Commands` is not empty on a fresh install. All of it is AppKit/menu work whose cost should be
+priced on its own, which is why it was kept out of the docs change.
+
+Surfaced while brainstorming the onboarding gap after a new user asked whether agterm has a file browser
+and the answer turned out to be one keymap line.

--- a/docs/backlog/seeded-lazygit-example-omits-target.md
+++ b/docs/backlog/seeded-lazygit-example-omits-target.md
@@ -1,0 +1,29 @@
+---
+worth: later
+where: agtermCore/Sources/agtermCore/ConfigPaths.swift:77
+added: 2026-08-20
+---
+# the seeded Lazygit example omits --target and can open its overlay elsewhere
+
+The starter `keymap.conf` ships:
+
+```
+command "Lazygit"  ctrl+a>g  agtermctl session overlay open 'zsh -lc lazygit' --socket "$AGT_SOCKET"
+```
+
+`TargetOptions.target` defaults to `active` (`agtermCore/Sources/agtermctlKit/Commands.swift:69`), and `active`
+is resolved when the request reaches the server, not when the chord built its context. The custom command is
+spawned detached and fire-and-forget (`agterm/Commands/CustomCommandRunner.swift:336`), so a session or window
+switch between the keypress and delivery opens the overlay over whatever is selected by then. The command
+reference already tells automated callers to pin it (`site/commands.html:379`), and a custom command has the
+stable `$AGT_SESSION_ID` for exactly this.
+
+The fix is one flag: `--target "$AGT_SESSION_ID"`. The line is otherwise valid — `overlay open` does not
+require a size flag, so omitting `--size-percent` correctly gives a full-size overlay.
+
+Worth doing because the `#extend` lesson now sends new users to **File ▸ Edit Keymap…**, where they read this
+example next to the docs' pinned one and get two different answers. Kept out of the docs change (#PR) because
+touching `ConfigPaths.swift` pulls in the full Swift gate run for a one-line seed-text improvement, and no
+existing user is blocked by it.
+
+Found by codex while reviewing the paste lines in the `#extend` lesson.

--- a/site/docs.html
+++ b/site/docs.html
@@ -194,6 +194,9 @@
             <a href="#notifications" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Notifications</a>
             <a href="#accessibility" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Accessibility</a>
             <a href="#settings" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Customization</a>
+            <a href="#keymap" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9"
+              >Custom commands &amp; keys</a
+            >
             <div style="height: 16px"></div>
             <span style="color: #4a5158; font-size: 11px; letter-spacing: 0.12em; padding: 4px 12px">SCRIPTING</span>
             <a href="#agtermctl" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">agtermctl reference</a>
@@ -204,7 +207,6 @@
               class="hv9"
               >Cookbook ↗</a
             >
-            <a href="#keymap" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Customizing keys</a>
             <a href="#ghostty" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Ghostty config</a>
             <a href="#status" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Agent status</a>
             <div style="height: 16px"></div>
@@ -1228,6 +1230,346 @@
             </figure>
           </section>
 
+          <!-- KEYMAP -->
+          <section id="keymap" style="scroll-margin-top: 88px; padding-top: 56px">
+            <h2
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 700;
+                font-size: 28px;
+                letter-spacing: -0.02em;
+                margin: 0 0 16px;
+                padding-bottom: 12px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+              "
+            >
+              Custom commands &amp; keys
+            </h2>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 20px">
+              agterm reads a user-editable, kitty-flavored keymap file at
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">~/.config/agterm/keymap.conf</span
+              >. It rebinds built-in menu shortcuts and defines custom shell commands bound to keys (and listed in the action
+              palette). The file is optional — a commented starter is written on first launch, and the directory can be changed in
+              <strong style="color: #e6e1d7">Settings ▸ Key Mapping</strong>. Three verbs; blank lines and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">#</span> comments are ignored.
+            </p>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13.5px;
+                line-height: 1.95;
+                overflow-x: auto;
+                color: #e6e1d7;
+              "
+            >
+              <span style="color: #6b727a"># rebind a built-in to a chord (mods joined by +)</span><br /><span
+                style="color: #5ea1f2"
+                >map</span
+              >
+              cmd+shift+l&nbsp;&nbsp;&nbsp;toggle_split<br /><span style="color: #5ea1f2">map</span>
+              ctrl+shift+k&nbsp;&nbsp;command_palette<br /><br /><span style="color: #6b727a"
+                ># or to several alternatives, joined by | with no spaces around it</span
+              ><br /><span style="color: #5ea1f2">map</span>
+              cmd+t|ctrl+a&gt;t&nbsp;&nbsp;toggle_scratch<br /><br /><span style="color: #6b727a"
+                ># define custom commands ("name" shows in the palette; chord optional)</span
+              ><br /><span style="color: #5ea1f2">command</span>
+              <span style="color: #f2b45c">"Open in Zed"</span>&nbsp;&nbsp;cmd+shift+e&nbsp;&nbsp;open -a Zed {AGT_SESSION_PWD}<br /><span
+                style="color: #5ea1f2"
+                >command</span
+              >
+              <span style="color: #f2b45c">"Lazygit"</span
+              >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ctrl+a&gt;g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;agtermctl session overlay open 'zsh -lc lazygit'
+              --socket {AGT_SOCKET}<br /><span style="color: #5ea1f2">command</span>
+              <span style="color: #f2b45c">"Deploy"</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./deploy.sh<br /><br /><span
+                style="color: #6b727a"
+                ># one system-wide chord that summons the quick terminal from any application</span
+              ><br /><span style="color: #5ea1f2">global-hotkey</span> ctrl+opt+space
+            </div>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              A chord is modifier words (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >ctrl</span
+              >, <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">cmd</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">opt</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift</span>) joined by
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> and a base key (a single
+              character or <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">tab</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >space</span
+              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">return</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >delete</span
+              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">left</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >right</span
+              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">up</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >down</span
+              >). A Shift-typed symbol is written
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+&lt;base&gt;</span>
+              (e.g. <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+/</span> for
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">?</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+=</span> for
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span>) — the base key, not the
+              shifted symbol. Custom commands may also use a leader sequence
+              (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ctrl+a&gt;g</span>), and their chord
+              must include a modifier — a bare key can't shadow a plain terminal key.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> takes exactly one
+              chord and binds it <strong style="color: #e6e1d7">system-wide</strong>: it summons the quick terminal while any
+              application is frontmost, which no other binding here can do — the rest only fire while agterm has the keyboard. It
+              must carry a modifier, takes no alternatives and no leader sequence, and a second
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> line replaces the
+              first. macOS registers it by physical key position, so it keeps firing on a non-Latin layout. Because the system owns
+              it rather than agterm, it takes no part in the collision rules below. Note which side wins: the system-wide chord
+              takes the key even while agterm is in front, so binding one a menu item already uses means that menu shortcut stops
+              firing. It is unset unless you add the line: agterm ships no default because registering a chord takes it
+              from every other application on the Mac, and that is not a cost to impose on someone who may never summon
+              the panel from outside agterm. Spending it on the chord the in-app binding already uses is allowed and is
+              the way to get one shortcut that works everywhere —
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey ctrl+`</span>
+              makes <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">⌃`</span> summon the panel
+              from any application, at the price of that chord no longer reaching anything else.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              One binding can offer several <strong style="color: #e6e1d7">alternatives</strong>, joined by
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">|</span> inside a single token with no
+              spaces around it —
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map cmd+t|ctrl+a&gt;t toggle_scratch</span>
+              fires the action from either, and a <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span>
+              takes alternatives the same way. For a built-in, the first single-chord alternative the menu can carry becomes the menu
+              shortcut; every
+              other alternative, on either verb, is delivered by a key monitor and so must carry a modifier on its first chord. This
+              is also how a built-in gets a leader sequence, because a menu item holds exactly one key equivalent:
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map ctrl+a&gt;s toggle_split</span> binds
+              the sequence and leaves the action with no menu shortcut at all — its shipped ⌘D is gone rather than kept, and free for
+              another action to claim. A typo in one alternative rejects the whole line, so a mistake can't hide behind a line that
+              half worked; an alternative that merely breaks a rule or collides with an existing binding drops on its own and its
+              siblings keep firing. If a line ends up binding nothing at all, the action simply keeps the shortcut it shipped with.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              Chords are written in Latin and keep working on a non-Latin keyboard layout. A layout that cannot type ASCII —
+              Russian, Greek, Hebrew, Arabic, Thai — resolves every chord by the physical key position, so
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">cmd+o</span> still fires on the key
+              marked O even though it types <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">щ</span>.
+              A layout that can type ASCII binds what it types, so an alternative Latin layout keeps its own letter positions: on
+              Dvorak, <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">cmd+o</span> follows the O you
+              actually type.
+            </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              Bindable built-in actions
+            </h3>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.9;
+                overflow-x: auto;
+                color: #cbc6bc;
+              "
+            >
+              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />toggle_workspace_collapse<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_workspace&nbsp;&nbsp;&nbsp;next_workspace<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
+            </div>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> is the one
+              action with no menu item of its own. macOS adds an "Enter Full Screen" item to the View menu whenever that menu is
+              drawn, and nothing suppresses it, so an item of agterm's own would sit beside it as a duplicate. The binding (⌃⌘F by
+              default) is handled directly instead, which is why the menu entry advertises the system's Globe+F rather than your
+              chord. Both work, and rebinding
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> changes the
+              chord as usual — it just won't show up next to that menu item.
+            </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              Command tokens
+            </h3>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.9;
+                overflow-x: auto;
+                color: #cbc6bc;
+              "
+            >
+              {AGT_SESSION_ID}&nbsp;&nbsp;&nbsp;{AGT_SESSION_NAME}&nbsp;&nbsp;&nbsp;{AGT_SESSION_PWD}<br />{AGT_WORKSPACE_ID}&nbsp;&nbsp;&nbsp;{AGT_WORKSPACE_NAME}<br />{AGT_WINDOW_ID}&nbsp;&nbsp;&nbsp;{AGT_WINDOW_NAME}<br />{AGT_PANE}&nbsp;&nbsp;&nbsp;{AGT_SELECTION}&nbsp;&nbsp;&nbsp;{AGT_SOCKET}
+            </div>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              Tokens expand at fire time (also exported as
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_*</span> env vars on the spawned
+              process). A token is substituted <strong style="color: #e6e1d7">raw</strong> into the shell line, so for content you
+              don't control —
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">{AGT_SELECTION}</span>, and also
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">{AGT_SESSION_NAME}</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >{AGT_SESSION_PWD}</span
+              >
+              (a remote host can set these via OSC) — prefer the matching quoted env var, e.g.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">"$AGT_SELECTION"</span>.
+            </p>
+            <div
+              style="
+                background: rgba(242, 180, 92, 0.07);
+                border: 1px solid rgba(242, 180, 92, 0.22);
+                border-radius: 10px;
+                padding: 16px 18px;
+                margin: 20px 0 0;
+                font-size: 14px;
+                color: #e2c79a;
+                line-height: 1.65;
+              "
+            >
+              <strong style="color: #f2b45c; font-family: &quot;JetBrains Mono&quot;, monospace">Detached, no TTY</strong> — a
+              custom command runs as a detached
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/bin/sh -c</span> with no controlling terminal, so
+              it suits fire-and-forget launches (GUI apps, scripts) — not interactive TUIs. Run a TUI like
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">lazygit</span> in an overlay
+              (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl session overlay open</span>) or a scratch
+              terminal, which have a real TTY. A non-zero exit posts a notification banner.
+            </div>
+            <div
+              style="
+                background: rgba(242, 180, 92, 0.07);
+                border: 1px solid rgba(242, 180, 92, 0.22);
+                border-radius: 10px;
+                padding: 16px 18px;
+                margin: 20px 0 0;
+                font-size: 14px;
+                color: #e2c79a;
+                line-height: 1.65;
+              "
+            >
+              <strong style="color: #f2b45c; font-family: &quot;JetBrains Mono&quot;, monospace">GUI PATH</strong> — a custom
+              command resolves its binaries against the app's GUI
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span>: the launchd default plus the bundled
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/usr/local/bin</span> and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/opt/homebrew/bin</span>. A bare
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl</span> or Homebrew binary works;
+              anything else your shell profile adds does not, and fails with exit 127. Give it an absolute path
+              or wrap the line in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh -lc '…'</span> —
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh -ilc '…'</span> when that
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> comes from
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">~/.zshrc</span>, which
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">-lc</span> does not read. The program an
+              overlay or scratch terminal runs gets the app's own unwidened
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> and always needs one of those.
+            </div>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 20px 0 0">
+              Open the file with <strong style="color: #e6e1d7">File ▸ Edit Keymap…</strong> (or the ⌃⇧P palette): it opens in a
+              95% overlay running <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$VISUAL</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >$EDITOR</span
+              >
+              (falling back to <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">vi</span>) and
+              reloads on quit. Apply edits made elsewhere with
+              <strong style="color: #e6e1d7">File ▸ Reload Keymap</strong> or
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap reload</span>. A
+              malformed line never discards the rest — it surfaces in the diagnostics list in Settings ▸ Key Mapping while the good
+              lines still apply.
+            </p>
+            <p style="font-size: 15.5px; line-height: 1.75; color: #cbc6bc; margin: 0 0 18px">
+              To check what is actually bound,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap list</span> prints every
+              built-in with the binds it resolved to (the menu shortcut first, then any alternatives, joined with
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">|</span>), the custom commands,
+              each diagnostic in full, and the key equivalents the menu
+              bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is
+              usually a menu problem, not a keymap one. Only the menu shortcut can appear there — an alternative never does, and
+              neither do
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">undo_close</span> (⌘Z) and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> (⌃⌘F), which a
+              key monitor delivers rather than a menu item.
+            </p>
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              v1 limitations
+            </h3>
+            <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px">
+              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
+                <span
+                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
+                  >›</span
+                >A built-in's <em>menu</em> shortcut is single-chord only: a leader sequence binds through the key monitor
+                instead, as an alternative, and so never shows next to its menu item.
+              </li>
+              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
+                <span
+                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
+                  >›</span
+                >A <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map</span> line can't bind a
+                bare, modifier-less arrow — a built-in rides an always-on menu key equivalent, so a bare arrow would
+                swallow the key in the terminal, the palettes, the dashboard grid, and every text field; any modifier
+                makes it bindable. The literal
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> can't be a bare
+                key token (they are the separators), but those keys are bindable as
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+=</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+.</span>; only
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">increase_font_size</span>'s
+                default ⌘+ shows as a glyph because its stored form doesn't round-trip through the file.
+              </li>
+              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
+                <span
+                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
+                  >›</span
+                >The Ctrl-Tab MRU switcher and Ctrl-1/Ctrl-2 pane focus are not rebindable yet.
+              </li>
+              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
+                <span
+                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
+                  >›</span
+                >Shortcut hints are not written the same way for both verbs. A built-in shows macOS glyphs (⌘⇧E), with every
+                alternative listed space-separated and a sequence's chords joined by
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> as in the file
+                (⌘T ⌃A&gt;T), in the palette and in the toolbar and sidebar tooltips alike. A
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span> shows the raw kitty
+                spelling you typed instead (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                  >cmd+shift+e</span
+                >), alternatives still joined by <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                  >|</span
+                >.
+              </li>
+            </ul>
+          </section>
+
           <!-- AGTERMCTL -->
           <section id="agtermctl" style="scroll-margin-top: 88px; padding-top: 56px">
             <h2
@@ -1844,346 +2186,6 @@
               shell scripts you run on your own machine against your own sessions, and several close sessions or delete
               workspaces, so read a recipe before you run it.
             </p>
-          </section>
-
-          <!-- KEYMAP -->
-          <section id="keymap" style="scroll-margin-top: 88px; padding-top: 56px">
-            <h2
-              style="
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-weight: 700;
-                font-size: 28px;
-                letter-spacing: -0.02em;
-                margin: 0 0 16px;
-                padding-bottom: 12px;
-                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-              "
-            >
-              Customizing keys
-            </h2>
-            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 20px">
-              agterm reads a user-editable, kitty-flavored keymap file at
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">~/.config/agterm/keymap.conf</span
-              >. It rebinds built-in menu shortcuts and defines custom shell commands bound to keys (and listed in the action
-              palette). The file is optional — a commented starter is written on first launch, and the directory can be changed in
-              <strong style="color: #e6e1d7">Settings ▸ Key Mapping</strong>. Three verbs; blank lines and
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">#</span> comments are ignored.
-            </p>
-            <div
-              style="
-                background: #15191c;
-                border: 1px solid rgba(255, 255, 255, 0.1);
-                border-radius: 10px;
-                padding: 18px 20px;
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-size: 13.5px;
-                line-height: 1.95;
-                overflow-x: auto;
-                color: #e6e1d7;
-              "
-            >
-              <span style="color: #6b727a"># rebind a built-in to a chord (mods joined by +)</span><br /><span
-                style="color: #5ea1f2"
-                >map</span
-              >
-              cmd+shift+l&nbsp;&nbsp;&nbsp;toggle_split<br /><span style="color: #5ea1f2">map</span>
-              ctrl+shift+k&nbsp;&nbsp;command_palette<br /><br /><span style="color: #6b727a"
-                ># or to several alternatives, joined by | with no spaces around it</span
-              ><br /><span style="color: #5ea1f2">map</span>
-              cmd+t|ctrl+a&gt;t&nbsp;&nbsp;toggle_scratch<br /><br /><span style="color: #6b727a"
-                ># define custom commands ("name" shows in the palette; chord optional)</span
-              ><br /><span style="color: #5ea1f2">command</span>
-              <span style="color: #f2b45c">"Open in Zed"</span>&nbsp;&nbsp;cmd+shift+e&nbsp;&nbsp;open -a Zed {AGT_SESSION_PWD}<br /><span
-                style="color: #5ea1f2"
-                >command</span
-              >
-              <span style="color: #f2b45c">"Lazygit"</span
-              >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ctrl+a&gt;g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;agtermctl session overlay open 'zsh -lc lazygit'
-              --socket {AGT_SOCKET}<br /><span style="color: #5ea1f2">command</span>
-              <span style="color: #f2b45c">"Deploy"</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./deploy.sh<br /><br /><span
-                style="color: #6b727a"
-                ># one system-wide chord that summons the quick terminal from any application</span
-              ><br /><span style="color: #5ea1f2">global-hotkey</span> ctrl+opt+space
-            </div>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
-              A chord is modifier words (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >ctrl</span
-              >, <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">cmd</span>,
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">opt</span>,
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift</span>) joined by
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> and a base key (a single
-              character or <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">tab</span>/<span
-                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >space</span
-              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">return</span>/<span
-                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >delete</span
-              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">left</span>/<span
-                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >right</span
-              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">up</span>/<span
-                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >down</span
-              >). A Shift-typed symbol is written
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+&lt;base&gt;</span>
-              (e.g. <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+/</span> for
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">?</span>,
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+=</span> for
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span>) — the base key, not the
-              shifted symbol. Custom commands may also use a leader sequence
-              (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ctrl+a&gt;g</span>), and their chord
-              must include a modifier — a bare key can't shadow a plain terminal key.
-            </p>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> takes exactly one
-              chord and binds it <strong style="color: #e6e1d7">system-wide</strong>: it summons the quick terminal while any
-              application is frontmost, which no other binding here can do — the rest only fire while agterm has the keyboard. It
-              must carry a modifier, takes no alternatives and no leader sequence, and a second
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> line replaces the
-              first. macOS registers it by physical key position, so it keeps firing on a non-Latin layout. Because the system owns
-              it rather than agterm, it takes no part in the collision rules below. Note which side wins: the system-wide chord
-              takes the key even while agterm is in front, so binding one a menu item already uses means that menu shortcut stops
-              firing. It is unset unless you add the line: agterm ships no default because registering a chord takes it
-              from every other application on the Mac, and that is not a cost to impose on someone who may never summon
-              the panel from outside agterm. Spending it on the chord the in-app binding already uses is allowed and is
-              the way to get one shortcut that works everywhere —
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey ctrl+`</span>
-              makes <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">⌃`</span> summon the panel
-              from any application, at the price of that chord no longer reaching anything else.
-            </p>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
-              One binding can offer several <strong style="color: #e6e1d7">alternatives</strong>, joined by
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">|</span> inside a single token with no
-              spaces around it —
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map cmd+t|ctrl+a&gt;t toggle_scratch</span>
-              fires the action from either, and a <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span>
-              takes alternatives the same way. For a built-in, the first single-chord alternative the menu can carry becomes the menu
-              shortcut; every
-              other alternative, on either verb, is delivered by a key monitor and so must carry a modifier on its first chord. This
-              is also how a built-in gets a leader sequence, because a menu item holds exactly one key equivalent:
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map ctrl+a&gt;s toggle_split</span> binds
-              the sequence and leaves the action with no menu shortcut at all — its shipped ⌘D is gone rather than kept, and free for
-              another action to claim. A typo in one alternative rejects the whole line, so a mistake can't hide behind a line that
-              half worked; an alternative that merely breaks a rule or collides with an existing binding drops on its own and its
-              siblings keep firing. If a line ends up binding nothing at all, the action simply keeps the shortcut it shipped with.
-            </p>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
-              Chords are written in Latin and keep working on a non-Latin keyboard layout. A layout that cannot type ASCII —
-              Russian, Greek, Hebrew, Arabic, Thai — resolves every chord by the physical key position, so
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">cmd+o</span> still fires on the key
-              marked O even though it types <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">щ</span>.
-              A layout that can type ASCII binds what it types, so an alternative Latin layout keeps its own letter positions: on
-              Dvorak, <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">cmd+o</span> follows the O you
-              actually type.
-            </p>
-
-            <h3
-              style="
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-weight: 600;
-                font-size: 16px;
-                color: #5ea1f2;
-                margin: 28px 0 12px;
-              "
-            >
-              Bindable built-in actions
-            </h3>
-            <div
-              style="
-                background: #15191c;
-                border: 1px solid rgba(255, 255, 255, 0.1);
-                border-radius: 10px;
-                padding: 18px 20px;
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-size: 13px;
-                line-height: 1.9;
-                overflow-x: auto;
-                color: #cbc6bc;
-              "
-            >
-              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />toggle_workspace_collapse<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_workspace&nbsp;&nbsp;&nbsp;next_workspace<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
-            </div>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> is the one
-              action with no menu item of its own. macOS adds an "Enter Full Screen" item to the View menu whenever that menu is
-              drawn, and nothing suppresses it, so an item of agterm's own would sit beside it as a duplicate. The binding (⌃⌘F by
-              default) is handled directly instead, which is why the menu entry advertises the system's Globe+F rather than your
-              chord. Both work, and rebinding
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> changes the
-              chord as usual — it just won't show up next to that menu item.
-            </p>
-
-            <h3
-              style="
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-weight: 600;
-                font-size: 16px;
-                color: #5ea1f2;
-                margin: 28px 0 12px;
-              "
-            >
-              Command tokens
-            </h3>
-            <div
-              style="
-                background: #15191c;
-                border: 1px solid rgba(255, 255, 255, 0.1);
-                border-radius: 10px;
-                padding: 18px 20px;
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-size: 13px;
-                line-height: 1.9;
-                overflow-x: auto;
-                color: #cbc6bc;
-              "
-            >
-              {AGT_SESSION_ID}&nbsp;&nbsp;&nbsp;{AGT_SESSION_NAME}&nbsp;&nbsp;&nbsp;{AGT_SESSION_PWD}<br />{AGT_WORKSPACE_ID}&nbsp;&nbsp;&nbsp;{AGT_WORKSPACE_NAME}<br />{AGT_WINDOW_ID}&nbsp;&nbsp;&nbsp;{AGT_WINDOW_NAME}<br />{AGT_PANE}&nbsp;&nbsp;&nbsp;{AGT_SELECTION}&nbsp;&nbsp;&nbsp;{AGT_SOCKET}
-            </div>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
-              Tokens expand at fire time (also exported as
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_*</span> env vars on the spawned
-              process). A token is substituted <strong style="color: #e6e1d7">raw</strong> into the shell line, so for content you
-              don't control —
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">{AGT_SELECTION}</span>, and also
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">{AGT_SESSION_NAME}</span>/<span
-                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >{AGT_SESSION_PWD}</span
-              >
-              (a remote host can set these via OSC) — prefer the matching quoted env var, e.g.
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">"$AGT_SELECTION"</span>.
-            </p>
-            <div
-              style="
-                background: rgba(242, 180, 92, 0.07);
-                border: 1px solid rgba(242, 180, 92, 0.22);
-                border-radius: 10px;
-                padding: 16px 18px;
-                margin: 20px 0 0;
-                font-size: 14px;
-                color: #e2c79a;
-                line-height: 1.65;
-              "
-            >
-              <strong style="color: #f2b45c; font-family: &quot;JetBrains Mono&quot;, monospace">Detached, no TTY</strong> — a
-              custom command runs as a detached
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/bin/sh -c</span> with no controlling terminal, so
-              it suits fire-and-forget launches (GUI apps, scripts) — not interactive TUIs. Run a TUI like
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">lazygit</span> in an overlay
-              (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl session overlay open</span>) or a scratch
-              terminal, which have a real TTY. A non-zero exit posts a notification banner.
-            </div>
-            <div
-              style="
-                background: rgba(242, 180, 92, 0.07);
-                border: 1px solid rgba(242, 180, 92, 0.22);
-                border-radius: 10px;
-                padding: 16px 18px;
-                margin: 20px 0 0;
-                font-size: 14px;
-                color: #e2c79a;
-                line-height: 1.65;
-              "
-            >
-              <strong style="color: #f2b45c; font-family: &quot;JetBrains Mono&quot;, monospace">GUI PATH</strong> — a custom
-              command resolves its binaries against the app's GUI
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span>: the launchd default plus the bundled
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl</span>,
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/usr/local/bin</span> and
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/opt/homebrew/bin</span>. A bare
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl</span> or Homebrew binary works;
-              anything else your shell profile adds does not, and fails with exit 127. Give it an absolute path
-              or wrap the line in
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh -lc '…'</span> —
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh -ilc '…'</span> when that
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> comes from
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">~/.zshrc</span>, which
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">-lc</span> does not read. The program an
-              overlay or scratch terminal runs gets the app's own unwidened
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> and always needs one of those.
-            </div>
-            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 20px 0 0">
-              Open the file with <strong style="color: #e6e1d7">File ▸ Edit Keymap…</strong> (or the ⌃⇧P palette): it opens in a
-              95% overlay running <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$VISUAL</span>/<span
-                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                >$EDITOR</span
-              >
-              (falling back to <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">vi</span>) and
-              reloads on quit. Apply edits made elsewhere with
-              <strong style="color: #e6e1d7">File ▸ Reload Keymap</strong> or
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap reload</span>. A
-              malformed line never discards the rest — it surfaces in the diagnostics list in Settings ▸ Key Mapping while the good
-              lines still apply.
-            </p>
-            <p style="font-size: 15.5px; line-height: 1.75; color: #cbc6bc; margin: 0 0 18px">
-              To check what is actually bound,
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap list</span> prints every
-              built-in with the binds it resolved to (the menu shortcut first, then any alternatives, joined with
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">|</span>), the custom commands,
-              each diagnostic in full, and the key equivalents the menu
-              bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is
-              usually a menu problem, not a keymap one. Only the menu shortcut can appear there — an alternative never does, and
-              neither do
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">undo_close</span> (⌘Z) and
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> (⌃⌘F), which a
-              key monitor delivers rather than a menu item.
-            </p>
-            <h3
-              style="
-                font-family: &quot;JetBrains Mono&quot;, monospace;
-                font-weight: 600;
-                font-size: 16px;
-                color: #5ea1f2;
-                margin: 28px 0 12px;
-              "
-            >
-              v1 limitations
-            </h3>
-            <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px">
-              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
-                <span
-                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
-                  >›</span
-                >A built-in's <em>menu</em> shortcut is single-chord only: a leader sequence binds through the key monitor
-                instead, as an alternative, and so never shows next to its menu item.
-              </li>
-              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
-                <span
-                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
-                  >›</span
-                >A <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map</span> line can't bind a
-                bare, modifier-less arrow — a built-in rides an always-on menu key equivalent, so a bare arrow would
-                swallow the key in the terminal, the palettes, the dashboard grid, and every text field; any modifier
-                makes it bindable. The literal
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> can't be a bare
-                key token (they are the separators), but those keys are bindable as
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+=</span> and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+.</span>; only
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">increase_font_size</span>'s
-                default ⌘+ shows as a glyph because its stored form doesn't round-trip through the file.
-              </li>
-              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
-                <span
-                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
-                  >›</span
-                >The Ctrl-Tab MRU switcher and Ctrl-1/Ctrl-2 pane focus are not rebindable yet.
-              </li>
-              <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
-                <span
-                  style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
-                  >›</span
-                >Shortcut hints are not written the same way for both verbs. A built-in shows macOS glyphs (⌘⇧E), with every
-                alternative listed space-separated and a sequence's chords joined by
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> as in the file
-                (⌘T ⌃A&gt;T), in the palette and in the toolbar and sidebar tooltips alike. A
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span> shows the raw kitty
-                spelling you typed instead (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                  >cmd+shift+e</span
-                >), alternatives still joined by <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                  >|</span
-                >.
-              </li>
-            </ul>
           </section>
 
           <!-- GHOSTTY -->

--- a/site/docs.html
+++ b/site/docs.html
@@ -183,6 +183,7 @@
           >
             <a href="#overview" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Overview</a>
             <a href="#install" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Install</a>
+            <a href="#extend" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Extend agterm</a>
             <div style="height: 16px"></div>
             <span style="color: #4a5158; font-size: 11px; letter-spacing: 0.12em; padding: 4px 12px">CONCEPTS</span>
             <a href="#workspaces" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9"
@@ -553,6 +554,246 @@
             </div>
           </section>
 
+          <!-- EXTEND -->
+          <section id="extend" style="scroll-margin-top: 88px; padding-top: 56px">
+            <h2
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 700;
+                font-size: 28px;
+                letter-spacing: -0.02em;
+                margin: 0 0 16px;
+                padding-bottom: 12px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+              "
+            >
+              Extend agterm
+            </h2>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              agterm ships a small set of features on purpose. A great many of the tools you might wish it shipped are one line
+              in <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">keymap.conf</span>, and the line
+              stays short because three pieces do the work: a
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">command</span> turns any shell line
+              into a named action on a key chord, an overlay gives an interactive program its own temporary terminal over the
+              session, and any CLI you already have fills that slot. agterm never needs to know what the program is.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 24px">
+              So &ldquo;does agterm have a file browser?&rdquo; has no yes-or-no answer. You bind the file browser you like, in
+              one line. The four steps below each add one building block; put the lines in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">keymap.conf</span> via
+              <strong style="color: #e6e1d7">File &#9656; Edit Keymap&hellip;</strong> and apply them with
+              <strong style="color: #e6e1d7">File &#9656; Reload Keymap</strong>.
+            </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              1. Act on the session you are in
+            </h3>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.9;
+                overflow-x: auto;
+                color: #cbc6bc;
+                white-space: pre;
+              "
+            >
+<span style="color: #6b727a"># open the session's working directory in Finder</span>
+<span style="color: #5ea1f2">command</span> "Open in Finder"  ctrl+a&gt;o  open "$AGT_SESSION_PWD"</div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              Read the line left to right:
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span> is the directive, the
+              quoted text is the name shown in the
+              <strong style="color: #e6e1d7">Navigate &#9656; Custom Commands</strong> palette,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ctrl+a&gt;o</span> is the chord that
+              fires it &mdash; Ctrl-A, then O &mdash; and everything after that is an ordinary shell line. The chord is
+              optional: leave it out and the action exists in the palette only.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              The building block is <strong style="color: #e6e1d7">session context</strong>. Every custom command is handed the
+              session it fired from &mdash; its directory, name, id, and current selection &mdash; as
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_*</span> environment variables
+              and as <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">{AGT_*}</span> tokens
+              substituted into the line. That is what makes one binding work in every session instead of hard-coding a path.
+            </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              2. Run an interactive program over the session
+            </h3>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.9;
+                overflow-x: auto;
+                color: #cbc6bc;
+                white-space: pre;
+              "
+            >
+<span style="color: #6b727a"># the yazi file manager, floating over the session at 95%</span>
+<span style="color: #5ea1f2">command</span> "Yazi"  ctrl+a&gt;y  agtermctl session overlay open 'zsh -lc yazi' --size-percent 95 --target "$AGT_SESSION_ID" --socket "$AGT_SOCKET"</div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              The building block is the <strong style="color: #e6e1d7">overlay</strong>. A custom command on its own runs detached
+              with no terminal, which suits launching a GUI app but kills a TUI at once, since it has nothing to draw on. An
+              overlay is a real terminal, so <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">yazi</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">lazygit</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">htop</span> and the rest behave
+              normally in it. It opens in the session's own working directory, and it disappears when the program exits, leaving
+              the shell underneath untouched.
+            </p>
+            <div
+              style="
+                background: rgba(242, 180, 92, 0.07);
+                border: 1px solid rgba(242, 180, 92, 0.22);
+                border-radius: 10px;
+                padding: 16px 18px;
+                margin: 20px 0 0;
+                font-size: 14px;
+                color: #e2c79a;
+                line-height: 1.65;
+              "
+            >
+              Note <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh -lc</span> rather than
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh -c</span>. The program an overlay runs inherits
+              agterm's own PATH, not your shell's, so a Homebrew binary needs a login shell to be found &mdash; or an absolute
+              path. Skip it and the overlay flashes open and vanishes, because the binary was never found.
+            </div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">agtermctl</span> is how the line asks
+              for that terminal: it is agterm's own command-line tool, and opening an overlay is one thing it can do. Step 3
+              opens up the rest.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--target "$AGT_SESSION_ID"</span> is
+              worth understanding rather than copying.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">agtermctl</span> does not act on
+              agterm directly; it sends a request over a socket, and agterm resolves it on arrival. Without a target the request
+              means &ldquo;whichever session is selected when this lands&rdquo;, which is normally the one you pressed the chord
+              in &mdash; but not if you switched in between. The token pins it to the session that fired, so the overlay always
+              opens where you asked for it.
+            </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              3. Reach the rest of the app
+            </h3>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.9;
+                overflow-x: auto;
+                color: #cbc6bc;
+                white-space: pre;
+              "
+            >
+<span style="color: #6b727a"># a second session in this directory, alongside this one, left in the background</span>
+<span style="color: #5ea1f2">command</span> "Session here"  ctrl+a&gt;n  agtermctl session new --cwd "$AGT_SESSION_PWD" --workspace "$AGT_WORKSPACE_ID" --window "$AGT_WINDOW_ID" --no-select --socket "$AGT_SOCKET"</div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              The building block is the <strong style="color: #e6e1d7">control API</strong>. Overlays are one entry in a much
+              larger catalog: the same
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">agtermctl</span> creates and renames
+              sessions, splits panes, moves windows, opens the native picker, reads a session's text back, and posts
+              notifications. Every state it sets it also reads back, which is what lets a script build a whole layout rather than
+              fire a single action.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              The extra flags are the same idea as
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--target</span> above, applied to
+              every axis this command can drift on. A bare
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">session new</span> lands in
+              whichever window is frontmost and whichever workspace is current when the request arrives, and it selects the new
+              session; the ids pin all three to where the chord was pressed, and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--no-select</span> leaves you where
+              you were. Keymap lines never wrap, so this one is long: one directive is always one line.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              Past a certain size the line becomes a script, and that is where the
+              <a href="https://github.com/umputun/agterm/tree/master/cookbook" style="color: #6d82f3">cookbook</a> starts: pick a
+              project from anywhere and open it in its own workspace, park a set of workspaces and bring them back later, or have
+              each tab resume its own agent conversation after a restart. Those are not one-liners, and the recipes do not
+              pretend otherwise.
+            </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              4. Or have an agent write it for you
+            </h3>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              Install the agent skill from <strong style="color: #e6e1d7">Help &#9656; Install Agent Skill&hellip;</strong>, then
+              ask the agent running in one of your sessions:
+            </p>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.9;
+                overflow-x: auto;
+                color: #cbc6bc;
+              "
+            >
+              add a custom command that opens yazi in a 95% overlay, bound to ctrl+a then y
+            </div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              The skill carries the keymap syntax, the full command catalog, the context tokens, and the PATH rule, so the agent
+              writes a working line instead of guessing at one. This step comes last on purpose: an agent without the skill will
+              still answer, plausibly and wrongly, and by now you can tell the difference.
+            </p>
+
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 24px 0 0">
+              From here, <a href="#keymap" style="color: #6d82f3">Custom commands &amp; keys</a> has the full keymap syntax and
+              the bindable actions, the <a href="/commands" style="color: #6d82f3">command reference</a> lists every
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">agtermctl</span> command with its
+              arguments, and the <a href="https://github.com/umputun/agterm/tree/master/cookbook" style="color: #6d82f3">cookbook</a>
+              collects worked recipes to copy and edit.
+            </p>
+          </section>
           <!-- WORKSPACES -->
           <section id="workspaces" style="scroll-margin-top: 88px; padding-top: 56px">
             <h2

--- a/site/docs.html
+++ b/site/docs.html
@@ -579,9 +579,30 @@
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 24px">
               So &ldquo;does agterm have a file browser?&rdquo; has no yes-or-no answer. You bind the file browser you like, in
-              one line. The four steps below each add one building block; put the lines in
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">keymap.conf</span> via
-              <strong style="color: #e6e1d7">File &#9656; Edit Keymap&hellip;</strong> and apply them with
+              one line. The four steps below each add one building block.
+            </p>
+            <div
+              style="
+                background: rgba(109, 130, 243, 0.08);
+                border: 1px solid rgba(109, 130, 243, 0.25);
+                border-radius: 10px;
+                padding: 16px 18px;
+                margin: 0 0 24px;
+                font-size: 15px;
+                color: #cbc6bc;
+                line-height: 1.65;
+              "
+            >
+              <strong style="color: #e6e1d7">You are not expected to write these by hand.</strong> Install the agent skill from
+              <strong style="color: #e6e1d7">Help &#9656; Install Agent Skill&hellip;</strong> and ask the agent in your session
+              for what you want; it knows the syntax, the command catalog, and the traps below.
+              <a href="#extend-agent" style="color: #6d82f3">Step 4</a> shows exactly that. The three steps before it are not the
+              long way round: they are what let you read the line the agent writes, change it later, and tell a working answer
+              from a plausible one.
+            </div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 24px">
+              To edit the file yourself, open it with
+              <strong style="color: #e6e1d7">File &#9656; Edit Keymap&hellip;</strong> and apply your changes with
               <strong style="color: #e6e1d7">File &#9656; Reload Keymap</strong>.
             </p>
 
@@ -751,19 +772,22 @@
             </p>
 
             <h3
+              id="extend-agent"
               style="
                 font-family: &quot;JetBrains Mono&quot;, monospace;
                 font-weight: 600;
                 font-size: 16px;
                 color: #5ea1f2;
                 margin: 28px 0 12px;
+                scroll-margin-top: 88px;
               "
             >
-              4. Or have an agent write it for you
+              4. Have the agent write it
             </h3>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
-              Install the agent skill from <strong style="color: #e6e1d7">Help &#9656; Install Agent Skill&hellip;</strong>, then
-              ask the agent running in one of your sessions:
+              This is the normal way to add things, not a shortcut for people who dislike config files. Install the agent skill
+              from <strong style="color: #e6e1d7">Help &#9656; Install Agent Skill&hellip;</strong>, then ask the agent running
+              in one of your sessions:
             </p>
             <div
               style="
@@ -782,8 +806,9 @@
             </div>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
               The skill carries the keymap syntax, the full command catalog, the context tokens, and the PATH rule, so the agent
-              writes a working line instead of guessing at one. This step comes last on purpose: an agent without the skill will
-              still answer, plausibly and wrongly, and by now you can tell the difference.
+              writes a working line instead of guessing at one. The skill is what makes the difference: an agent without it will
+              still answer, plausibly and wrongly. It is shown last rather than first because the three steps above are what let
+              you tell those two apart, and what let you change the line afterwards without asking again.
             </p>
 
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 24px 0 0">

--- a/site/index.html
+++ b/site/index.html
@@ -290,7 +290,7 @@
             />
             <img
               src="/assets/screenshot-floating-overlay.webp"
-              alt="A file manager in a floating overlay over the active session"
+              alt="The yazi file manager in a floating overlay over the active session"
               width="1187"
               height="696"
               loading="lazy"
@@ -943,7 +943,10 @@
             />
             <figcaption style="padding: 16px 20px; font-size: 14px; color: #949ba4">
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #5ea1f2; font-size: 12px">overlay</span>
-              &nbsp;Run a program in a floating panel over the active session.
+              &nbsp;The yazi file manager in a floating panel over the active session, from one
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span> line in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">keymap.conf</span>.
+              <a href="/docs#extend" style="color: #6d82f3">Extend agterm</a>
             </figcaption>
           </figure>
           <figure


### PR DESCRIPTION
a new user asked whether agterm has a file browser. It does, as one keymap line, and nothing in the docs put that within reach. Overlays were explained at `site/docs.html:770` and the `command` directive at `:1895`, eleven hundred lines apart, under a nav heading that named key configuration rather than extension. The cookbook is the closest thing to teaching material, but 26 of its 28 recipes ship a script, so there was no rung between the five nouns and a full workflow.

adds an "Extend agterm" section between Install and the concepts tour. Four steps, each naming the building block it adds: session context, the overlay, the control API, then asking an agent that has the bundled skill. That last step reframes the skill from driving agterm during automation to customizing it, which no public copy said before.

**the paste lines are pinned on purpose.** A custom command is spawned detached, so a bare `--target` resolves `active` when the request reaches the server rather than when the chord fired, and the overlay can open in whatever the user switched to. Same on `session new` for `--window` and `--workspace`, plus `--no-select` so the comment matches what the line does. Overlay programs are wrapped in `zsh -lc`: #393 widened the PATH the custom-command runner uses, not the one a terminal-spawned program gets.

first commit is a pure relocation of the keymap section, 715/713 lines, content unchanged apart from the heading. Read it separately from the second and the diff stays reviewable.

also names yazi in the floating-overlay captions in README and `site/index.html`, which is where the question actually forms.

two findings kept out of scope, both written up in `docs/backlog/`: the in-app menu wording (`File > Edit Keymap...` does not read as "add features"), and the seeded Lazygit example's own missing `--target`.

docs only, no Swift touched. HTML structure validated on both files, and the relocation was checked byte-identical against 042f2399 apart from the heading.
