### PR TITLE
add agtermctl version and teach the agent skill the cookbook

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -132,7 +132,7 @@ renumbering. Do not reintroduce a count anywhere.
 - `font.inc`, `font.dec`, `font.reset`
 - `window.new`, `.list`, `.select`, `.close`, `.rename`, `.delete`, `.resize`, `.move`, `.zoom`,
   `.fullscreen`, `.minimize`
-- `keymap.reload`, `keymap.list`, `config.reload`, `theme.set`, `theme.list`, `restore.clear`
+- `keymap.reload`, `keymap.list`, `config.reload`, `theme.set`, `theme.list`, `restore.clear`, `version`
 
 `debug.appearance` is a private `Command` case, absent from the list above, used only by `AppearanceFlipUITests`.
 It accepts light/dark, sets `NSApp.appearance`, posts `.agtermSystemAppearanceChanged`, echoes the effective
@@ -567,6 +567,23 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   remains visible. Workspace adapters stay in `ControlServer+WorkspaceCommands.swift`.
 
 ## Tree and window read-back
+
+- `version` and the tree's `app` are two projections of ONE `AppIdentity`, built once in the app target
+  from `Bundle.main` and passed in. Nothing below the app target reads `Bundle.main`: a hosted test would
+  see its own host bundle and the projections would drift apart. The same value feeds
+  `SurfaceEnvironment`'s `TERM_PROGRAM_VERSION`, so the three can never disagree.
+- `app.version` is the comparable number a cookbook recipe's minimum is checked against; `app.commit` is
+  diagnostics and never part of that comparison. `app` is the only CONSTANT on the tree top level. It is
+  absent from `window.list` because it describes the app rather than a window and duplicating it there
+  buys nothing — NOT because a cache would stale it, which cannot happen to a constant. A caller with no
+  tree uses `version`.
+- `agtermctl version`'s `client:` line is HUMAN OUTPUT ONLY. `--json` stays the raw `ControlResponse` like
+  every other command; a client-reported path in the protocol would be a field the server cannot vouch
+  for. Resolve it with `_NSGetExecutablePath` + `realpath`, never `argv[0]`, and never print it after a
+  server error.
+- A keymap- or palette-launched process inherits the APP's launch environment, not a surface's, so it has
+  no `TERM_PROGRAM_VERSION` (`CustomCommandRunner` merges `ProcessInfo.processInfo.environment` with the
+  `AGT_*` context only). That is why a recipe preflight uses `agtermctl version` rather than the variable.
 
 - Session nodes include foreground/split foreground argv, background spec, overlay size, pane overlays,
   split axis, split ratio, split focus, status fields, flag, unseen, restore pins, surfaces, and `realized`.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -68,7 +68,10 @@ paths:
   merge, marker, backup, and optional-agent policy.
 - Skill installation targets every existing Claude/Codex skill root, creating Claude only when neither
   exists. Refuse an unmarked `SKILL.md`. The sole source is `plugins/agterm/skills/agterm/` with
-  `SKILL.md`, references, examples, troubleshooting, and `scripts/show-image.sh`.
+  `SKILL.md`, references, examples, cookbook, troubleshooting, and `scripts/show-image.sh`. The whole
+  directory copies verbatim, so a new file ships automatically — but the loader opens only what `SKILL.md`
+  routes to, so a file added without a `description`/`when_to_use` trigger and a body pointer is dead
+  weight.
 - `show-image.sh` opens a PTY overlay and emits chunked kitty APC/base64. Pinned Ghostty has no OSC-1337
   or sixel, agent stdout escapes controls, and tool shells lack `/dev/tty`. Resolve relative to the loaded
   skill; hardcoded install paths and `${CLAUDE_PLUGIN_ROOT}` fail across app/plugin copies.

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -85,6 +85,13 @@ extension ControlServer {
         return ControlResponse(ok: true, result: ControlResult(keymap: payload))
     }
 
+    /// Which app is serving this socket. App-global: no target, no `--window`, and no window needs to be
+    /// open, which is what makes it usable as a preflight from a keymap-launched script — those inherit the
+    /// app's launchd environment and so carry no `TERM_PROGRAM_VERSION`.
+    func appIdentity() -> ControlResponse {
+        ControlResponse(ok: true, result: ControlResult(app: identity))
+    }
+
     /// Every menu-bar item carrying a key equivalent, in the same kitty syntax the keymap uses so a caller can
     /// compare the lists. Only the app target reads `NSApp.mainMenu`, so this is `keymap.list`'s app-side half.
     @MainActor

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -111,10 +111,16 @@ final class ControlServer {
     /// progressing and parks the accept loop. A normal reader drains in milliseconds.
     nonisolated private static let writeDeadlineSeconds = 10
 
-    init(library: WindowLibrary, actions: AppActions, settingsModel: SettingsModel, socketPath: String? = nil) {
+    /// Which agterm this is, injected rather than read from `Bundle.main` here: the identity is the app's to
+    /// know, and a hosted test would otherwise see its own host bundle.
+    let identity: AppIdentity
+
+    init(library: WindowLibrary, actions: AppActions, settingsModel: SettingsModel, identity: AppIdentity,
+         socketPath: String? = nil) {
         self.library = library
         self.actions = actions
         self.settingsModel = settingsModel
+        self.identity = identity
         self.resolver = ControlTargetResolver(library: library)
         self.socketPath = socketPath ?? ControlServer.defaultSocketPath()
         // ownership is decided HERE, not in `start()`. The launch window's surfaces are built during the
@@ -433,7 +439,7 @@ final class ControlServer {
                 .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
                 .windowFullscreen, .windowMinimize,
-                .restoreClear, .dashboard:
+                .restoreClear, .dashboard, .version:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)
@@ -634,7 +640,8 @@ final class ControlServer {
                 case .fixed: return "fixed"
                 case .untouched: return "untouched"
                 }
-            }
+            },
+            app: identity
         )
     }
 

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -31,9 +31,18 @@ struct agtermApp: App {
     /// The plain `WindowGroup`'s scene id, used by `openWindow(id:)` to spawn additional windows.
     private static let windowGroupID = "terminal"
 
+    /// Which agterm this is, read from the bundle ONCE and shared by every surface that reports a version:
+    /// the `TERM_PROGRAM_VERSION` of each spawned terminal, the `tree` payload, and the `version` command.
+    /// Nothing below the app target reads `Bundle.main` — a hosted test would see its own host bundle and
+    /// the projections would disagree.
+    static let appIdentity: AppIdentity = {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        return AppIdentity(version: version,
+                           recordedCommit: Bundle.main.infoDictionary?["GitCommit"] as? String)
+    }()
+
     /// The version paired with agterm's `TERM_PROGRAM` identity in every spawned terminal.
-    private static let terminalProgramVersion =
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    private static let terminalProgramVersion = appIdentity.version
 
     /// Hosted XCTest loads the real executable before `setUp`, so its scheme sets isolated state/socket paths
     /// plus this sentinel pre-`init()`; the scene then mounts a placeholder — no surfaces, no server.
@@ -58,7 +67,8 @@ struct agtermApp: App {
         _settingsModel = State(initialValue: settingsModel)
         welcomeDue = FirstRunWelcome.isDue(welcomeShown: settingsModel.settings.welcomeShown,
                                            hasPriorState: hadPriorState)
-        let controlServer = ControlServer(library: library, actions: actions, settingsModel: settingsModel)
+        let controlServer = ControlServer(library: library, actions: actions, settingsModel: settingsModel,
+                                          identity: Self.appIdentity)
         _controlServer = State(initialValue: controlServer)
         _sessionSwitcher = State(initialValue: SessionSwitcher(library: library, canSwitch: { actions.uiActionsEnabled }))
         _paneShortcuts = State(initialValue: PaneShortcuts(library: library, actions: actions))

--- a/agtermCore/Sources/agtermCore/AppIdentity.swift
+++ b/agtermCore/Sources/agtermCore/AppIdentity.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Which agterm is serving this control socket. Derived ONCE by the app from its own bundle and projected
+/// unchanged into both `tree` and `version`, so the two can never disagree. `version` is the comparable
+/// number a recipe checks its minimum against; `commit` is diagnostics only and never part of that
+/// comparison.
+public struct AppIdentity: Codable, Sendable, Equatable {
+    public let version: String
+    /// The build's git commit, omitted for a build that recorded none.
+    public let commit: String?
+
+    public init(version: String, commit: String? = nil) {
+        self.version = version
+        self.commit = commit
+    }
+
+    /// Build from raw bundle values. `commit` is dropped when the build recorded nothing usable — absent,
+    /// empty, or the literal `unknown` that `build.sh`/`release.sh` emit when git cannot answer — so no
+    /// caller renders `0.24.0 (unknown)`.
+    public init(version: String, recordedCommit: String?) {
+        self.version = version
+        switch recordedCommit {
+        case nil, "", "unknown": self.commit = nil
+        default: self.commit = recordedCommit
+        }
+    }
+}

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -265,7 +265,7 @@ public final class AppStore {
                             dashboardMembers: () -> [String]? = { nil },
                             dashboardHighlighted: () -> String? = { nil },
                             dashboardFontSize: () -> Double? = { nil },
-                            dashboardFontMode: () -> String? = { nil }) -> ControlTree {
+                            dashboardFontMode: () -> String? = { nil }, app: AppIdentity? = nil) -> ControlTree {
         let activeID = selectedSessionID
         // `currentWorkspaceID`, not the selected session's owner: an EMPTY destination selects nothing, so
         // deriving this from the selection alone made `tree` name the workspace `workspace.go` just left.
@@ -333,7 +333,7 @@ public final class AppStore {
                            dashboardHighlighted: dashboardHighlighted(),
                            dashboardFontSize: dashboardFontSize(),
                            dashboardFontMode: dashboardFontMode(),
-                           pickPending: pickPending())
+                           pickPending: pickPending(), app: app)
     }
 
     /// The tree's `paneOverlays`: the panes covered by their own overlay, omitted when neither is.

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -60,6 +60,7 @@ public protocol ControlActions {
     func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse
     func reloadKeymap() -> ControlResponse
     func listKeymap() -> ControlResponse
+    func appIdentity() -> ControlResponse
     func reloadGhosttyConfig() -> ControlResponse
     func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse
     func setTheme(args: ControlArgs?) -> ControlResponse
@@ -228,7 +229,7 @@ public struct ControlDispatcher {
             return dispatchWorkspaceCommand(request)
         case .quick, .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList,
                 .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
-                .sidebarCollapse, .restoreClear:
+                .sidebarCollapse, .restoreClear, .version:
             return dispatchAppCommand(request)
         case .quickType, .quickText:
             return await dispatchQuickCommand(request)
@@ -709,6 +710,8 @@ public struct ControlDispatcher {
             return actions.reloadKeymap()
         case .keymapList:
             return actions.listKeymap()
+        case .version:
+            return actions.appIdentity()
         case .configReload:
             return actions.reloadGhosttyConfig()
         case .notify:

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -80,6 +80,7 @@ public enum Command: String, Codable, Sendable {
     case pickResult = "pick.result"
     case pickCancel = "pick.cancel"
     case restoreClear = "restore.clear"
+    case version = "version"
     /// UI-TEST-ONLY: forces the app-level appearance (`light`|`dark` via `args.name`) so an XCUITest can
     /// simulate a macOS light/dark flip; with NO name it READS the side the last config feed applied, so a
     /// test can assert the flip drove the reload. Refused outside an XCUITest launch, and EXEMPT from the
@@ -740,13 +741,18 @@ public struct ControlTree: Codable, Sendable, Equatable {
     public let dashboardFontMode: String?
     /// The id of the picker currently awaiting a choice, or nil when no picker is open.
     public let pickPending: String?
+    /// The app serving this socket. Constant rather than live like every field above it, and present so an
+    /// agent already reading the tree gets its version floor without a second round-trip; `version` answers
+    /// the same question for a caller that has no tree, no window, and no JSON parser.
+    public let app: AppIdentity?
 
     public init(workspaces: [ControlWorkspaceNode], idleMs: Int? = nil, autoFollowMs: Int? = nil,
                 sidebarVisible: Bool? = nil, sidebarMode: String? = nil, workspaceFilter: Bool? = nil,
                 quickVisible: Bool? = nil,
                 zoomedSurface: String? = nil, dashboardMembers: [String]? = nil,
                 dashboardHighlighted: String? = nil, dashboardFontSize: Double? = nil,
-                dashboardFontMode: String? = nil, pickPending: String? = nil) {
+                dashboardFontMode: String? = nil, pickPending: String? = nil,
+                app: AppIdentity? = nil) {
         self.workspaces = workspaces
         self.idleMs = idleMs
         self.autoFollowMs = autoFollowMs
@@ -760,6 +766,7 @@ public struct ControlTree: Codable, Sendable, Equatable {
         self.dashboardFontSize = dashboardFontSize
         self.dashboardFontMode = dashboardFontMode
         self.pickPending = pickPending
+        self.app = app
     }
 }
 
@@ -868,6 +875,8 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var pick: ControlPickResult?
     /// The addressed surface's cursor position for `surface.cursor`.
     public var cursor: ControlCursor?
+    /// The app serving this socket, for `version`. The same value `tree` carries.
+    public var app: AppIdentity?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
@@ -875,7 +884,8 @@ public struct ControlResult: Codable, Sendable, Equatable {
                 theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil,
                 sync: Bool? = nil, light: String? = nil, dark: String? = nil,
                 events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil,
-                pick: ControlPickResult? = nil, cursor: ControlCursor? = nil) {
+                pick: ControlPickResult? = nil, cursor: ControlCursor? = nil,
+                app: AppIdentity? = nil) {
         self.id = id
         self.tree = tree
         self.text = text
@@ -893,6 +903,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.keymap = keymap
         self.pick = pick
         self.cursor = cursor
+        self.app = app
     }
 }
 

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -89,7 +89,8 @@ public struct Agtermctl: ParsableCommand {
         commandName: "agtermctl",
         abstract: "Drive agterm over its control socket.",
         subcommands: [Tree.self, Events.self, Workspace.self, Session.self, Surface.self, Dashboard.self, Window.self, Quick.self,
-                      Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Pick.self, Restore.self]
+                      Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Pick.self, Restore.self,
+                      Version.self]
     )
 
     public init() {}

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -641,13 +641,10 @@ struct Version: RequestCommand {
     func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .version) }
 
     func run() throws {
-        let client = SocketClient(path: options.socketPath())
-        let response = try client.send(try makeRequest())
-        SocketClient.printResponse(response, json: options.json)
-        if !options.json, response.ok, let path = Version.clientPath() {
+        try defaultRun()
+        if !options.json, let path = Version.clientPath() {
             print("client: \(path)")
         }
-        if !response.ok { throw ExitCode.failure }
     }
 
     /// The running executable's real path. `_NSGetExecutablePath` rather than `argv[0]`, which is whatever

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -627,3 +627,38 @@ struct Font: ParsableCommand {
         }
     }
 }
+
+// MARK: - version
+
+/// Which agterm is serving the socket this client reached. The app answers from its own bundle, so a
+/// stale `agtermctl` earlier on `PATH` than the bundled helper cannot misreport it. The resolved client
+/// path prints beside it as a diagnostic for exactly that case, and stays OUT of `--json`, which keeps its
+/// promise of being the raw server response: a JSON consumer ran the binary and can resolve its own path.
+struct Version: RequestCommand {
+    static let configuration = CommandConfiguration(abstract: "Print the version of the app serving the socket.")
+    @OptionGroup var options: BasicOptions
+
+    func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .version) }
+
+    func run() throws {
+        let client = SocketClient(path: options.socketPath())
+        let response = try client.send(try makeRequest())
+        SocketClient.printResponse(response, json: options.json)
+        if !options.json, response.ok, let path = Version.clientPath() {
+            print("client: \(path)")
+        }
+        if !response.ok { throw ExitCode.failure }
+    }
+
+    /// The running executable's real path. `_NSGetExecutablePath` rather than `argv[0]`, which is whatever
+    /// the caller chose to exec with, and `realpath` because the installed CLI is a symlink into the bundle.
+    static func clientPath() -> String? {
+        var size = UInt32(0)
+        _ = _NSGetExecutablePath(nil, &size)
+        var buffer = [CChar](repeating: 0, count: Int(size))
+        guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
+        guard let resolved = realpath(buffer, nil) else { return String(cString: buffer) }
+        defer { free(resolved) }
+        return String(cString: resolved)
+    }
+}

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -193,6 +193,10 @@ struct SocketClient {
         if let keymap = response.result?.keymap {
             return formatKeymap(keymap)
         }
+        if let app = response.result?.app {
+            guard let commit = app.commit, !commit.isEmpty else { return app.version }
+            return "\(app.version) (\(commit))"
+        }
         if let text = response.result?.text {
             return text
         }

--- a/agtermCore/Tests/agtermCoreTests/AppIdentityTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppIdentityTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct AppIdentityTests {
+    @Test func appIdentityDropsAnUnrecordedCommit() {
+        for raw in [nil, "", "unknown"] as [String?] {
+            #expect(AppIdentity(version: "0.24.0", recordedCommit: raw).commit == nil)
+        }
+        #expect(AppIdentity(version: "0.24.0", recordedCommit: "a1b2c3d").commit == "a1b2c3d")
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1148,6 +1148,30 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.keymapList])
     }
 
+    @Test func versionRoutesToActionsAndKeepsTheIdentity() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let identity = AppIdentity(version: "0.24.0", commit: "a1b2c3d")
+        actions.nextVersionResponse = ControlResponse(ok: true, result: ControlResult(app: identity))
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .version))
+
+        #expect(response?.result?.app == identity)
+        #expect(actions.calls == [.version])
+    }
+
+    // app-global like keymap.list: a target or window a caller attaches is ignored, never resolved.
+    @Test func versionIgnoresTargetAndWindow() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .version, target: "active",
+                                                                args: ControlArgs(window: "w1")))
+
+        #expect(response?.ok == true)
+        #expect(actions.calls == [.version])
+    }
+
     @Test func notifyRequiresBodyBeforeCallingActions() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -1709,4 +1709,26 @@ struct ControlProtocolTests {
             try JSONDecoder().decode(ControlRequest.self, from: Data(json.utf8))
         }
     }
+
+    @Test func appIdentityRoundTripsInTreeAndResult() throws {
+        let identity = AppIdentity(version: "0.24.0", commit: "a1b2c3d")
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(workspaces: [], app: identity),
+                                                                      app: identity))
+        let decoded = try JSONDecoder().decode(ControlResponse.self, from: JSONEncoder().encode(response))
+
+        #expect(decoded.result?.app == identity)
+        #expect(decoded.result?.tree?.app == identity)
+        #expect(decoded.result?.tree?.app == decoded.result?.app)
+    }
+
+    @Test func appIdentityIsOmittedWhenAbsentSoAnOlderPayloadStillDecodes() throws {
+        let line = String(decoding: try JSONEncoder().encode(ControlTree(workspaces: [])), as: UTF8.self)
+        #expect(!line.contains("app"))
+        #expect(try JSONDecoder().decode(ControlTree.self, from: Data(line.utf8)).app == nil)
+
+        let commitless = AppIdentity(version: "0.24.0")
+        let encoded = String(decoding: try JSONEncoder().encode(commitless), as: UTF8.self)
+        #expect(!encoded.contains("commit"))
+        #expect(try JSONDecoder().decode(AppIdentity.self, from: Data(encoded.utf8)) == commitless)
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -45,6 +45,7 @@ final class MockControlActions: ControlActions {
         case font(target: String?, window: String?, pane: String?, String)
         case keymapReload
         case keymapList
+        case version
         case configReload
         case notify(target: String?, window: String?, title: String?, body: String)
         case themeSet(String?)
@@ -112,6 +113,7 @@ final class MockControlActions: ControlActions {
     var nextFontResponse = ControlResponse(ok: true)
     var nextNotifyResponse = ControlResponse(ok: true)
     var nextKeymapListResponse = ControlResponse(ok: true)
+    var nextVersionResponse = ControlResponse(ok: true)
     var nextKeymapResponse = ControlResponse(ok: true)
     var nextConfigResponse = ControlResponse(ok: true)
     var nextThemeSetResponse = ControlResponse(ok: true)
@@ -350,6 +352,11 @@ final class MockControlActions: ControlActions {
     func listKeymap() -> ControlResponse {
         calls.append(.keymapList)
         return nextKeymapListResponse
+    }
+
+    func appIdentity() -> ControlResponse {
+        calls.append(.version)
+        return nextVersionResponse
     }
 
     func reloadGhosttyConfig() -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -63,7 +63,8 @@ struct SkillInstallTests {
         #expect(codexPlugin["name"] as? String == SkillInstall.skillName)
 
         let skill = repository.appendingPathComponent("\(pluginRoot)/\(skillLeaf)")
-        for file in ["SKILL.md", "reference.md", "examples.md", "troubleshooting.md", "scripts/show-image.sh"] {
+        for file in ["SKILL.md", "reference.md", "examples.md", "cookbook.md", "troubleshooting.md",
+                     "scripts/show-image.sh"] {
             #expect(FileManager.default.fileExists(atPath: skill.appendingPathComponent(file).path),
                     "missing \(file) in \(pluginRoot)/\(skillLeaf)")
         }

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -1858,4 +1858,20 @@ struct CommandsTests {
         // a newline in the path would smuggle an extra ghostty key into the per-surface overlay.
         #expect(validationMessage(["session", "background", "image", "x.png\nclipboard-read = allow\ny.png"]) != nil)
     }
+
+    @Test func versionParsesWithNoArgumentsAndTakesNoTarget() throws {
+        #expect(try request(["version"]).cmd == .version)
+        #expect(try request(["version"]).target == nil)
+        #expect(try request(["version"]).args == nil)
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["version", "--target", "active"]) }
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["version", "--window", "1"]) }
+    }
+
+    @Test func versionResolvesItsOwnExecutablePath() throws {
+        let path = try #require(Version.clientPath())
+        #expect(path.hasPrefix("/"))
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(path == (path as NSString).resolvingSymlinksInPath)
+    }
+
 }

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -919,6 +919,26 @@ struct SocketClientTests {
         #expect(lines.contains("  Nord"))
         #expect(lines.contains("  default ghostty"))
     }
+
+    @Test func formatsAppIdentityAndOmitsAnEmptyCommit() {
+        let withCommit = ControlResponse(ok: true, result: ControlResult(app: AppIdentity(version: "0.24.0", commit: "a1b2c3d")))
+        #expect(SocketClient.formatResponse(withCommit, json: false) == "0.24.0 (a1b2c3d)")
+
+        for commit in [nil, ""] as [String?] {
+            let response = ControlResponse(ok: true, result: ControlResult(app: AppIdentity(version: "0.24.0", commit: commit)))
+            #expect(SocketClient.formatResponse(response, json: false) == "0.24.0")
+        }
+    }
+
+    @Test func versionJSONCarriesTheRawResponseWithoutTheClientPath() throws {
+        let response = ControlResponse(ok: true, result: ControlResult(app: AppIdentity(version: "0.24.0", commit: "a1b2c3d")))
+        let line = SocketClient.formatResponse(response, json: true)
+        #expect(!line.contains("client"))
+        #expect(!line.contains(Version.clientPath() ?? "agtermctl"))
+
+        let decoded = try JSONDecoder().decode(ControlResponse.self, from: Data(line.utf8))
+        #expect(decoded == response)
+    }
 }
 
 private final class EventReadScript: @unchecked Sendable {
@@ -1251,4 +1271,5 @@ private final class OverlayResultScript: @unchecked Sendable {
             return ControlResponse(ok: false, error: "unexpected cmd \(request.cmd)")
         }
     }
+
 }

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -31,6 +31,7 @@ final class ControlServerPickTests: XCTestCase {
                 library: library,
                 actions: actions,
                 settingsModel: settings,
+                identity: AppIdentity(version: "9.9.9", commit: "testsha"),
                 socketPath: stateDir.appendingPathComponent("control.sock").path
             )
         }

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -22,6 +22,7 @@ final class ControlServerSessionActionsTests: XCTestCase {
                 library: library,
                 actions: actions,
                 settingsModel: SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir)),
+                identity: AppIdentity(version: "9.9.9", commit: "testsha"),
                 socketPath: stateDir.appendingPathComponent("control.sock").path
             )
         }

--- a/agtermTests/ControlServerTests.swift
+++ b/agtermTests/ControlServerTests.swift
@@ -180,6 +180,7 @@ final class ControlServerTests: XCTestCase {
             library: library,
             actions: AppActions(library: library),
             settingsModel: SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir)),
+            identity: AppIdentity(version: "9.9.9"),
             socketPath: socketPath
         )
         servers.append(server)

--- a/agtermTests/ControlServerWorkspaceCommandsTests.swift
+++ b/agtermTests/ControlServerWorkspaceCommandsTests.swift
@@ -22,6 +22,7 @@ final class ControlServerWorkspaceCommandsTests: XCTestCase {
                 library: library,
                 actions: actions,
                 settingsModel: SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir)),
+                identity: AppIdentity(version: "9.9.9", commit: "testsha"),
                 socketPath: stateDir.appendingPathComponent("control.sock").path
             )
         }
@@ -39,6 +40,19 @@ final class ControlServerWorkspaceCommandsTests: XCTestCase {
 
     // the workspace's first session may already be the selected one, so selecting through the store's
     // own `selectWorkspace` is what makes the command retarget rather than report a lie
+    // both projections must be the SAME injected identity, not two independent bundle reads
+    func testVersionAndTreeReportTheInjectedIdentity() throws {
+        let injected = AppIdentity(version: "9.9.9", commit: "testsha")
+
+        let version = server.appIdentity()
+        XCTAssertTrue(version.ok, version.error ?? "")
+        XCTAssertEqual(version.result?.app, injected)
+
+        let tree = server.controlTree(window: nil)
+        XCTAssertTrue(tree.ok, tree.error ?? "")
+        XCTAssertEqual(tree.result?.tree?.app, injected)
+    }
+
     func testSelectingTheWorkspaceOwningTheSelectionDropsTheFreshWorkspace() throws {
         let store = try XCTUnwrap(library.activeStore)
         let owner = try XCTUnwrap(store.currentWorkspaceID)

--- a/agtermTests/ControlServerWorkspaceCommandsTests.swift
+++ b/agtermTests/ControlServerWorkspaceCommandsTests.swift
@@ -40,19 +40,6 @@ final class ControlServerWorkspaceCommandsTests: XCTestCase {
 
     // the workspace's first session may already be the selected one, so selecting through the store's
     // own `selectWorkspace` is what makes the command retarget rather than report a lie
-    // both projections must be the SAME injected identity, not two independent bundle reads
-    func testVersionAndTreeReportTheInjectedIdentity() throws {
-        let injected = AppIdentity(version: "9.9.9", commit: "testsha")
-
-        let version = server.appIdentity()
-        XCTAssertTrue(version.ok, version.error ?? "")
-        XCTAssertEqual(version.result?.app, injected)
-
-        let tree = server.controlTree(window: nil)
-        XCTAssertTrue(tree.ok, tree.error ?? "")
-        XCTAssertEqual(tree.result?.tree?.app, injected)
-    }
-
     func testSelectingTheWorkspaceOwningTheSelectionDropsTheFreshWorkspace() throws {
         let store = try XCTUnwrap(library.activeStore)
         let owner = try XCTUnwrap(store.currentWorkspaceID)
@@ -69,6 +56,19 @@ final class ControlServerWorkspaceCommandsTests: XCTestCase {
         XCTAssertEqual(response.result?.id, owner.uuidString)
         XCTAssertEqual(store.selectedSessionID, session.id)
         XCTAssertEqual(store.currentWorkspaceID, owner)
+    }
+
+    // both projections must be the SAME injected identity, not two independent bundle reads
+    func testVersionAndTreeReportTheInjectedIdentity() throws {
+        let injected = AppIdentity(version: "9.9.9", commit: "testsha")
+
+        let version = server.appIdentity()
+        XCTAssertTrue(version.ok, version.error ?? "")
+        XCTAssertEqual(version.result?.app, injected)
+
+        let tree = server.controlTree(window: nil)
+        XCTAssertTrue(tree.ok, tree.error ?? "")
+        XCTAssertEqual(tree.result?.tree?.app, injected)
     }
 
     func testSelectingAnEmptyWorkspaceReportsAndTargetsIt() throws {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1539,6 +1539,33 @@ final class ControlAPIUITests: ControlAPITestCase {
 
     // keymap.reload re-reads keymap.conf and returns the parse-diagnostic count. With no keymap file
     // seeded (the auto-created starter is all comments), a reload reports zero diagnostics.
+    // version and the tree's app are two projections of one AppIdentity, so they must agree, and version
+    // must answer without resolving a window.
+    func testVersionReportsTheServingAppAndMatchesTheTree() throws {
+        let response = try sendCommand(#"{"cmd":"version"}"#)
+        XCTAssertEqual(response["ok"] as? Bool, true, "version should succeed: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "version should carry a result")
+        let app = try XCTUnwrap(result["app"] as? [String: Any], "version should carry an app identity: \(response)")
+        let version = try XCTUnwrap(app["version"] as? String, "the identity should carry a version: \(app)")
+        XCTAssertFalse(version.isEmpty, "the version should not be empty: \(app)")
+
+        let tree = try XCTUnwrap(try sendCommand(#"{"cmd":"tree"}"#)["result"] as? [String: Any],
+                                 "tree should carry a result")
+        let treeApp = try XCTUnwrap((tree["tree"] as? [String: Any])?["app"] as? [String: Any],
+                                    "the tree top level should carry the same app identity")
+        XCTAssertEqual(treeApp["version"] as? String, version, "the two projections must agree: \(treeApp)")
+        XCTAssertEqual(treeApp["commit"] as? String, app["commit"] as? String,
+                       "the commit must come from the same identity: \(treeApp)")
+    }
+
+    // app-global: a target and a window selector are ignored rather than resolved or rejected.
+    func testVersionIgnoresTargetAndWindow() throws {
+        let response = try sendCommand(#"{"cmd":"version","target":"active","args":{"window":"nope"}}"#)
+        XCTAssertEqual(response["ok"] as? Bool, true, "version should ignore addressing: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "version should carry a result")
+        XCTAssertNotNil(result["app"], "the identity should come back regardless of addressing: \(response)")
+    }
+
     func testKeymapReloadReportsZeroDiagnostics() throws {
         let response = try sendCommand(#"{"cmd":"keymap.reload"}"#)
         XCTAssertEqual(response["ok"] as? Bool, true, "keymap.reload should succeed: \(response)")

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1535,10 +1535,8 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(reset["ok"] as? Bool, true, "font.reset on the active session should succeed: \(reset)")
     }
 
-    // MARK: - Keymap
+    // MARK: - Version
 
-    // keymap.reload re-reads keymap.conf and returns the parse-diagnostic count. With no keymap file
-    // seeded (the auto-created starter is all comments), a reload reports zero diagnostics.
     // version and the tree's app are two projections of one AppIdentity, so they must agree, and version
     // must answer without resolving a window.
     func testVersionReportsTheServingAppAndMatchesTheTree() throws {
@@ -1566,6 +1564,10 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNotNil(result["app"], "the identity should come back regardless of addressing: \(response)")
     }
 
+    // MARK: - Keymap
+
+    // keymap.reload re-reads keymap.conf and returns the parse-diagnostic count. With no keymap file
+    // seeded (the auto-created starter is all comments), a reload reports zero diagnostics.
     func testKeymapReloadReportsZeroDiagnostics() throws {
         let response = try sendCommand(#"{"cmd":"keymap.reload"}"#)
         XCTAssertEqual(response["ok"] as? Bool, true, "keymap.reload should succeed: \(response)")

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -14,8 +14,9 @@ description: >
   window/workspace/session addressing model and the AGTERM_* environment a spawned shell sees, plus
   subscribe to status, notification, session lifecycle, and tree-change events; diagnose problems
   (keymap editor, custom actions, logs); and file a bug as a GitHub issue or a
-  feature request / question as a GitHub Discussion. Also report the version of the app serving the
-  socket.
+  feature request / question as a GitHub Discussion. Also list, fetch and install the repository's
+  cookbook recipes, and read one as reference for a tricky workflow; and report the version of the app
+  serving the socket.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.split.close, session.scratch, session.focus, session.resize, surface.zoom, surface.cursor, cursor column, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
@@ -23,8 +24,9 @@ when_to_use: >
   session.hud, hud panel, show a message over a session, workspace.new, workspace.select, workspace.go, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
-  AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: agterm version,
-  which agterm is running, agterm version check. Also troubleshoot agterm,
+  AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: agterm cookbook,
+  cookbook recipe, list recipes, install a recipe, agterm recipe for X, what recipes are there, and
+  agterm version, which agterm is running, agterm version check. Also troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
   bug, report an agterm issue, open an agterm discussion / feature request.
 allowed-tools: Bash(agtermctl *)
@@ -157,8 +159,8 @@ rule.) After `--command`, confirm in `tree --json` that the new node's `foregrou
 
 ## Command summary
 
-Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
-**examples.md**.
+Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; worked
+examples in **examples.md**; installable community workflows in **cookbook.md**.
 
 **tree** — print the workspace/session tree (`--json` for structured). Each session node carries
 `foreground`/`splitForeground` (the live argv of each pane's foreground process, omitted when the pane
@@ -544,8 +546,10 @@ Full detail, templates, and the exact `gh` commands are in **troubleshooting.md*
   (`result.id`/`text`/`exitCode`/`count`/`affected`/`tree`/`windows`/`app`), error strings, the scratch/overlay/split
   lifecycle, and the keymap.conf format (`map` / `command`, chords, leaders, `|` alternatives,
   `{AGT_X}` tokens).
-- **examples.md** — copy-paste agtermctl recipes for common tasks (build a layout, run a program in a
+- **examples.md** — copy-paste agtermctl examples for common tasks (build a layout, run a program in a
   blocking overlay and read its status, type into a fresh session, notify, inspect the tree).
+- **cookbook.md** — how to list, acquire and install the repository's cookbook recipes, and how to read
+  one as reference for a tricky workflow. The recipe list lives in the repo, not here; fetch it.
 - **troubleshooting.md** — diagnosing common problems (keymap editor, custom actions, logs) and the
   bug-issue / feature-Discussion reporting workflow (draft-first, scrub, never post without approval).
 - **scripts/show-image.sh** — bundled helper that displays an image inline in an overlay (see above).

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -14,7 +14,8 @@ description: >
   window/workspace/session addressing model and the AGTERM_* environment a spawned shell sees, plus
   subscribe to status, notification, session lifecycle, and tree-change events; diagnose problems
   (keymap editor, custom actions, logs); and file a bug as a GitHub issue or a
-  feature request / question as a GitHub Discussion.
+  feature request / question as a GitHub Discussion. Also report the version of the app serving the
+  socket.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.split.close, session.scratch, session.focus, session.resize, surface.zoom, surface.cursor, cursor column, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
@@ -22,7 +23,8 @@ when_to_use: >
   session.hud, hud panel, show a message over a session, workspace.new, workspace.select, workspace.go, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
-  AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
+  AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: agterm version,
+  which agterm is running, agterm version check. Also troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
   bug, report an agterm issue, open an agterm discussion / feature request.
 allowed-tools: Bash(agtermctl *)
@@ -100,13 +102,15 @@ Inspect the live tree any time with `agtermctl tree --json` (workspaces → sess
 terminal title (e.g. a remote host over SSH), omitted when none was reported — read it when a
 session's local `cwd` is stale because it's connected to a remote. `surfaces[].id` is the
 control address for `surface zoom` and `surface cursor` (`left`, `right`, `scratch`, `overlay`,
-`overlay-left`, or `overlay-right`), including hidden-but-alive split/scratch surfaces. The tree object also carries five
-read-only top-level fields: `idleMs` (ms since the last user input in the window), `autoFollowMs`
+`overlay-left`, or `overlay-right`), including hidden-but-alive split/scratch surfaces. The tree object also carries
+read-only top-level fields — `idleMs` (ms since the last user input in the window), `autoFollowMs`
 (the Auto-follow timeout in ms, omitted when Disabled), `sidebarVisible` (whether the window's
 sidebar is currently shown — the read side of the write-only `sidebar` command), `sidebarMode`
-(`tree` or `flagged` — the read side of `sidebar mode`), and `quickVisible` (whether the quick terminal is
-shown — the read side of the write-only `quick` command; app-level, so every window reports the same
-value). List windows with
+(`tree` or `flagged` — the read side of `sidebar mode`), `workspaceFilter`, `quickVisible` (whether the
+quick terminal is shown — the read side of the write-only `quick` command; app-level, so every window
+reports the same value), `zoomedSurface`, the four `dashboard*` fields, `pickPending`, and `app` (the
+serving app's `version`, plus `commit` when the build recorded one — the same value `agtermctl version`
+returns). reference.md lists every one with its exact shape. List windows with
 `agtermctl window list --json`; each window also reports `autoFollowMs`, `sidebarVisible`, `geometry`
 (the live frame `{x, y, width, height, display}` in the units `window move`/`window resize` take — the
 read side, so record it then restore the exact frame), and `fullscreen`/`zoomed`/`minimized` (the read side
@@ -488,6 +492,13 @@ appearance automatically; `theme set --dark none` stops tracking. The app defaul
 **restore** — `restore clear` — clear every session's saved foreground command (the
 restore-running-command capture) so the next restart restores plain shells.
 
+**version** — `agtermctl version` — which agterm is serving this socket, as `result.app` (`version`, plus
+`commit` when the build recorded one). App-global: no target, no `--window`, no window need be open, so it
+works as a preflight from a keymap-launched script, which has no `$TERM_PROGRAM_VERSION`. Address the
+socket explicitly (`--socket "$AGTERM_SOCKET"`, or `"$AGT_SOCKET"` in a keymap child): a bare call
+resolves the DEFAULT socket, which may be another app. The same identity is on the tree top level as
+`app`.
+
 ## Displaying an image inline
 
 This skill bundles `scripts/show-image.sh`. It opens an overlay (a real terminal) and renders the
@@ -530,7 +541,7 @@ Full detail, templates, and the exact `gh` commands are in **troubleshooting.md*
 ## Reference files
 
 - **reference.md** — full per-command detail: every flag, the JSON return shapes
-  (`result.id`/`text`/`exitCode`/`count`/`affected`/`tree`/`windows`), error strings, the scratch/overlay/split
+  (`result.id`/`text`/`exitCode`/`count`/`affected`/`tree`/`windows`/`app`), error strings, the scratch/overlay/split
   lifecycle, and the keymap.conf format (`map` / `command`, chords, leaders, `|` alternatives,
   `{AGT_X}` tokens).
 - **examples.md** — copy-paste agtermctl recipes for common tasks (build a layout, run a program in a

--- a/plugins/agterm/skills/agterm/cookbook.md
+++ b/plugins/agterm/skills/agterm/cookbook.md
@@ -62,10 +62,14 @@ serving the socket — but **address the socket explicitly**, because `agtermctl
 `AGTERM_SOCKET` and a bare invocation resolves the default path, which may be a DIFFERENT app than the
 one that spawned this session:
 
-- Checking from a session shell: `agtermctl version --socket "$AGTERM_SOCKET"`.
-- Inside a recipe's own preflight, launched from the keymap or the palette:
-  `agtermctl version --socket "$AGT_SOCKET"`.
-- Fall back to a bare `agtermctl version` only when neither variable is set.
+- For an interactive check from a session shell, use
+  `agtermctl version --socket "$AGTERM_SOCKET"`.
+- Inside an automated preflight launched from the keymap or the palette, use
+  `agtermctl version --json --socket "$AGT_SOCKET"` and extract only `.result.app.version` with the
+  JSON parser the recipe already requires. Never compare the human output: it also includes the client
+  path and may include a parenthesized commit.
+- Fall back to the default socket only when neither variable is set. An automated check still uses
+  `agtermctl version --json` and extracts only `.result.app.version`.
 
 `$TERM_PROGRAM_VERSION` carries the same number in a session shell, and is the fallback on a release
 too old to have the `version` command, along with the About panel. It is ABSENT in a keymap- or

--- a/plugins/agterm/skills/agterm/cookbook.md
+++ b/plugins/agterm/skills/agterm/cookbook.md
@@ -1,0 +1,102 @@
+# agterm cookbook
+
+The cookbook is a directory of installable `agtermctl` workflows kept in the agterm repository, one
+directory per recipe. It is NOT bundled with this skill, so unless the session sits in an agterm
+checkout it has to be fetched.
+
+Two uses, same acquisition path:
+
+- **Install a recipe** the user asked for.
+- **Read one as reference** when a workflow is hard to compose — a recipe is a working solution to a
+  real sequencing problem, so follow how it drives the commands instead of inventing a sequence.
+  Nothing is installed in this case.
+
+## Where it is
+
+`umputun/agterm`, directory `cookbook/`, browsable at
+`https://github.com/umputun/agterm/tree/master/cookbook`. The index is `cookbook/README.md`.
+
+Never recite recipe names from memory. Recipes are added and changed independently of this skill, so
+a fetched index is the only current list; anything not in it does not exist. Never assemble a recipe
+URL from a name — the only URL you may fetch for a recipe is one the index linked.
+
+Use the agent's own URL retrieval for the single-file fetches. Materializing a directory needs a shell
+download, which is one archive fetch, not one per file — ask before it.
+
+## Listing
+
+Fetch `https://raw.githubusercontent.com/umputun/agterm/master/cookbook/README.md` and report it as it
+stands. It groups recipes by what they
+are for and gives each one's minimum agterm version and its dependencies. Answer "what can I install"
+from that fetch alone — no recipe directory is needed to list.
+
+## Acquiring one
+
+Anything that ends in files on disk pins first, so the index you read and the payload you copy come
+from the same tree. Every URL below is derivable without knowing any recipe name — `<sha>` is the one
+you resolved in step 1, and nothing else is ever interpolated:
+
+1. Resolve `master` to one commit SHA:
+   `https://api.github.com/repos/umputun/agterm/commits/master` (the `sha` field).
+2. Fetch the index at that SHA:
+   `https://raw.githubusercontent.com/umputun/agterm/<sha>/cookbook/README.md`.
+3. Resolve the requested name only against links in that index. A name that does not appear there is
+   not a recipe; say so rather than guessing. Check that the linked target is a direct child of
+   `cookbook/` — anything reaching outside it is not a recipe either.
+4. Materialize from the same SHA: download the pinned repository snapshot
+   `https://github.com/umputun/agterm/archive/<sha>.tar.gz` into a temp dir and take the one directory
+   from it. This is the whole repo at that commit, NOT a per-recipe URL — never construct one of those.
+5. Read `Requirements` and `Setup` from what was acquired, never from memory of the index row.
+6. Read the payload itself before copying or binding it. A script copied unread is a script the user
+   runs on the next keypress.
+
+A local checkout is used instead only when the session sits in an actual agterm repository: a git
+repo whose root holds `cookbook/` alongside `agtermCore/` and `project.yml`, not merely a directory
+containing `cookbook/`. State the path and whether the tree is dirty before using anything out of it.
+A dirty tree is not a blocker: testing a local edit is a normal case.
+
+## Requirements
+
+Every recipe states a minimum agterm version. `agtermctl version` reports the version of the app
+serving the socket — but **address the socket explicitly**, because `agtermctl` never reads
+`AGTERM_SOCKET` and a bare invocation resolves the default path, which may be a DIFFERENT app than the
+one that spawned this session:
+
+- Checking from a session shell: `agtermctl version --socket "$AGTERM_SOCKET"`.
+- Inside a recipe's own preflight, launched from the keymap or the palette:
+  `agtermctl version --socket "$AGT_SOCKET"`.
+- Fall back to a bare `agtermctl version` only when neither variable is set.
+
+`$TERM_PROGRAM_VERSION` carries the same number in a session shell, and is the fallback on a release
+too old to have the `version` command, along with the About panel. It is ABSENT in a keymap- or
+palette-launched process, which inherits the app's launch environment rather than a terminal
+surface's — so a recipe preflight cannot use it.
+
+Check the recipe's other requirements too (`jq`, `fzf`, `python3`, a particular shell, a named agent)
+and report what is missing before installing rather than after.
+
+## Installing
+
+Recipes are third-party scripts that run on the user's machine against the user's own sessions, and
+several close sessions or delete workspaces. Show what a recipe does and what it needs before
+installing it. Follow the recipe's own `Setup`; never invent a procedure it does not describe.
+
+Every file an install touches is merged, never replaced:
+
+- Read the file first and show the exact line or block to be added.
+- Add only if absent.
+- Stop and ask when the command name already exists with different content, or the chord is already
+  taken. Do not pick a different chord unprompted.
+- Preserve unrelated lines and comments. This covers `keymap.conf`, shell rc files, and agent settings
+  alike.
+- Never overwrite an existing script payload without comparing it and putting the difference to the
+  user.
+
+Do not run an acquired script as part of installing it.
+
+Applying a new keymap entry needs `agtermctl keymap reload` (or File ▸ Reload Keymap); say so.
+
+## Contributing
+
+`cookbook/CONTRIBUTING.md` in the repository holds the rules for adding a recipe. Fetch it when asked;
+do not summarize them from memory.

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -1,9 +1,10 @@
-# agterm control recipes
+# agterm control examples
 
 Worked `agtermctl` examples. See `reference.md` for exact flags and return shapes. All assume
 `agtermctl` is on PATH and you are inside an agterm session (`AGTERM_ENABLED=1`).
 
-Installable, human-facing versions of these workflows: https://github.com/umputun/agterm/tree/master/cookbook
+Installable, human-facing workflows live in the repository's cookbook — see `cookbook.md` for how to
+list, fetch and install one, or to read one as reference for a tricky case.
 
 ## Inspect the current state
 
@@ -205,7 +206,7 @@ program renders normally in the overlay; read its OUTPUT from the program's own 
 Pass `--target "$AGTERM_SESSION_ID"` so the overlay attaches to YOUR (the calling) session. Without
 `--target` it opens on whatever session is currently active — so if the user has moved to another
 session or workspace, an agent (e.g. running revdiff) pops a blocking full-pane overlay on the WRONG
-session. Always target your own session for these recipes.
+session. Always target your own session for these examples.
 
 ```bash
 agtermctl session overlay open "revdiff HEAD~3 --output /tmp/notes.md" --target "$AGTERM_SESSION_ID" --block   # this session
@@ -488,7 +489,7 @@ agtermctl sidebar collapse --window "$AGTERM_WINDOW_ID"  # collapse a specific w
 
 Collapse or expand ONE workspace by id (the per-workspace pair, unlike `sidebar expand`/`collapse` which
 act on all of them). Create a workspace already collapsed with `workspace new --collapsed`, then add
-sessions with `session new --no-select` so it never opens or steals the current selection — the recipe
+sessions with `session new --no-select` so it never opens or steals the current selection — the example
 for staging a batch of sessions out of the way. Read the open/closed state back from the tree workspace
 node's `collapsed` flag (`true` when collapsed, omitted when expanded).
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -15,7 +15,8 @@ Full detail for every `agtermctl` command. See `SKILL.md` for the model and addr
 - **Response shape**: `{"ok": true, "result": {…}}` or `{"ok": false, "error": "<message>"}`.
   `result` carries one of: `id` (affected/new session/workspace/window), `text` (session copy/text),
   `exitCode` (overlay result), `count` (diagnostics/search), `affected` (sessions actually changed by a
-  batch close/move), `tree` (the tree), `windows` (window list). The process exit code is non-zero when
+  batch close/move), `tree` (the tree), `windows` (window list), `app` (the serving app's identity, for
+  `version`). The process exit code is non-zero when
   `ok` is false.
 - **Options go after the subcommand**: `agtermctl session type "ls" --target active`, never before it.
 
@@ -197,7 +198,7 @@ members), and `collapsed` (whether this workspace is COLLAPSED in the sidebar tr
 `workspace collapse`/`workspace expand` and `workspace new --collapsed`; `true` when collapsed, omitted
 when expanded, so an all-expanded tree carries no `collapsed` keys).
 
-The tree object itself carries twelve top-level read-only fields: `idleMs` (milliseconds since the last
+The tree object itself carries thirteen top-level read-only fields: `idleMs` (milliseconds since the last
 user input in the window, omitted before any activity), `autoFollowMs` (the window's Auto-follow
 timeout in milliseconds, omitted when the setting is Disabled), `sidebarVisible` (whether the
 window's sidebar is currently shown — the read side of the write-only `sidebar` command, so a script
@@ -221,12 +222,17 @@ as both), `dashboardHighlighted` (the highlighted cell's pane ref — the one En
 that exact pane), `dashboardFontSize` (the absolute font size in points applied to the cells, omitted when
 the mode is `untouched`), and `dashboardFontMode` (`auto` for `--auto-size`, `fixed` for `--font-size`, or
 `untouched`), plus `pickPending` (the id of the native picker currently awaiting an answer in this
-window, omitted when none is pending). `idleMs` is live
+window, omitted when none is pending), and `app` (which agterm is serving this socket: `version`, plus
+`commit` when the build recorded one — the same value `agtermctl version` returns, so an agent already
+reading the tree gets its version floor without a second round-trip; it is not duplicated onto
+`window.list`, where a caller uses `version` instead). `idleMs` is live
 and grows while the window is idle, so it is on `tree` only, never `window.list`; `sidebarVisible` is on
 both; `sidebarMode`, `workspaceFilter`, `quickVisible`, `zoomedSurface`, the four `dashboard*` fields, and
 `pickPending`
-are `tree`-only (a GUI/keyboard change would leave a cached copy stale).
-All twelve are read-only projections of GUI state.
+are `tree`-only (a GUI/keyboard change would leave a cached copy stale). All of those are read-only
+projections of live GUI state. `app` is the one CONSTANT among them, and is absent from `window.list`
+for a different reason: it describes the serving app rather than a window, so repeating it on every row
+buys nothing. A caller with no tree uses `version`.
 
 ## workspace
 
@@ -1196,6 +1202,30 @@ For a PER-SESSION, per-pane override that pins (or suppresses) what a pane resto
 `session restore` (in the session section above): it wins over the captured foreground, bypasses the
 denylist, and is what a `SessionStart` hook rewrites to reattach a non-idempotent command. `restore clear`
 here is app-global and touches only the captured commands, not those overrides.
+
+## version
+
+`agtermctl version` — which agterm is serving this socket. App-global: no target, no `--window`, and no
+window need be open, so it works as a preflight from a keymap-launched script. Returns `result.app`:
+
+- `version` — the app's version, the number a cookbook recipe's minimum is compared against.
+- `commit` — the build's git commit, omitted when the build recorded none. Diagnostics only; never part
+  of a version comparison.
+
+Human output is `version` alone, or `version (commit)`, followed by a `client:` line naming the resolved
+path of the `agtermctl` that ran — a diagnostic for a stale CLI earlier on `PATH` than the app's bundled
+helper. That line is human output only: `--json` stays the raw server response, and a caller that needs
+the client path resolves the binary it invoked itself.
+
+Address the socket explicitly when the answer must be about THIS session's app: `agtermctl` never reads
+`AGTERM_SOCKET`, so a bare call resolves the default path and may report a different instance. Use
+`--socket "$AGTERM_SOCKET"` from a session shell and `--socket "$AGT_SOCKET"` from a keymap- or
+palette-launched child.
+
+The same identity is on the `tree` top level as `app`, so an agent already reading the tree needs no
+second call. In a session shell `$TERM_PROGRAM_VERSION` carries the same number, but it is ABSENT in a
+process launched from the keymap or the palette, which inherits the app's launch environment rather than
+a terminal surface's.
 
 ## Errors you may see
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1,7 +1,7 @@
 # agterm control reference
 
-Full detail for every `agtermctl` command. See `SKILL.md` for the model and addressing overview, and
-`examples.md` for recipes.
+Full detail for every `agtermctl` command. See `SKILL.md` for the model and addressing overview,
+`examples.md` for worked examples, and `cookbook.md` for the repository's installable recipes.
 
 ## Connection and output
 

--- a/project.yml
+++ b/project.yml
@@ -88,7 +88,8 @@ targets:
       - path: agterm/Resources/hud
         type: folder
         buildPhase: resources
-      # Agent skill package (SKILL.md + reference.md + examples.md + troubleshooting.md + scripts).
+      # Agent skill package (SKILL.md + reference.md + examples.md + cookbook.md + troubleshooting.md
+      # + scripts).
       # It lives at plugins/agterm/skills/agterm so the SAME directory is also the skill source for
       # the Claude Code and Codex plugin manifests — one copy, three consumers. Folder reference so
       # the whole dir copies verbatim to Contents/Resources/agterm; the installer copies it from

--- a/site/commands.html
+++ b/site/commands.html
@@ -292,8 +292,11 @@
               (overlay result), <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">count</span>
               (search matches, keymap/config diagnostics),
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ratio</span> (session resize),
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">tree</span>, or
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">windows</span>.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">tree</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">windows</span>, or
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">app</span>
+              (the serving app's identity, for
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">version</span>).
             </p>
             <div
               style="

--- a/site/commands.html
+++ b/site/commands.html
@@ -203,6 +203,7 @@
             <a href="#keymap" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">keymap</a>
             <a href="#config" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">config</a>
             <a href="#restore" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">restore</a>
+            <a href="#version" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">version</a>
             <div style="height: 16px"></div>
             <span style="color: #4a5158; font-size: 11px; letter-spacing: 0.12em; padding: 4px 12px">HELP</span>
             <a href="#errors" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Errors</a>
@@ -512,8 +513,15 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace filter</span>),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quickVisible</span>, and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> (the pending native picker's id,
-                omitted when none is open). All seven are read-only
-                projections of GUI state.
+                omitted when none is open),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomedSurface</span>, the four
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">dashboard*</span> fields, and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">app</span> (which agterm is serving this socket —
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">version</span>, plus
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commit</span> when the build recorded one; the same value
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">agtermctl version</span> returns).
+                All are read-only, and all but
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">app</span> are projections of live GUI state.
               </p>
             </div>
           </section>
@@ -2626,6 +2634,48 @@
                 It does <em>not</em> clear a <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session new --command</span>
                 session's own command — that is the durable creation identity and still re-runs on restore when the setting is on.
                 This is the counterpart to the opt-in <em>Restore running commands on restart</em> setting.
+              </p>
+            </div>
+          </section>
+
+          <section id="version" style="scroll-margin-top: 88px; padding-top: 56px">
+            <h2
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 700;
+                font-size: 28px;
+                letter-spacing: -0.02em;
+                margin: 0 0 16px;
+                padding-bottom: 12px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+              "
+            >
+              version
+            </h2>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl version
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">version</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Which agterm is serving this socket. App-global: no target, no
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span>, and no window need be open, so it
+                works as a preflight from a keymap-launched script. Returns
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.app</span> with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">version</span> and, when the build recorded one,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commit</span> — diagnostics only, never part of a
+                version comparison.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Human output is the version, or <span style="font-family: &quot;JetBrains Mono&quot;, monospace">version (commit)</span>,
+                followed by a <span style="font-family: &quot;JetBrains Mono&quot;, monospace">client:</span> line naming the resolved path of
+                the <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl</span> that ran — a diagnostic for a stale CLI
+                ahead of the app's bundled helper on <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span>. That line is
+                human output only; <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--json</span> stays the raw response.
+                The same identity is on the tree top level as
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">app</span>, so an agent already reading the tree needs no
+                second call.
               </p>
             </div>
           </section>

--- a/site/docs.html
+++ b/site/docs.html
@@ -475,6 +475,8 @@
                 ><strong style="color: #e6e1d7">Install Agent Skill…</strong> teaches Claude Code or Codex how to drive agterm
                 through <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span>, so an
                 agent inside a session can build its own layout, run overlays, and manage windows without you explaining the API.
+                It also knows the cookbook, so you can ask it to list the available recipes, set one up for you, or read one for
+                reference when a workflow is hard to get right.
                 It drives the app through the CLI, so install that one too. The same skill is also published as a plugin from the
                 repository — <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
                   >claude plugin marketplace add umputun/agterm</span


### PR DESCRIPTION
the bundled agent skill knew the cookbook only as a bare URL in `examples.md`, so an agent asked to list recipes or set one up had nothing to work from. It also had no way to check a recipe's minimum version, since `agtermctl` reported none and `$TERM_PROGRAM_VERSION` never reaches a keymap- or palette-launched process, which is how a recipe normally runs.

**`agtermctl version`** reports which agterm is serving the socket. App-global: no target, no `--window`, and no window need be open. One `AppIdentity` is built in the app target from `Bundle.main` and injected into `ControlServer`, feeding `tree.app`, the command, and each spawned terminal's `TERM_PROGRAM_VERSION` from a single value, so the three cannot drift apart. `commit` rides beside the version as diagnostics and is never part of a comparison.

human output adds a `client:` line naming the resolved path of the `agtermctl` that ran, which catches a stale CLI ahead of the bundled helper on `PATH`. That line is human output only; `--json` stays the raw response.

**`cookbook.md`** carries no recipe names. It resolves `master` to a commit SHA, reads the index at that SHA, resolves a requested name only against links in that index, and materializes from the same SHA, so the index read and the payload copied come from one tree and no URL is ever assembled from a name. Installing follows the recipe's own Setup: read each file first, add only if absent, stop and ask on a duplicate command or an occupied chord. It also covers reading a recipe as reference for a tricky workflow rather than installing it.

two doc drifts fixed along the way: `SKILL.md` claimed the tree had five top-level fields and `site/commands.html` claimed seven, where it has twelve.
