### PR TITLE
feat(nav): add cmd+1..cmd+9 session slots

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -189,8 +189,11 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   `--grow-left|right|primary|split|top|bottom` delta, defaulting an unset ratio to 0.5. Require a split,
   clamp through store limits, persist, then post the object-scoped live-divider notification. Hidden split
   stores for next show. Return clamped ratio as `%.3f`; read `splitRatio`.
-- `session.go --to next|prev|first|last|next-attention|prev-attention` operates on current selection in
-  the placement store, wraps within filtered scope, and returns selected ID. It has no target.
+- `session.go --to next|prev|first|last|next-attention|prev-attention|1-9` operates on current selection in
+  the placement store, wraps within filtered scope, and returns selected ID. It has no target. A digit is
+  the absolute slot the ⌘1…⌘9 chords select, one vocabulary with them ([[keymap]] owns the rule); a slot
+  naming no session leaves the selection where it was and still answers ok with it, exactly as a one-session
+  `next` does.
 - `notify` requires body, defaults title and session, skips OSC focus suppression, increments unseen, and
   uses click identity. When banners are disabled, return `ControlNotify.bannersOffNote` (#286); delivered
   requests omit text. Read through `unseen`.

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -62,7 +62,7 @@ paths:
   alternative, `alternative skipped`/`alternative dropped` with more), pinned by
   `KeymapTests.pipeFreeKeymapParsesExactlyAsItDidBeforeAlternatives`.
 - Pure types live in `Keybind.swift`, `KeybindMatcher`, `CustomCommand`/`CommandContext`,
-  `BuiltinAction` (46 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
+  `BuiltinAction` (55 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
   `CommandContext` owns the shared expansion/environment token table.
 - Built-ins use AppKit menu key equivalents from `keymap.equivalent(for:)`; apply only non-nil
   `KeyboardShortcut`s. SwiftUI rebuilds menu shortcuts on the next activation, not immediately after
@@ -143,10 +143,18 @@ paths:
   disjoint without relying on dispatch order. Standard menu items such as ⌘Q/⌘C/⌘, remain AppKit's
   responsibility.
 - `BuiltinAction.defaultChord` is the sole built-in default. Every menu item resolves
-  override-or-default, including the six arrow actions. Two keyed actions are delivered by a monitor
+  override-or-default, including the six arrow actions. Three keyed families are delivered by a monitor
   rather than a menu equivalent: `undo_close` through `UndoCloseShortcut`, so native text undo still
-  works, and `toggle_fullscreen` through `CustomCommandRunner`, because agterm ships no full screen menu
-  item for it to ride — see [[windows]]. Both are absent from `keymap list`'s `menu` by design.
+  works, and `toggle_fullscreen` plus `select_session_1`…`_9` through `CustomCommandRunner` — agterm ships
+  no full screen menu item for the first to ride (see [[windows]]), and the nine slots deliberately have
+  neither a menu item nor a palette row, the fuzzy session palette being the by-name surface nine numbered
+  rows would only crowd. All are absent from `keymap list`'s `menu` by design; the slots resolve through
+  `Keymap.sessionSlotAction(forChord:)` and run via `paletteLessHandler`, so they still take the shipped
+  conflict model and `uiActionsEnabled` gate.
+- `SessionSlot.index` owns what ⌘1…⌘9 select, over `navigableSessions` like every other step: slot 9
+  overflows to the LAST session only past nine sessions, since below that there is no unreachable tail and a
+  slot must not name two different rows at one count. `session.go --to 1`…`9` is the same vocabulary, so a
+  chord and a control call cannot mean different things.
 - Write shifted symbols as `shift+<base>`: `shift+/` for `?`, `shift+=` for `+`, `shift+5` for `%`, and
   `shift+.` for `>`. `CustomCommandRunner` uses `characters(byApplyingModifiers: [])` to recover that
   base; keep `KeymapUITests.testCustomCommandShiftedSymbolFires`.
@@ -201,9 +209,11 @@ paths:
   it to parse clean, and counts the chords that survive.
   Both verbs rot: `validateBindings` clears a custom shortcut a built-in has claimed just as
   `resolveBuiltinOverrides` drops the colliding `map`.
-- New shipped defaults must not break a valid existing keymap. `parseKeymap` vacates the new horizontal
-  split default when an old file explicitly uses `cmd+shift+d`, and vacates Dashboard's new default when
-  an old file explicitly uses `cmd+shift+g`. An explicit map for the new action opts into its new chord.
+- New shipped defaults must not break a valid existing keymap. `vacatesNewDefault` gives the new action's
+  chord up to whatever an old file already spells there — a `map`, an alternative, or a custom shortcut —
+  and an explicit map for the new action, in any form, opts into it. It owns `cmd+shift+d`
+  (`toggle_horizontal_split`), `cmd+shift+g` (`dashboard`) and `cmd+1`…`cmd+9` (the slots); a later default
+  joins its list rather than adding a fourth copy of the check.
 - **`{AGT_X}` interpolation is intentionally raw and unquoted.** Selection, OSC title, OSC 7 pwd, and the
   session/workspace/window names and `--cwd` a caller supplies over control or the GUI can all inject
   visible shell metacharacters. `TerminalText.sanitized` strips control characters, not `;`,

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -185,6 +185,9 @@ paths:
   Option-Command-Left/Right remains pane focus.
 - `navigateSession` uses `navigableSessions`, wraps previous/next, selects ends for first/last, chooses
   first on nil/invalid selection, and no-ops when empty. Menu, palette, and `session.go` share it.
+- The ⌘1…⌘9 slots are the absolute form of the same step: `navigatePlain(.slot(n))`, so gate, activity note
+  and pane reveal match the arrows exactly. They have no menu item and no palette row; [[keymap]] owns the
+  monitor dispatch and `SessionSlot`'s overflow rule.
 - Previous/Next Workspace are the level above: `navigateWorkspace` steps `currentWorkspaceID` through
   `visibleWorkspaces` and lands on the target's FIRST session, so the keybind, the palette row and
   `workspace.go` mean one thing. Keyless, tree mode only, and it reveals a landed pane off the step's

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -140,12 +140,15 @@ extension AppActions {
         paletteLessHandler(for: action)?()
     }
 
-    /// The entry point for a built-in that no `PaletteCommand` row owns — window management and the three
-    /// palette launchers, each already gated where it needs to be — and nil for every action the palette
+    /// The entry point for a built-in that no `PaletteCommand` row owns — window management, the three
+    /// palette launchers and the nine session slots, each already gated where it needs to be — and nil for
+    /// every action the palette
     /// covers. The SINGLE listing of those actions: `perform(_:)` dispatches through it and
     /// `AppActionsPaletteTests` partitions `BuiltinAction.allCases` across it and `PaletteCommand`, so a new
     /// action reaching neither fails a test instead of binding a key that swallows itself and does nothing.
     func paletteLessHandler(for action: BuiltinAction) -> (() -> Void)? {
+        // the nine session slots: no row, since the fuzzy session palette already lists every session by name.
+        if let slot = action.sessionSlot { return { self.selectSessionSlot(slot) } }
         switch action {
         case .newWindow: return { self.newWindow() }
         case .renameWindow: return renameActiveWindow

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -422,6 +422,11 @@ final class AppActions {
         revealActiveBlockedPane(captured: indicator)
     }
 
+    /// Jump to an absolute slot in the sidebar's flattened visual order (⌘1…⌘9, `session.go --to N`), through
+    /// the same `navigatePlain` the directional steps use, so where a jump lands and what it focuses cannot
+    /// differ from where a step does. A slot naming no session leaves the selection alone.
+    func selectSessionSlot(_ slot: Int) { navigatePlain(.slot(slot)) }
+
     func selectNextSession() { navigatePlain(.next) }
     func selectPreviousSession() { navigatePlain(.previous) }
     func selectFirstSession() { navigatePlain(.first) }

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -79,8 +79,8 @@ final class CustomCommandRunner {
 
     /// Feed one key event to the matcher; returns whether it was consumed (so the caller drops it). Esc while
     /// armed resets, `.fired` runs a command, `.firedBuiltin` runs a built-in action, `.armed` arms the leader
-    /// timer, and `toggle_fullscreen`'s chord toggles full screen without reaching the matcher at all — all
-    /// consumed; `.unmatched` passes through.
+    /// timer, and the two menu-item-less built-in families — `toggle_fullscreen` and the nine session slots —
+    /// are dispatched without reaching the matcher at all; all consumed. `.unmatched` passes through.
     ///
     /// Acts when the key window's first responder is a terminal surface (context from that surface), or when
     /// the key window is an agterm terminal window whose focus is NOT on a text field — including one emptied
@@ -137,6 +137,13 @@ final class CustomCommandRunner {
         // ordinary `.firedBuiltin` route and so takes that route's modal rule.
         if !commandEngine.isArmed, chord == settings.keymap.equivalent(for: .toggleFullscreen) {
             keyWindow.toggleFullScreen(nil)
+            return true
+        }
+        // the nine ⌘1…⌘9 session slots carry no menu item either, so their menu chords are matched here too;
+        // `perform` runs them through the gate their `paletteLessHandler` entry holds. A half-typed leader
+        // still wins, as above.
+        if !commandEngine.isArmed, let slot = settings.keymap.sessionSlotAction(forChord: chord) {
+            actions.perform(slot, in: keyWindow)
             return true
         }
         switch commandEngine.advance(chord) {

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -1,50 +1,6 @@
 import Foundation
 import Observation
 
-/// A relative step through the flattened session list for keyboard navigation. `next`/`previous` step one
-/// and wrap, `first`/`last` jump to a tree end, `nextAttention`/`previousAttention` step (wrapping) through
-/// only the sessions needing attention — status `blocked` or `completed`.
-public enum SessionNavigation: Sendable { case next, previous, first, last, nextAttention, previousAttention }
-
-extension SessionNavigation {
-    /// Maps a control-channel direction string to a case, nil for an unknown one. Both `prev` (the CLI's
-    /// spelling) and `previous` are accepted.
-    public init?(wire: String) {
-        switch wire {
-        case "next": self = .next
-        case "prev", "previous": self = .previous
-        case "first": self = .first
-        case "last": self = .last
-        case "next-attention": self = .nextAttention
-        case "prev-attention", "previous-attention": self = .previousAttention
-        default: return nil
-        }
-    }
-}
-
-/// A relative step through the visible workspace list. Only `next`/`previous`: a workspace carries no
-/// attention state, and wrapping already reaches both ends.
-public enum WorkspaceNavigation: Sendable { case next, previous }
-
-/// What one workspace step landed on. The indicator is the selected session's, captured BEFORE an
-/// `autoReset` status cleared, which is what lets the GUI route pane reveal exactly as session nav does
-/// (`AppActions.revealActiveBlockedPane`); nil for an empty workspace.
-public struct WorkspaceStep: Sendable {
-    public let workspaceID: UUID
-    public let indicator: AgentIndicator?
-}
-
-extension WorkspaceNavigation {
-    /// Maps a control-channel direction string to a case, nil for unknown. Both spellings of previous.
-    public init?(wire: String) {
-        switch wire {
-        case "next": self = .next
-        case "prev", "previous": self = .previous
-        default: return nil
-        }
-    }
-}
-
 /// The whole app state: the workspace tree and the current selection. `@Observable @MainActor` so views
 /// observe mutations and all model access is main-actor isolated (implicitly `Sendable` via isolation).
 /// Selection is one `Session.ID?` — workspace rows are non-selectable headers, so the workspace is derived.
@@ -635,7 +591,8 @@ public final class AppStore {
     /// (`navigableSessions`: the flagged set in `.flagged` mode, the MARKED workspaces' sessions while the
     /// focus filter is applied, else all). `next`/`previous` move one and WRAP WITHIN that set, never leaking
     /// across the filter; `first`/`last` jump to its ends; with no/invalid selection `next`/`previous` land
-    /// on the first session. No-op on an empty list. Routes through `selectSession`, inheriting recency,
+    /// on the first session; `slot` jumps to an absolute position in it, per `SessionSlot.index`.
+    /// No-op on an empty list. Routes through `selectSession`, inheriting recency,
     /// badge clearing, persistence and workspace derivation. Targets are always in-set, so nav never triggers
     /// `disableFocusIfSelectionOutsideSet` — that stays the safety net for an explicit cross-set select.
     @discardableResult
@@ -657,6 +614,9 @@ public final class AppStore {
         case .nextAttention, .previousAttention:
             guard let found = attentionTarget(in: sessions, forward: direction == .nextAttention) else { return nil }
             target = found
+        case .slot(let slot):
+            guard let index = SessionSlot.index(slot, count: ids.count) else { return nil }
+            target = ids[index]
         }
         return selectSession(target)
     }

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -21,6 +21,11 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
     case previousSession = "previous_session", nextSession = "next_session"
     case previousAttentionSession = "previous_attention_session", nextAttentionSession = "next_attention_session"
     case firstSession = "first_session", lastSession = "last_session"
+    case selectSession1 = "select_session_1", selectSession2 = "select_session_2"
+    case selectSession3 = "select_session_3", selectSession4 = "select_session_4"
+    case selectSession5 = "select_session_5", selectSession6 = "select_session_6"
+    case selectSession7 = "select_session_7", selectSession8 = "select_session_8"
+    case selectSession9 = "select_session_9"
     case quickTerminal = "quick_terminal", sessionPalette = "session_palette", commandPalette = "command_palette"
     case customCommandPalette = "custom_command_palette", showAttention = "show_attention"
     case dashboard = "dashboard"
@@ -61,10 +66,26 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
         case .nextSession: return Chord(mods: [.command, .option], key: "down")
         case .previousAttentionSession: return Chord(mods: [.control, .option], key: "up")
         case .nextAttentionSession: return Chord(mods: [.control, .option], key: "down")
+        case .selectSession1, .selectSession2, .selectSession3, .selectSession4, .selectSession5,
+             .selectSession6, .selectSession7, .selectSession8, .selectSession9:
+            return sessionSlot.map { Chord(mods: [.command], key: String($0)) }
         case .renameWindow, .deleteWindow, .renameWorkspace, .deleteWorkspace, .renameSession, .duplicateSession,
              .clearStatus, .firstSession, .lastSession, .selectTheme, .toggleFlaggedView, .focusWorkspace,
              .toggleWorkspaceFilter, .previousWorkspace, .nextWorkspace, .toggleWorkspaceCollapse:
             return nil
         }
+    }
+
+    /// The nine absolute session jumps ⌘1…⌘9, in slot order. They carry NO menu item and no palette row —
+    /// nine numbered rows would be noise beside the fuzzy session palette — so `CustomCommandRunner` matches
+    /// their chords and `AppActions.paletteLessHandler` runs them. `SessionSlot` owns what a slot selects.
+    public static let sessionSlots: [BuiltinAction] = [
+        .selectSession1, .selectSession2, .selectSession3, .selectSession4, .selectSession5,
+        .selectSession6, .selectSession7, .selectSession8, .selectSession9
+    ]
+
+    /// Which slot this action selects, nil for every other action.
+    public var sessionSlot: Int? {
+        Self.sessionSlots.firstIndex(of: self).map { $0 + 1 }
     }
 }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -327,7 +327,7 @@ public struct ControlDispatcher {
             return actions.selectSession(request.target, window: request.args?.window)
         case .sessionGo:
             guard let dir = (request.args?.to).flatMap(SessionNavigation.init(wire:)) else {
-                return ControlResponse(ok: false, error: "session.go requires --to next|prev|first|last|next-attention|prev-attention")
+                return ControlResponse(ok: false, error: "session.go requires --to next|prev|first|last|next-attention|prev-attention|1-9")
             }
             return actions.goSession(window: request.args?.window, direction: dir)
         case .sessionClose:

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -37,6 +37,13 @@ public struct Keymap: Equatable, Sendable {
         return builtinUnbound.contains(action) ? nil : action.defaultChord
     }
 
+    /// The session-slot built-in `chord` resolves to, nil when it is none of them. The slots ship a menu
+    /// chord like any other built-in — so the conflict model still guards ⌘1…⌘9 — but no menu item carries it,
+    /// which is why the key monitor looks the chord up here instead.
+    public func sessionSlotAction(forChord chord: Chord) -> BuiltinAction? {
+        BuiltinAction.sessionSlots.first { equivalent(for: $0) == chord }
+    }
+
     /// The monitor-bound binds for a built-in, empty when it has none.
     public func sequences(for action: BuiltinAction) -> [Keybind] {
         builtinSequences[action] ?? []
@@ -141,36 +148,13 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
 
     // a final pass, not incremental: the cross-section validation below needs the same resolved chord set.
     let resolved = resolveMapLines(mapLines)
-    // Cmd-Shift-D belonged to Dashboard before horizontal split existed. Any valid old configuration that
-    // explicitly used that chord keeps it: vacate the new action's default unless the file maps that action.
     var compatibilityUnbound = resolved.unbound
-    let horizontalMapped = resolved.overrides.contains { $0.action == .toggleHorizontalSplit }
-        || resolved.alternatives[.toggleHorizontalSplit] != nil
-        || resolved.unbound.contains(.toggleHorizontalSplit)
-    let oldDashboardChord = Chord(mods: [.command, .shift], key: "d")
-    let oldConfigUsesHorizontalChord = resolved.overrides.contains {
-        $0.action != .toggleHorizontalSplit && $0.chord == oldDashboardChord
-    } || resolved.alternatives.contains { action, entry in
-        action != .toggleHorizontalSplit && entry.alternatives.contains { $0.keybind.first == oldDashboardChord }
-    } || commandLines.contains { line in
-        line.alternatives.contains { $0.keybind.first == oldDashboardChord }
+    // Cmd-Shift-D belonged to Dashboard before horizontal split existed, Cmd-Shift-G and Cmd-1…9 were free
+    // before Dashboard and the session slots claimed them.
+    for action in [.toggleHorizontalSplit, .dashboard] + BuiltinAction.sessionSlots
+    where vacatesNewDefault(action, resolved: resolved, commandLines: commandLines) {
+        compatibilityUnbound.insert(action)
     }
-    if !horizontalMapped, oldConfigUsesHorizontalChord {
-        compatibilityUnbound.insert(.toggleHorizontalSplit)
-    }
-    // Cmd-Shift-G was previously free. An existing explicit binding on it keeps working; Dashboard becomes
-    // keyless until the user maps it, instead of a new shipped default invalidating their configuration.
-    let newDashboardChord = Chord(mods: [.command, .shift], key: "g")
-    let dashboardMapped = resolved.overrides.contains { $0.action == .dashboard }
-        || resolved.alternatives[.dashboard] != nil || resolved.unbound.contains(.dashboard)
-    let oldConfigUsesNewDashboardChord = resolved.overrides.contains {
-        $0.action != .dashboard && $0.chord == newDashboardChord
-    } || resolved.alternatives.contains { action, entry in
-        action != .dashboard && entry.alternatives.contains { $0.keybind.first == newDashboardChord }
-    } || commandLines.contains { line in
-        line.alternatives.contains { $0.keybind.first == newDashboardChord }
-    }
-    if !dashboardMapped, oldConfigUsesNewDashboardChord { compatibilityUnbound.insert(.dashboard) }
     let builtinOverrides = resolveBuiltinOverrides(resolved.overrides, unbound: compatibilityUnbound,
                                                    alternatives: resolved.alternatives, diagnostics: &diagnostics)
 
@@ -304,6 +288,26 @@ private struct ParsedOverride {
     let action: BuiltinAction
     let chord: Chord
     let line: Int
+}
+
+/// Whether `action`'s SHIPPED default has to step aside for an existing file. A default added after a keymap
+/// was written must not invalidate it, so an action that the file never maps gives its chord up to whatever
+/// the file already spells there — a `map` line, a `map` alternative, or a custom command's shortcut. Mapping
+/// the action itself, in any form, opts into the new chord.
+private func vacatesNewDefault(_ action: BuiltinAction,
+                               resolved: (overrides: [ParsedOverride],
+                                          alternatives: [BuiltinAction: MapLineAlternatives],
+                                          unbound: Set<BuiltinAction>),
+                               commandLines: [ParsedCommandLine]) -> Bool {
+    guard let chord = action.defaultChord else { return false }
+    let mapped = resolved.overrides.contains { $0.action == action }
+        || resolved.alternatives[action] != nil || resolved.unbound.contains(action)
+    guard !mapped else { return false }
+    return resolved.overrides.contains { $0.action != action && $0.chord == chord }
+        || resolved.alternatives.contains { owner, entry in
+            owner != action && entry.alternatives.contains { $0.keybind.first == chord }
+        }
+        || commandLines.contains { line in line.alternatives.contains { $0.keybind.first == chord } }
 }
 
 /// Fold the file-order `map` lines to one per action and split them by dispatch path. A `map` line declares

--- a/agtermCore/Sources/agtermCore/SessionNavigation.swift
+++ b/agtermCore/Sources/agtermCore/SessionNavigation.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+// The keyboard/control vocabulary for moving the selection. Pure value types with no store
+// dependency; `AppStore.navigateSession`/`navigateWorkspace` are what apply them.
+
+/// A step through the flattened session list for keyboard navigation. `next`/`previous` step one
+/// and wrap, `first`/`last` jump to a tree end, `nextAttention`/`previousAttention` step (wrapping) through
+/// only the sessions needing attention — status `blocked` or `completed`, and `slot` is the absolute
+/// browser-style ⌘1…⌘9 jump.
+public enum SessionNavigation: Sendable, Equatable {
+    case next, previous, first, last, nextAttention, previousAttention
+    case slot(Int)
+}
+
+extension SessionNavigation {
+    /// Maps a control-channel direction string to a case, nil for an unknown one. Both `prev` (the CLI's
+    /// spelling) and `previous` are accepted; `1`…`9` are the slots, the same vocabulary the chords carry.
+    public init?(wire: String) {
+        switch wire {
+        case "next": self = .next
+        case "prev", "previous": self = .previous
+        case "first": self = .first
+        case "last": self = .last
+        case "next-attention": self = .nextAttention
+        case "prev-attention", "previous-attention": self = .previousAttention
+        default:
+            guard let slot = Int(wire), SessionSlot.range.contains(slot) else { return nil }
+            self = .slot(slot)
+        }
+    }
+}
+
+/// The absolute session slots ⌘1…⌘9 select. The nine are a fixed vocabulary shared by
+/// `BuiltinAction.selectSession1`…`9` and `session.go --to 1`…`9`, so a chord and a control call mean one
+/// thing.
+public enum SessionSlot {
+    public static let range = 1...9
+
+    /// Which index of the flattened list `slot` names, nil when it names nothing. The LAST slot overflows to
+    /// the end of the list — with more sessions than slots there would otherwise be no keystroke reaching the
+    /// tail at all — but only then: with nine or fewer it stays the plain ninth, so a slot never means two
+    /// rows at one count. An out-of-range slot and one past the end both resolve to nil.
+    public static func index(_ slot: Int, count: Int) -> Int? {
+        guard range.contains(slot), count > 0 else { return nil }
+        if slot == range.upperBound, count > range.upperBound { return count - 1 }
+        return slot <= count ? slot - 1 : nil
+    }
+}
+
+/// A relative step through the visible workspace list. Only `next`/`previous`: a workspace carries no
+/// attention state, and wrapping already reaches both ends.
+public enum WorkspaceNavigation: Sendable { case next, previous }
+
+/// What one workspace step landed on. The indicator is the selected session's, captured BEFORE an
+/// `autoReset` status cleared, which is what lets the GUI route pane reveal exactly as session nav does
+/// (`AppActions.revealActiveBlockedPane`); nil for an empty workspace.
+public struct WorkspaceStep: Sendable {
+    public let workspaceID: UUID
+    public let indicator: AgentIndicator?
+}
+
+extension WorkspaceNavigation {
+    /// Maps a control-channel direction string to a case, nil for unknown. Both spellings of previous.
+    public init?(wire: String) {
+        switch wire {
+        case "next": self = .next
+        case "prev", "previous": self = .previous
+        default: return nil
+        }
+    }
+}

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -101,8 +101,8 @@ struct Session: ParsableCommand {
 
     struct Go: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "go",
-            abstract: "Navigate sessions: next|prev|first|last|next-attention|prev-attention.")
-        @Option(name: .long, help: "Direction: next, prev, first, last, next-attention, or prev-attention (attention = blocked/completed).") var to: String
+            abstract: "Navigate sessions: next|prev|first|last|next-attention|prev-attention|1-9.")
+        @Option(name: .long, help: "Direction: next, prev, first, last, next-attention, prev-attention (attention = blocked/completed), or a slot 1-9 (the ⌘1-⌘9 jumps).") var to: String
         @OptionGroup var options: ClientOptions
 
         func makeRequest() throws -> ControlRequest {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
@@ -135,6 +135,67 @@ struct AppStoreNavigationTests {
         #expect(SessionNavigation(wire: "prev-attention") == .previousAttention)
         #expect(SessionNavigation(wire: "previous-attention") == .previousAttention)
         #expect(SessionNavigation(wire: "sideways") == nil)
+        #expect(SessionNavigation(wire: "1") == .slot(1))
+        #expect(SessionNavigation(wire: "9") == .slot(9))
+        #expect(SessionNavigation(wire: "0") == nil)
+        #expect(SessionNavigation(wire: "10") == nil)
+        #expect(SessionNavigation(wire: "-1") == nil)
+    }
+
+    @Test func slotSelectsTheNthNavigableSession() {
+        let (store, ids) = Self.makeNavTree()
+        store.selectSession(ids[0])
+        store.navigateSession(.slot(3))
+        #expect(store.selectedSessionID == ids[2])
+        store.navigateSession(.slot(1))
+        #expect(store.selectedSessionID == ids[0])
+    }
+
+    @Test func slotBeyondTheListLeavesSelectionAlone() {
+        let (store, ids) = Self.makeNavTree()
+        store.selectSession(ids[1])
+        store.navigateSession(.slot(5))
+        #expect(store.selectedSessionID == ids[1])
+        store.navigateSession(.slot(9))
+        #expect(store.selectedSessionID == ids[1])
+    }
+
+    @Test func lastSlotOverflowsToTheEndOnlyPastNine() {
+        // with ten sessions ⌘9 is the only keystroke reaching the tail, so it means "last"; with exactly
+        // nine it stays the plain ninth, which is the same row anyway. Fewer than nine and it means nothing.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        var ids: [UUID] = []
+        for i in 1...9 { ids.append(store.addSession(toWorkspace: ws.id, cwd: "/s\(i)")!.id) }
+        store.selectSession(ids[0])
+        store.navigateSession(.slot(9))
+        #expect(store.selectedSessionID == ids[8])
+        ids.append(store.addSession(toWorkspace: ws.id, cwd: "/s10")!.id)
+        store.selectSession(ids[0])
+        store.navigateSession(.slot(9))
+        #expect(store.selectedSessionID == ids[9])
+    }
+
+    @Test func slotIndexTableIsTheWholeRule() {
+        #expect(SessionSlot.index(1, count: 0) == nil)
+        #expect(SessionSlot.index(1, count: 1) == 0)
+        #expect(SessionSlot.index(4, count: 3) == nil)
+        #expect(SessionSlot.index(3, count: 3) == 2)
+        #expect(SessionSlot.index(9, count: 9) == 8)
+        #expect(SessionSlot.index(9, count: 40) == 39)
+        #expect(SessionSlot.index(8, count: 40) == 7)
+        #expect(SessionSlot.index(0, count: 4) == nil)
+        #expect(SessionSlot.index(10, count: 40) == nil)
+    }
+
+    @Test func slotCountsTheFILTEREDListLikeEveryOtherStep() {
+        let (store, ids) = Self.makeNavTree()
+        store.selectSession(ids[2])
+        store.setFocusedWorkspace(store.workspaces[1].id) // personal: [c, d]
+        store.navigateSession(.slot(2))
+        #expect(store.selectedSessionID == ids[3])
+        store.navigateSession(.slot(3))
+        #expect(store.selectedSessionID == ids[3], "the hidden workspace's sessions hold no slot")
     }
 
     @Test func navigateAttentionStepsThroughAttentionSessionsOnly() {

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -33,7 +33,9 @@ struct BuiltinActionTests {
         #expect(BuiltinAction.previousWorkspace.rawValue == "previous_workspace")
         #expect(BuiltinAction.nextWorkspace.rawValue == "next_workspace")
         #expect(BuiltinAction.toggleWorkspaceCollapse.rawValue == "toggle_workspace_collapse")
-        #expect(BuiltinAction.allCases.count == 46)
+        #expect(BuiltinAction.selectSession1.rawValue == "select_session_1")
+        #expect(BuiltinAction.selectSession9.rawValue == "select_session_9")
+        #expect(BuiltinAction.allCases.count == 55)
     }
 
     @Test func rejectsUnknownName() {
@@ -123,6 +125,15 @@ struct BuiltinActionTests {
             .customCommandPalette: Chord(mods: [.control, .shift], key: "o"),
             .showAttention: Chord(mods: [.control, .shift], key: "i"),
             .dashboard: Chord(mods: [.command, .shift], key: "g"),
+            .selectSession1: Chord(mods: [.command], key: "1"),
+            .selectSession2: Chord(mods: [.command], key: "2"),
+            .selectSession3: Chord(mods: [.command], key: "3"),
+            .selectSession4: Chord(mods: [.command], key: "4"),
+            .selectSession5: Chord(mods: [.command], key: "5"),
+            .selectSession6: Chord(mods: [.command], key: "6"),
+            .selectSession7: Chord(mods: [.command], key: "7"),
+            .selectSession8: Chord(mods: [.command], key: "8"),
+            .selectSession9: Chord(mods: [.command], key: "9"),
         ]
         #expect(expected.count == BuiltinAction.allCases.count)
         for action in BuiltinAction.allCases {
@@ -185,5 +196,17 @@ struct BuiltinActionTests {
             #expect(action.defaultChord == nil, "expected nil default for \(action.rawValue)")
         }
         #expect(BuiltinAction.allCases.filter { $0.defaultChord == nil } == BuiltinAction.allCases.filter { keyless.contains($0) })
+    }
+
+    @Test func sessionSlotsCarryTheNineCommandDigitsInOrder() {
+        #expect(BuiltinAction.sessionSlots.map(\.sessionSlot) == Array(SessionSlot.range).map { Optional($0) })
+        for slot in SessionSlot.range {
+            let action = BuiltinAction.sessionSlots[slot - 1]
+            let chord = Chord(mods: [.command], key: String(slot))
+            #expect(action.rawValue == "select_session_\(slot)")
+            #expect(action.defaultChord == chord)
+            #expect(parseKeybind("cmd+\(slot)") == [chord])
+        }
+        #expect(BuiltinAction.allCases.filter { $0.sessionSlot != nil } == BuiltinAction.sessionSlots)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -343,6 +343,16 @@ struct ControlDispatcherTests {
         ])
     }
 
+    @Test func sessionGoRoutesASlotDigit() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let jumped = await dispatcher.dispatch(ControlRequest(cmd: .sessionGo, args: ControlArgs(to: "3")))
+
+        #expect(jumped == ControlResponse(ok: true))
+        #expect(actions.calls == [.sessionGo(window: nil, .slot(3))])
+    }
+
     @Test func sessionCloseRoutesBatchTargets() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -376,11 +386,11 @@ struct ControlDispatcherTests {
 
         #expect(missingDirection == ControlResponse(
             ok: false,
-            error: "session.go requires --to next|prev|first|last|next-attention|prev-attention"
+            error: "session.go requires --to next|prev|first|last|next-attention|prev-attention|1-9"
         ))
         #expect(badDirection == ControlResponse(
             ok: false,
-            error: "session.go requires --to next|prev|first|last|next-attention|prev-attention"
+            error: "session.go requires --to next|prev|first|last|next-attention|prev-attention|1-9"
         ))
         #expect(missingName == ControlResponse(ok: false, error: "session.rename requires a name"))
         #expect(actions.calls.isEmpty)

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -1282,6 +1282,39 @@ struct KeymapTests {
         #expect(keymap.equivalent(for: .dashboard) == nil)
     }
 
+    @Test func sessionSlotsShipTheirDefaultsAndResolveByChord() {
+        let keymap = parseKeymap("").keymap
+        for slot in SessionSlot.range {
+            let chord = Chord(mods: [.command], key: String(slot))
+            #expect(keymap.equivalent(for: BuiltinAction.sessionSlots[slot - 1]) == chord)
+            #expect(keymap.sessionSlotAction(forChord: chord) == BuiltinAction.sessionSlots[slot - 1])
+        }
+        #expect(keymap.sessionSlotAction(forChord: Chord(mods: [.command], key: "0")) == nil)
+    }
+
+    @Test func existingCmdDigitBindingsAreNotBrokenByTheSlotDefaults() {
+        let (keymap, diagnostics) = parseKeymap("""
+        map cmd+3 toggle_workspace_filter
+        command "Old binding" cmd+7 echo ok
+        """)
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.equivalent(for: .toggleWorkspaceFilter) == Chord(mods: [.command], key: "3"))
+        #expect(keymap.commands.first?.shortcut == "cmd+7")
+        #expect(keymap.equivalent(for: .selectSession3) == nil)
+        #expect(keymap.equivalent(for: .selectSession7) == nil)
+        #expect(keymap.builtinUnbound.isSuperset(of: [.selectSession3, .selectSession7]))
+        #expect(keymap.equivalent(for: .selectSession4) == Chord(mods: [.command], key: "4"),
+                "only the claimed slots step aside")
+        #expect(keymap.sessionSlotAction(forChord: Chord(mods: [.command], key: "3")) == nil)
+    }
+
+    @Test func mappingASlotItselfOptsIntoTheNewChord() {
+        let (keymap, diagnostics) = parseKeymap("map cmd+shift+2 select_session_2")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.equivalent(for: .selectSession2) == Chord(mods: [.command, .shift], key: "2"))
+        #expect(keymap.sessionSlotAction(forChord: Chord(mods: [.command, .shift], key: "2")) == .selectSession2)
+    }
+
     @Test func keymapStoreLoadsFileAndRecoversWhenMissing() throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-keymap-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -271,6 +271,15 @@ struct SocketClientTests {
             next_attention_session      ctrl+opt+down
             first_session               -
             last_session                -
+            select_session_1            cmd+1
+            select_session_2            cmd+2
+            select_session_3            cmd+3
+            select_session_4            cmd+4
+            select_session_5            cmd+5
+            select_session_6            cmd+6
+            select_session_7            cmd+7
+            select_session_8            cmd+8
+            select_session_9            cmd+9
             quick_terminal              ctrl+`
             session_palette             ctrl+p
             command_palette             ctrl+shift+p

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -998,8 +998,34 @@ final class ControlAPIUITests: ControlAPITestCase {
     func testSessionGoInvalidDirectionErrors() throws {
         let response = try sendCommand(#"{"cmd":"session.go","args":{"to":"sideways"}}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "an invalid direction should fail: \(response)")
-        XCTAssertEqual(response["error"] as? String, "session.go requires --to next|prev|first|last|next-attention|prev-attention",
+        XCTAssertEqual(response["error"] as? String,
+                       "session.go requires --to next|prev|first|last|next-attention|prev-attention|1-9",
                        "should return the direction guard: \(response)")
+    }
+
+    // session.go --to <digit> is the absolute ⌘1…⌘9 jump: slot 2 selects the second session, and a slot the
+    // tree cannot fill leaves the selection where it was.
+    func testSessionGoJumpsToASlot() throws {
+        let firstID = UUID(uuidString: "EEEE0000-0000-0000-0000-000000000011")!
+        let secondID = UUID(uuidString: "FFFF0000-0000-0000-0000-000000000012")!
+        let snapshot = """
+        {"version":1,"selectedSessionID":"\(firstID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(firstID.uuidString)","customName":null,"cwd":"\(NSHomeDirectory())"},\
+        {"id":"\(secondID.uuidString)","customName":null,"cwd":"\(NSHomeDirectory())"}]}]}
+        """
+        try relaunch(withSnapshot: snapshot)
+
+        let second = try sendCommand(#"{"cmd":"session.go","args":{"to":"2"}}"#)
+        XCTAssertEqual(second["ok"] as? Bool, true, "session.go 2 should succeed: \(second)")
+        XCTAssertEqual(((second["result"] as? [String: Any])?["id"] as? String)?.lowercased(),
+                       secondID.uuidString.lowercased(), "slot 2 should select the second session: \(second)")
+        XCTAssertTrue(pollActiveSessionID(secondID, timeout: 10), "the second session should become active")
+
+        let empty = try sendCommand(#"{"cmd":"session.go","args":{"to":"7"}}"#)
+        XCTAssertEqual(empty["ok"] as? Bool, true, "an unfilled slot still answers ok: \(empty)")
+        XCTAssertEqual(((empty["result"] as? [String: Any])?["id"] as? String)?.lowercased(),
+                       secondID.uuidString.lowercased(), "an unfilled slot must not move the selection: \(empty)")
     }
 
     // session.go next-attention/prev-attention steps only through sessions needing attention (blocked or

--- a/agtermUITests/SessionNavUITests.swift
+++ b/agtermUITests/SessionNavUITests.swift
@@ -1,8 +1,8 @@
 import XCTest
 
 /// End-to-end test for keyboard navigation between sessions (⌥⌘↑ previous, ⌥⌘↓ next — ⌥⌘ avoids the
-/// text-field caret shadowing bare ⌘+arrows would cause; First/Last have no hotkey, covered by the
-/// agtermCore unit tests). Sessions are Metal `GhosttySurfaceView`s with no readable accessibility
+/// text-field caret shadowing bare ⌘+arrows would cause; ⌘1…⌘9 jump to a slot; First/Last have no hotkey,
+/// covered by the agtermCore unit tests). Sessions are Metal `GhosttySurfaceView`s with no readable accessibility
 /// text, so this uses the terminal itself as the oracle: each session's shell has a distinct `tty`,
 /// so typing `tty > file` in the focused session records which shell received the keystrokes. That
 /// proves keyboard focus follows the selection as prev/next step between sessions.
@@ -63,6 +63,15 @@ final class SessionNavUITests: XCTestCase {
         app.typeKey(.downArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         XCTAssertEqual(ttyAfterCommand(named: "next"), secondTTY, "Opt+Cmd+Down selects the next session")
+
+        // the slots carry no menu item, so this is the only place their monitor dispatch runs end to end.
+        app.typeKey("1", modifierFlags: [.command])
+        usleep(500_000)
+        XCTAssertEqual(ttyAfterCommand(named: "slot-one"), firstTTY, "Cmd+1 selects the first session")
+
+        app.typeKey("2", modifierFlags: [.command])
+        usleep(500_000)
+        XCTAssertEqual(ttyAfterCommand(named: "slot-two"), secondTTY, "Cmd+2 selects the second session")
     }
 
     /// Polls until a query resolves to `expected` matching elements.

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -275,7 +275,8 @@ omitted when expanded).
 - `close [--target T ...]` — close one session, or repeat `--target` to close a batch with one
   grace-period undo.
 - `select` · `rename <name>` · `reveal` (select the focused pane's cwd in Finder).
-- `go --to next|prev|first|last|next-attention|prev-attention` — move the selection between sessions.
+- `go --to next|prev|first|last|next-attention|prev-attention|1-9` — move the selection between sessions;
+  a digit is the absolute ⌘1-⌘9 jump to the Nth visible session (9 = last when there are more than nine).
 - `move <workspace>` (relocate) or `move --to up|down|top|bottom` (reorder within the workspace) or
   `move --after SID | --before SID` (place after/before an anchor session; the anchor carries its own
   workspace, so this relocates + positions in one shot, even cross-workspace). For workspace and

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -375,12 +375,14 @@ buys nothing. A caller with no tree uses `version`.
 - `session rename <name> [--target] [--window W]`.
 - `session reveal [--target] [--window W]` — select the target session's focused-pane working
   directory in Finder. Errors when that directory no longer exists.
-- `session go --to next|prev|first|last|next-attention|prev-attention [--window W]` — move the
+- `session go --to next|prev|first|last|next-attention|prev-attention|1-9 [--window W]` — move the
   selection relative to the CURRENT one (no `--target`). Operates over the VISIBLE/FILTERED set: the
   flagged sessions in flagged mode, the marked workspaces' sessions while the focus filter is applied,
   else all sessions (clearing the flag / suspending the filter restores the full set). next/prev wrap around at the ends (last→first,
   first→last); first/last jump to the ends of that set; next-attention/prev-attention step only through the filtered
-  sessions needing attention (status blocked/completed), wrapping. Returns the newly selected id.
+  sessions needing attention (status blocked/completed), wrapping. A digit 1-9 is the absolute jump the
+  ⌘1-⌘9 chords make: the Nth session of that same set, nothing when it holds fewer, and 9 means the LAST
+  session once there are more than nine. Returns the newly selected id.
 - `session move <workspace> [--target] [--window W]` — relocate the session to another workspace
   (appends). OR `session move --to up|down|top|bottom [--target]` — reorder within its workspace. OR
   `session move --after SID | --before SID [--target]` — place the session directly after / before an
@@ -512,7 +514,7 @@ error keeps those names for compatibility.
   no longer wiped by foreground typing in the main pane, and only a keystroke in the OWNING pane clears
   it), and (2) when the status needs attention (`blocked`/`completed`), any user-initiated GUI selection of
   the session lands on the tagged pane — auto-follow,
-  the attention-nav (⌃⌥↑/⌃⌥↓, the Navigate menu), plain session nav (⌥⌘↑/↓/first/last),
+  the attention-nav (⌃⌥↑/⌃⌥↓, the Navigate menu), plain session nav (⌥⌘↑/↓/first/last, the ⌘1-⌘9 slots),
   the command palettes, a sidebar row click, and a Dock-menu session row all reveal and focus it, flipping to the split or
   showing a hidden scratch instead of the main pane. An `active` status keeps the existing pane selection.
   (The socket `session go next-attention|prev-attention`
@@ -1127,7 +1129,7 @@ Built-in action names for `map` include: `new_window`, `new_workspace`, `new_ses
 `decrease_font_size`, `reset_font_size`, `toggle_split`, `toggle_horizontal_split`, `toggle_scratch`, `toggle_sidebar`,
 `focus_workspace`, `toggle_workspace_filter`, `quick_terminal`,
 `session_palette`, `command_palette`, `custom_command_palette`, `dashboard`, and the navigation actions (`previous_session`, `next_session`,
-`first_session`, `last_session`, `previous_attention_session`, `next_attention_session`,
+`first_session`, `last_session`, `select_session_1`…`select_session_9`, `previous_attention_session`, `next_attention_session`,
 `focus_left_pane`, `focus_right_pane`, `select_theme`). Editing the keymap from a terminal: open
 `keymap.conf` in `$EDITOR`, then `agtermctl keymap reload`.
 

--- a/site/commands.html
+++ b/site/commands.html
@@ -990,7 +990,7 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session go --to next|prev|first|last|next-attention|prev-attention [--window W]
+                agtermctl session go --to next|prev|first|last|next-attention|prev-attention|1-9 [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.go</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
@@ -1004,6 +1004,9 @@
                 needing attention (status
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">blocked</span> or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">completed</span>), also wrapping.
+                A digit <span style="font-family: &quot;JetBrains Mono&quot;, monospace">1</span>-<span style="font-family: &quot;JetBrains Mono&quot;, monospace">9</span> is the absolute jump the
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">⌘1</span>-<span style="font-family: &quot;JetBrains Mono&quot;, monospace">⌘9</span> chords make: the Nth session of that same set, and
+                nothing when it holds fewer. <span style="font-family: &quot;JetBrains Mono&quot;, monospace">9</span> means the LAST session once there are more than nine.
                 <strong style="color: #bfbab0">Returns</strong> the newly selected
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
               </p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1254,6 +1254,26 @@
                     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
                   "
                 >
+                  ⌘1…⌘9
+                </div>
+                <div
+                  style="
+                    padding: 12px 16px;
+                    background: #22272b;
+                    color: #cbc6bc;
+                    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+                  "
+                >
+                  Jump to the 1st–9th session in the sidebar; with more than nine, ⌘9 is the last one
+                </div>
+                <div
+                  style="
+                    padding: 12px 16px;
+                    background: #15191c;
+                    color: #6d82f3;
+                    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+                  "
+                >
                   ⌃⌥↑↓
                 </div>
                 <div
@@ -1653,7 +1673,7 @@
                 color: #cbc6bc;
               "
             >
-              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />toggle_workspace_collapse<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_workspace&nbsp;&nbsp;&nbsp;next_workspace<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
+              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />toggle_workspace_collapse<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />select_session_1&nbsp;&hellip;&nbsp;select_session_9<br />previous_workspace&nbsp;&nbsp;&nbsp;next_workspace<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
             </div>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> is the one


### PR DESCRIPTION
⌘1–⌘8 select the 1st–8th session in the sidebar's flattened order; ⌘9 selects the 9th, or the **last** session once there are more than nine. A slot naming no session leaves the selection alone.

Numbering is global across workspaces and uses the same `navigableSessions` scope as ⌥⌘↑/↓, so flagged mode and the focus filter confine the slots identically. Landing behavior is the arrow path (`navigatePlain(.slot(n))`).

### Surfaces

- Nine rebindable built-ins `select_session_1`…`select_session_9`, default ⌘1…⌘9.
- No menu item and no palette row — the fuzzy session palette is the by-name surface. Chords are matched by `CustomCommandRunner` like `toggle_fullscreen`'s and run by `paletteLessHandler`; conflict model and `uiActionsEnabled` gate unchanged.
- `agtermctl session go --to 1`…`9`.

### Notes

- Existing keymaps are safe: a file already binding ⌘3 keeps it and `select_session_3` stays keyless. The two ad-hoc ⌘⇧D/⌘⇧G compatibility blocks became one `vacatesNewDefault` helper the slots share.
- `SessionSlot.index` owns the overflow rule: slot 9 means "last" only past nine sessions.
- `AppStore.swift` was at the 1000-line limit, so the navigation vocabulary types moved unchanged into `SessionNavigation.swift`.
- Docs updated: `site/docs.html`, `site/commands.html`, the bundled skill, and the `keymap` / `menu-actions` / `control-api` rules.

### Testing

- `swift test` — 2632 pass. `make lint` clean, `make build` succeeds.
- `make test-app` — passes except `AgentHooksInstallerTests.testAlertWithoutDocsKeepsTheSingleDefaultButton`, which fails on master too (Xcode 26.3 `NSAlert` reports no buttons when none were added).
- XCUITest **not yet run**: `SessionNavUITests/testSessionNavigationFollowsFocus` and `ControlAPIUITests/testSessionGoJumpsToASlot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
