### PR TITLE
fix: export split-pane working directory to AGT_SESSION_PWD

### DIFF
--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -309,7 +309,7 @@ final class CustomCommandRunner {
         return CommandContext(
             sessionID: session.id.uuidString,
             sessionName: session.displayName,
-            sessionPWD: session.effectiveCwd,
+            sessionPWD: session.cwd(for: pane),
             workspaceID: workspace?.id.uuidString ?? "",
             workspaceName: workspace?.name ?? "",
             windowID: windowID?.uuidString ?? "",

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -424,6 +424,16 @@ public final class Session: Identifiable {
     /// `AGTERM_SESSION_PWD`, which must stay stable regardless of focus.
     public var effectiveCwd: String { currentCwd ?? initialCwd }
 
+    /// The working directory for a given pane role: the split pane's while targeting `.right`, else the primary's.
+    public func cwd(for pane: CommandContext.Pane) -> String {
+        switch pane {
+        case .right:
+            return splitCwd ?? initialSplitCwd ?? effectiveCwd
+        case .left, .scratch:
+            return effectiveCwd
+        }
+    }
+
     /// The focused pane's surface: the split (right) while it has focus and exists, else the primary. With the
     /// split hidden the detail pane maximizes this one and focus helpers target it, so typing always reaches
     /// the visible pane.

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -241,6 +241,22 @@ struct SessionTests {
         #expect(session.effectiveCwd == "/repo/primary")
     }
 
+    @Test func cwdForPaneResolvesPaneSpecificDirectory() {
+        let session = Session(initialCwd: "/repo")
+        session.currentCwd = "/repo/primary"
+        session.splitCwd = "/var/log"
+        #expect(session.cwd(for: .left) == "/repo/primary")
+        #expect(session.cwd(for: .scratch) == "/repo/primary")
+        #expect(session.cwd(for: .right) == "/var/log")
+
+        session.splitCwd = nil
+        session.initialSplitCwd = "/var/restored"
+        #expect(session.cwd(for: .right) == "/var/restored")
+
+        session.initialSplitCwd = nil
+        #expect(session.cwd(for: .right) == "/repo/primary")
+    }
+
     @Test func agentIndicatorDefaultsToIdle() {
         let session = Session(initialCwd: "/repo")
         #expect(session.agentIndicator == AgentIndicator())

--- a/agtermTests/CustomCommandRunnerTests.swift
+++ b/agtermTests/CustomCommandRunnerTests.swift
@@ -362,6 +362,7 @@ final class CustomCommandRunnerTests: XCTestCase {
         let owner = try XCTUnwrap(fix.store.currentWorkspaceID)
         let session = try XCTUnwrap(fix.store.addSession(toWorkspace: owner, cwd: "/tmp/left-cwd"))
         let split = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        split.session = session
         session.splitSurface = split
         session.splitCwd = "/tmp/right-cwd"
         session.hasSplit = true

--- a/agtermTests/CustomCommandRunnerTests.swift
+++ b/agtermTests/CustomCommandRunnerTests.swift
@@ -359,17 +359,22 @@ final class CustomCommandRunnerTests: XCTestCase {
 
     func testAChordFiredInSplitPaneResolvesSplitPaneWorkingDirectory() throws {
         let fix = try fixture()
+        let leftDir = stateDir.appendingPathComponent("left-cwd")
+        let rightDir = stateDir.appendingPathComponent("right-cwd")
+        try FileManager.default.createDirectory(at: leftDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: rightDir, withIntermediateDirectories: true)
+
         let owner = try XCTUnwrap(fix.store.currentWorkspaceID)
-        let session = try XCTUnwrap(fix.store.addSession(toWorkspace: owner, cwd: "/tmp/left-cwd"))
+        let session = try XCTUnwrap(fix.store.addSession(toWorkspace: owner, cwd: leftDir.path))
         let split = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
         split.session = session
         session.splitSurface = split
-        session.splitCwd = "/tmp/right-cwd"
+        session.splitCwd = rightDir.path
         session.hasSplit = true
         session.isSplit = true
         session.splitFocused = true
 
         let written = try fired(fix.runner, from: split, writing: "\"$AGT_SESSION_PWD\"")
-        XCTAssertEqual(written, "/tmp/right-cwd")
+        XCTAssertEqual(written, rightDir.path)
     }
 }

--- a/agtermTests/CustomCommandRunnerTests.swift
+++ b/agtermTests/CustomCommandRunnerTests.swift
@@ -356,4 +356,19 @@ final class CustomCommandRunnerTests: XCTestCase {
 
         XCTAssertEqual(written, "left \(session.id.uuidString)")
     }
+
+    func testAChordFiredInSplitPaneResolvesSplitPaneWorkingDirectory() throws {
+        let fix = try fixture()
+        let owner = try XCTUnwrap(fix.store.currentWorkspaceID)
+        let session = try XCTUnwrap(fix.store.addSession(toWorkspace: owner, cwd: "/tmp/left-cwd"))
+        let split = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        session.splitSurface = split
+        session.splitCwd = "/tmp/right-cwd"
+        session.hasSplit = true
+        session.isSplit = true
+        session.splitFocused = true
+
+        let written = try fired(fix.runner, from: split, writing: "\"$AGT_SESSION_PWD\"")
+        XCTAssertEqual(written, "/tmp/right-cwd")
+    }
 }


### PR DESCRIPTION
### Problem
When a custom command or key chord is triggered from the right split pane (or from the palette while the right pane is focused), `$AGT_SESSION_PWD` (and the child process `$PWD`) resolves to the primary (left) pane's working directory instead of the active split pane's directory.

### Cause
In `agterm/Commands/CustomCommandRunner.swift`, `context(for:in:selectionSurface:pane:)` builds `CommandContext` using `session.effectiveCwd`, which is hardcoded to the primary pane (`currentCwd ?? initialCwd`).

### Solution
- Added `session.cwd(for: pane)` in `Session.swift` to resolve `splitCwd ?? initialSplitCwd ?? effectiveCwd` when targeting `.right`, and `effectiveCwd` otherwise.
- Updated `CustomCommandRunner.context` to pass `session.cwd(for: pane)`.
- Added test coverage in `SessionTests` and `CustomCommandRunnerTests`.