### PR TITLE
docs: own the Settings-managed ghostty key list in one place

### DIFF
--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -570,7 +570,7 @@ final class GhosttyApp {
             scopedPath.withCString { ghostty_config_load_file(cfg, $0) }
         }
 
-        // agterm's own appearance settings (font/size/theme), loaded last so the UI-managed keys win.
+        // agterm's own settings conf, loaded last so every key `ghosttyConfigLines()` emits wins.
         let settingsConf = Self.settingsConfigURL.path
         if FileManager.default.fileExists(atPath: settingsConf) {
             settingsConf.withCString { ghostty_config_load_file(cfg, $0) }

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -565,8 +565,8 @@ final class SettingsModel {
         # Example — make the macOS Option key send Alt (uncomment to enable):
         # macos-option-as-alt = true
         #
-        # NOTE: agterm's UI-managed keys (font, theme, background opacity/blur, scroll speed) are set
-        # in Settings and always win over this file — set those in Settings, everything else here.
+        # NOTE: Values agterm emits from Settings load after this file and win. See the current list at
+        # https://agterm.com/docs#ghostty; put other keys here.
         #
         # NOT SUPPORTED: the `ssh-env` and `ssh-terminfo` shell-integration features. They work by
         # wrapping `ssh` as a call to the `ghostty` CLI absent from agterm's bundle,

--- a/agtermTests/CustomCommandRunnerTests.swift
+++ b/agtermTests/CustomCommandRunnerTests.swift
@@ -272,7 +272,8 @@ final class CustomCommandRunnerTests: XCTestCase {
         let deadline = Date().addingTimeInterval(5)
         while Date() < deadline {
             RunLoop.current.run(until: Date().addingTimeInterval(0.01))
-            if let written = try? String(contentsOf: probe, encoding: .utf8) { return written }
+            // sh truncates the redirect target before printf writes; poll past that zero-byte window.
+            if let written = try? String(contentsOf: probe, encoding: .utf8), !written.isEmpty { return written }
         }
         return nil
     }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,7 @@ Reload after every edit (File ▸ Reload Keymap, or `agtermctl keymap reload`). 
 
 ## Changing ghostty settings
 
-Most terminal behavior comes from ghostty. The common knobs (font, theme, background opacity and blur, scroll speed) are in agterm's Settings, but any other ghostty key (`macos-option-as-alt`, `keybind`, `window-padding-*`, and so on) is set in a config file.
+Most terminal behavior comes from ghostty. Use agterm's Settings for its built-in controls and a config file for other ghostty keys such as `macos-option-as-alt`, `keybind`, and `window-padding-*`.
 
 agterm reads four config sources, each overriding the one before it:
 
@@ -90,7 +90,7 @@ ghostty's bundled defaults  →  ~/.config/ghostty/config  →  <config dir>/gho
 
 - `<config dir>/ghostty.conf` (default `~/.config/agterm/ghostty.conf`, next to `keymap.conf`) is scoped to agterm only; the standalone Ghostty.app never reads it. Use it for keys you want in agterm but not everywhere.
 - `~/.config/ghostty/config` is your global ghostty config, shared with Ghostty.app, and already in the chain.
-- The keys agterm sets from its Settings window load last, so the Settings picker wins for what it manages. Put everything else in `ghostty.conf`.
+- Values agterm emits from Settings load last and win over matching values in `ghostty.conf`. The [Ghostty config guide](https://agterm.com/docs#ghostty) lists the keys. Put everything else in `ghostty.conf`.
 
 Edit `ghostty.conf` with **File ▸ Edit ghostty.conf…** (or the ⌃⇧P palette), which opens it in `$EDITOR` and reloads on exit, the same as Edit Keymap. After editing it elsewhere, apply it with **File ▸ Reload Config**, the action palette, or `agtermctl config reload`. A malformed line is skipped while the good ones still apply. The diagnostic count (shown in a banner and printed by `config.reload`, where `0` means a clean reload) covers every ghostty config source, not just `ghostty.conf`, because the diagnostics do not record which file they came from. Check the Console log for the offending line.
 

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -957,8 +957,8 @@ agtermctl config reload                 # apply it; prints the diagnostic count 
 ```
 
 `ghostty.conf` is scoped to agterm and overrides the bundled defaults and your global
-`~/.config/ghostty/config`; agterm's own Settings (font, theme, opacity, scroll) still win. Full key
-reference: https://ghostty.org/docs/config
+`~/.config/ghostty/config`; the values agterm emits from Settings load last and win over matching values
+there. Current list: https://agterm.com/docs#ghostty. Full key reference: https://ghostty.org/docs/config
 
 ## Set the terminal theme
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1146,8 +1146,9 @@ as the GUI's File ▸ Reload Config menu/palette item, which posts a warning ban
 ghostty config and the place to put agterm overrides/customizations. It is ALWAYS loaded. The app builds
 its terminal config in order, each source overriding the one before: ghostty's bundled defaults, then
 your global `~/.config/ghostty/config` (OFF by default — opt in with Settings ▸ General ▸ Use my global
-Ghostty config), then `<config dir>/ghostty.conf`, then agterm's own Settings (font, theme, background
-opacity/blur, scroll speed), which load last and win for the keys the UI manages. The scoped file is
+Ghostty config), then `<config dir>/ghostty.conf`, then the values agterm emits from Settings, which
+load last and win over matching values in `ghostty.conf`. The current list of those keys is at
+https://agterm.com/docs#ghostty. The scoped file is
 agterm-only; the standalone Ghostty.app never reads it. agterm is self-contained by default, so a config
 written for Ghostty.app does not silently change agterm — put agterm overrides in `ghostty.conf` (e.g.
 `macos-option-as-alt = true`); the full reference is at https://ghostty.org/docs/config. Editing it from

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -26,8 +26,9 @@ You are inside agterm (`AGTERM_ENABLED=1`). Use:
   record which file a diagnostic came from), so check the Console log for the offending line. `ghostty.conf`
   (next to `keymap.conf`, always loaded) is where agterm customizations go; it overrides the bundled
   defaults, and the global `~/.config/ghostty/config` is NOT loaded unless Settings ▸ General ▸ Use my
-  global Ghostty config is on. agterm's Settings (font/theme/opacity/scroll) still win. Use it for keys the UI does not expose, e.g.
-  `macos-option-as-alt`. Most keys apply to open panes on reload, but layout keys (`window-padding-*`)
+  global Ghostty config is on. Values agterm emits from Settings load last and win over matching values
+  here; the current list is at https://agterm.com/docs#ghostty. Use it for keys the UI does not expose,
+  e.g. `macos-option-as-alt`. Most keys apply to open panes on reload, but layout keys (`window-padding-*`)
   and spawn-time keys (`term`, `shell-integration-features`) only take effect in a new session/window
   or after a relaunch. Full reference: https://ghostty.org/docs/config. Two values in it do NOT apply:
   `ssh-env` and `ssh-terminfo` for `shell-integration-features`. Ghostty implements them by replacing

--- a/site/docs.html
+++ b/site/docs.html
@@ -2508,8 +2508,15 @@
               >) is the place to customize agterm. It sits next to
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">keymap.conf</span> and gets the same
               treatment: a fully commented starter file is written on first launch, so a fresh one changes nothing. It is always loaded,
-              and is scoped to agterm so the standalone Ghostty.app never reads it. Put any ghostty config key there — the keys
-              agterm manages from Settings (font, theme, opacity, blur, scroll speed) still win. A common use:
+              and is scoped to agterm so the standalone Ghostty.app never reads it. Put any ghostty config key there. Values agterm emits
+              from Settings use <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">font-family</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">font-size</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">theme</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">background-opacity</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">background-blur</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">mouse-scroll-multiplier</span>, and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">right-click-action</span>. They load last,
+              so they win over matching values in this file. The last two are emitted even when their controls use the defaults. A common use:
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">macos-option-as-alt = true</span>. The
               full key reference is at <a href="https://ghostty.org/docs/config" style="color: #6d82f3">ghostty.org/docs/config</a>.
               Two values in it do not apply here:


### PR DESCRIPTION
seven places told the user which ghostty keys agterm's Settings manages, and therefore which ones win over a hand-written `ghostty.conf`. All seven were wrong the same way: they omitted `right-click-action`, which `ghosttyConfigLines()` emits unconditionally and which does win.

rather than correct seven copies of one list, `site/docs.html` now owns it, and names the actual keys instead of UI categories: `font-family`, `font-size`, `theme`, `background-opacity`, `background-blur`, `mouse-scroll-multiplier` and `right-click-action`, with a note that the last two go out even when their controls sit at the defaults. The other six state the precedence rule and link there.

those six are the seeded `ghostty.conf` starter text, `docs/troubleshooting.md`, the three copies inside the bundled skill (`reference.md`, `troubleshooting.md`, `examples.md`), and a code comment at the emission site in `GhosttyApp.swift`.

the starter text only reaches new installs, since `ensureStarterGhosttyConfig` returns early when the file already exists. For anyone already running agterm, the site, the troubleshooting guide and the bundled skill are the surfaces that carry the correction.

**the second commit is separate from the docs.** `CustomCommandRunnerTests.fired()` could read its probe during the zero-byte window between shell redirection and printf. It now waits for non-empty content, and a genuinely empty result still times out and fails. The test that exposed it calls `fired()` three times where its siblings call it once, which is why it failed the suite while passing in isolation.

validated with `make lint`, a Debug build, 2,623 host-free tests in 99 suites, and 252 hosted AppKit tests.
