### PR TITLE
feat: add cursor shape and blink to Appearance settings

### DIFF
--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -204,6 +204,11 @@ final class SettingsModel {
     func setMouseScrollMultiplier(_ value: Double?) { settings.mouseScrollMultiplier = value; persistAndApply() }
     // ghostty key (right-click-action): persistAndApply() rewrites the conf and reloads surfaces live.
     func setRightClickPaste(_ value: Bool?) { settings.rightClickPaste = value; persistAndApply() }
+    // ghostty keys (cursor-style / cursor-style-blink). A reload re-applies both to the panes already
+    // open, though only while a pane's cursor still follows the configured default: a program that set its
+    // own shape with DECSCUSR keeps that until it resets.
+    func setCursorStyle(_ value: AppSettings.CursorStyle?) { settings.cursorStyle = value?.rawValue; persistAndApply() }
+    func setCursorBlink(_ value: Bool?) { settings.cursorBlink = value; persistAndApply() }
     // sidebar behavior, not a ghostty key; the Coordinator reads the mirror on the next click.
     func setWorkspaceRowClickExpands(_ value: Bool?) { settings.workspaceRowClickExpands = value; persistAndApply() }
     func setInactivePaneMuteStrength(_ value: Int?) { settings.inactivePaneMuteStrength = value; persistAndApply() }

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "SettingsView")
 
 /// The Settings window (Cmd+,): six tabs — General (mouse, sessions, ghostty config), Appearance
-/// (font/theme + window translucency + mute), Interface (per-element title-bar and sidebar chrome
+/// (font/theme/cursor + window translucency + mute), Interface (per-element title-bar and sidebar chrome
 /// visibility), Notifications (banner / badge / attention toggles), Agent Status (sidebar glyph colors and
 /// shapes + blocked sound + auto-follow), and Key Mapping (config directory + keymap diagnostics + Reload).
 /// Throughout, a control's binding maps its DEFAULT value back to nil so `settings.json` stays minimal.
@@ -200,7 +200,7 @@ private struct GeneralSettingsView: View {
     }
 }
 
-/// Appearance tab: Terminal (font family, size, theme) and Window (toolbar mode, background opacity + blur,
+/// Appearance tab: Terminal (font family, size, cursor, theme) and Window (toolbar mode, background opacity + blur,
 /// sidebar tint + font size, pane/backdrop mute), each persisting and live-applying via `SettingsModel`.
 private struct AppearanceSettingsView: View {
     let model: SettingsModel
@@ -221,6 +221,26 @@ private struct AppearanceSettingsView: View {
                     Text("Default font size: \(Int(model.settings.fontSize ?? 13))")
                 }
                 .accessibilityIdentifier("settings-font-size")
+
+                // "From config" is a state, not a synonym for Block: it emits no `cursor-style`, so the
+                // config chain still picks the shape, where Block writes an override that beats it.
+                Picker("Cursor", selection: cursorStyle) {
+                    Text("From config").tag(AppSettings.CursorStyle?.none)
+                    Text("Block").tag(AppSettings.CursorStyle?.some(.block))
+                    Text("Bar").tag(AppSettings.CursorStyle?.some(.bar))
+                    Text("Underline").tag(AppSettings.CursorStyle?.some(.underline))
+                }
+                .accessibilityIdentifier("settings-cursor-style")
+                SettingHint("A picked shape overrides cursor-style in ghostty.conf; From config leaves it in charge.")
+
+                // three rows, not a toggle: Program controlled emits nothing, which is the only state that
+                // leaves DEC mode 12 able to drive the blink.
+                Picker("Cursor blink", selection: cursorBlink) {
+                    Text("Program controlled").tag(Bool?.none)
+                    Text("Blink by default").tag(Bool?.some(true))
+                    Text("Steady by default").tag(Bool?.some(false))
+                }
+                .accessibilityIdentifier("settings-cursor-blink")
 
                 // the CURRENT appearance's theme; while following, the on-screen side. The "default ghostty"
                 // row shows only when NOT following — a dual conditional needs two named themes.
@@ -317,6 +337,17 @@ private struct AppearanceSettingsView: View {
 
     private var fontSize: Binding<Double> {
         Binding(get: { model.settings.fontSize ?? 13 }, set: { model.setFontSize($0) })
+    }
+
+    /// nil is the From config row; a shape this version does not offer (a future one, or a hand-written
+    /// `block_hollow`) resolves to nil too, so the picker shows From config rather than a blank selection.
+    private var cursorStyle: Binding<AppSettings.CursorStyle?> {
+        Binding(get: { model.settings.effectiveCursorStyle }, set: { model.setCursorStyle($0) })
+    }
+
+    /// Passed through as ghostty's own three states; nil is Program controlled (see `AppSettings.cursorBlink`).
+    private var cursorBlink: Binding<Bool?> {
+        Binding(get: { model.settings.cursorBlink }, set: { model.setCursorBlink($0) })
     }
 
     /// The sidebar row-text size.

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -97,6 +97,19 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case custom
     }
 
+    /// The terminal cursor shape, carrying ghostty's own `cursor-style` values as raw names. There is no
+    /// case for nil, which is a state of its own: it emits nothing, leaving whatever `cursor-style` the
+    /// config chain resolves — agterm's bundled block, or the user's own `ghostty.conf` — in charge.
+    ///
+    /// ghostty's `block_hollow` is deliberately absent. An unfocused surface is already marked by drawing
+    /// its cursor hollow, so a hollow block chosen as the RESTING shape makes focused and unfocused panes
+    /// identical and costs that signal. It stays reachable from `ghostty.conf` for anyone who wants it.
+    public enum CursorStyle: String, CaseIterable, Sendable {
+        case block
+        case bar
+        case underline
+    }
+
     /// The user-idle timeout after which the window's selection auto-follows to the oldest blocked
     /// session. `off` is both the default and the nil case, so picking it clears the stored field.
     public enum AutoFollowAttention: String, CaseIterable, Sendable {
@@ -163,6 +176,16 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var darkTheme: String?
     /// Whether the terminal follows the macOS Light/Dark appearance; nil/false = off, emitting one `theme`.
     public var followSystemAppearance: Bool?
+    /// The cursor shape, a `CursorStyle` raw value resolved by `effectiveCursorStyle`; nil emits nothing
+    /// and leaves the config chain deciding. A picked shape wins over a `cursor-style` in the user's own
+    /// `ghostty.conf`, because the settings conf loads last — that IS the difference between nil and an
+    /// explicit `.block`, which otherwise render the same cursor.
+    public var cursorStyle: String?
+    /// Whether the cursor blinks, mirroring ghostty's own `?bool` for the key: nil emits nothing and is a
+    /// third state rather than "off" — the cursor blinks AND DEC mode 12 can still change it. Either
+    /// explicit value takes DEC mode 12 away (`DECSCUSR` still wins over both), so all three are named in
+    /// the picker instead of collapsing to a toggle that could not say "always blink".
+    public var cursorBlink: Bool?
     /// Window background opacity in 0...1, nil = opaque. Composited at the AppKit window level, NOT by the
     /// ghostty renderer, which `ghosttyConfigLines()` pins fully transparent below 1.
     public var backgroundOpacity: Double?
@@ -273,6 +296,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     public init(fontFamily: String? = nil, fontSize: Double? = nil, theme: String? = nil,
                 darkTheme: String? = nil, followSystemAppearance: Bool? = nil,
+                cursorStyle: String? = nil, cursorBlink: Bool? = nil,
                 backgroundOpacity: Double? = nil, backgroundBlur: Int? = nil, notificationsEnabled: Bool? = nil,
                 toolbarMode: String? = nil, compactToolbar: Bool? = nil, notificationBadgeEnabled: Bool? = nil,
                 activeStatusColorHex: String? = nil, blockedStatusColorHex: String? = nil,
@@ -297,6 +321,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.theme = theme
         self.darkTheme = darkTheme
         self.followSystemAppearance = followSystemAppearance
+        self.cursorStyle = cursorStyle
+        self.cursorBlink = cursorBlink
         self.backgroundOpacity = backgroundOpacity
         self.backgroundBlur = backgroundBlur
         self.notificationsEnabled = notificationsEnabled
@@ -355,6 +381,13 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// single read point.
     public var effectiveDockBounce: DockBounce {
         dockBounce.flatMap(DockBounce.init(rawValue:)) ?? .off
+    }
+
+    /// The resolved cursor shape, or nil when unset OR when the stored raw name is one this version does
+    /// not offer — a future shape, or a `block_hollow` written by hand. The single read point, so an
+    /// unoffered value falls back to the config chain rather than being emitted from here.
+    public var effectiveCursorStyle: CursorStyle? {
+        cursorStyle.flatMap(CursorStyle.init(rawValue:))
     }
 
     /// The resolved glyph silhouette for one agent status: the configured raw name when a KNOWN
@@ -466,6 +499,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
         } else if let single = light ?? dark {
             lines.append("theme = \(single)")
         }
+        // emitted only when picked, so everyone who never opens the picker keeps the bundled block — and
+        // their own ghostty.conf `cursor-style` — exactly as before.
+        if let cursorStyle = effectiveCursorStyle { lines.append("cursor-style = \(cursorStyle.rawValue)") }
+        // both explicit values are emitted; nil is the third state, which emits nothing and leaves DEC
+        // mode 12 able to drive the blink.
+        if let cursorBlink { lines.append("cursor-style-blink = \(cursorBlink)") }
         // a translucent window composites its tint at the AppKit level, so the renderer must draw fully
         // transparent or the surface and the window stack two tints. at full opacity (or unset) these are
         // omitted and ghostty paints its own background.

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -505,6 +505,43 @@ struct AppSettingsTests {
         #expect(legacy.rightClickPaste == nil)
     }
 
+    @Test func cursorStyleIsAGhosttyKeyEmittedOnlyWhenPicked() throws {
+        // "From config" emits nothing, so a hand-written ghostty.conf `cursor-style` still decides.
+        #expect(AppSettings().cursorStyle == nil)
+        #expect(AppSettings().effectiveCursorStyle == nil)
+        #expect(!AppSettings().ghosttyConfigLines().contains { $0.hasPrefix("cursor-style") })
+        for style in AppSettings.CursorStyle.allCases {
+            let settings = AppSettings(cursorStyle: style.rawValue)
+            #expect(settings.effectiveCursorStyle == style)
+            #expect(settings.ghosttyConfigLines().contains("cursor-style = \(style.rawValue)"))
+            let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(settings))
+            #expect(decoded == settings)
+        }
+        // block_hollow is a valid ghostty shape the picker deliberately does not offer, so it resolves
+        // like any unoffered value: back to the config chain, never emitted from settings.
+        for raw in ["block_hollow", "spinner"] {
+            #expect(AppSettings(cursorStyle: raw).effectiveCursorStyle == nil)
+            #expect(!AppSettings(cursorStyle: raw).ghosttyConfigLines().contains { $0.hasPrefix("cursor-style") })
+        }
+        let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
+        #expect(legacy.cursorStyle == nil)
+        #expect(legacy.effectiveCursorStyle == nil)
+    }
+
+    @Test func cursorBlinkCarriesGhosttysThreeStates() throws {
+        // nil is not "off": ghostty blinks AND keeps honoring DEC mode 12, which either explicit key kills.
+        #expect(AppSettings().cursorBlink == nil)
+        #expect(!AppSettings().ghosttyConfigLines().contains { $0.hasPrefix("cursor-style-blink") })
+        #expect(AppSettings(cursorBlink: true).ghosttyConfigLines().contains("cursor-style-blink = true"))
+        #expect(AppSettings(cursorBlink: false).ghosttyConfigLines().contains("cursor-style-blink = false"))
+        for value: Bool? in [nil, true, false] {
+            let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(cursorBlink: value)))
+            #expect(decoded.cursorBlink == value)
+        }
+        let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
+        #expect(legacy.cursorBlink == nil)
+    }
+
     @Test func newSessionDirectoryRoundTripsAndIsNotAConfigLine() throws {
         let original = AppSettings(newSessionDirectory: "custom", newSessionCustomDirectory: "/tmp/work")
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))

--- a/agtermUITests/SettingsUITests.swift
+++ b/agtermUITests/SettingsUITests.swift
@@ -209,6 +209,44 @@ final class SettingsUITests: XCTestCase {
                       "selecting Normal should persist toolbarMode=normal to settings.json")
     }
 
+    func testCursorStyleAndBlinkPickersPersist() throws {
+        let picker = settingsControl(tab: "Appearance", control: "settings-cursor-style")
+
+        picker.click()
+        let bar = app.menuItems["Bar"]
+        XCTAssertTrue(bar.waitForExistence(timeout: 5), "the cursor dropdown should offer a Bar item")
+        bar.click()
+        XCTAssertTrue(poll { self.settingsValue("cursorStyle") == "bar" },
+                      "selecting Bar should persist cursorStyle=bar to settings.json")
+
+        picker.click()
+        let fromConfig = app.menuItems["From config"]
+        XCTAssertTrue(fromConfig.waitForExistence(timeout: 5), "the cursor dropdown should offer a From config item")
+        fromConfig.click()
+        XCTAssertTrue(poll { self.settingsObject()?["cursorStyle"] == nil },
+                      "selecting From config should remove the cursorStyle key from settings.json")
+
+        // block_hollow is deliberately not offered; an unfocused pane already renders its cursor hollow.
+        picker.click()
+        XCTAssertFalse(app.menuItems["Hollow block"].exists, "the cursor dropdown should not offer a hollow block")
+        app.typeKey(.escape, modifierFlags: [])
+
+        let blink = settingsControl(tab: "Appearance", control: "settings-cursor-blink")
+        blink.click()
+        let steady = app.menuItems["Steady by default"]
+        XCTAssertTrue(steady.waitForExistence(timeout: 5), "the blink dropdown should offer a Steady by default item")
+        steady.click()
+        XCTAssertTrue(poll { self.settingsBool("cursorBlink") == false },
+                      "selecting Steady by default should persist cursorBlink=false")
+
+        blink.click()
+        let programControlled = app.menuItems["Program controlled"]
+        XCTAssertTrue(programControlled.waitForExistence(timeout: 5), "the blink dropdown should offer a Program controlled item")
+        programControlled.click()
+        XCTAssertTrue(poll { self.settingsObject()?["cursorBlink"] == nil },
+                      "selecting Program controlled should remove the cursorBlink key from settings.json")
+    }
+
     func testQuickTerminalSizePickerPersists() throws {
         let picker = settingsControl(tab: "Interface", control: "settings-quick-terminal-size")
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -1422,7 +1422,7 @@
                 <span
                   style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
                   >›</span
-                ><strong style="color: #e6e1d7">Appearance</strong> — terminal font and theme, the toolbar mode (Normal with the
+                ><strong style="color: #e6e1d7">Appearance</strong> — terminal font and theme, the cursor shape and its blink, the toolbar mode (Normal with the
                 working directory, Compact, or Hidden for a full-bleed terminal with no titlebar or traffic lights), window
                 background opacity and blur, the sidebar tint, the sidebar font size, the palette and switcher font size, and how much the terminal behind a floating
                 panel dims — the inactive half of a split, and the session left visible around a floating overlay or the


### PR DESCRIPTION
Discussed in #483.

**What is the problem?**

The cursor shape is reachable only by hand-editing `~/.config/agterm/ghostty.conf`. agterm pins `cursor-style = block` in its bundled defaults and no Settings tab exposes it, so changing it means knowing that the agterm-scoped config file exists, knowing the ghostty key name, and knowing that `~/.config/ghostty/config` does nothing unless "Use my global Ghostty config" is on. Every other terminal makes a thin bar caret a Settings control, and Appearance ▸ Terminal already owns font, size and theme — the same kind of setting, driven the same way.

**How does this solve it?**

Two pickers in Appearance ▸ Terminal — `Cursor` (From config / Block / Bar / Underline) and `Cursor blink` (Program controlled / Blink by default / Steady by default) — emitting `cursor-style` and `cursor-style-blink` from `AppSettings.ghosttyConfigLines()`. Nothing new in the plumbing: `persistAndApply()` already rewrites the settings conf and reloads the surfaces.

The three points from the discussion, as built:

- **From config and Block are named as the different states they are.** From config emits no `cursor-style` at all, so a `cursor-style` already sitting in someone's `ghostty.conf` still picks the shape; Block writes an override that beats that file. Both rows are kept, and a hint under the picker says which way that goes: *"A picked shape overrides cursor-style in ghostty.conf; From config leaves it in charge."*
- **Blink is three rows, not a toggle.** Unset is not "off" — the cursor blinks and DEC mode 12 can still change it, while either explicit value takes DEC mode 12 away and `DECSCUSR` wins over both. So `cursorBlink` stays ghostty's own `?bool` and the picker names all three, which also makes "always blink" sayable and kills the instability where ON meant two different things depending on a hand-written `ghostty.conf`.
- **`block_hollow` is not offered.** An unfocused surface is already marked by drawing its cursor hollow, so a hollow block as the resting shape would make focused and unfocused panes identical. It is not in `CursorStyle` at all, so a `block_hollow` hand-written into `settings.json` resolves like any unoffered value — back to the config chain, never emitted from here — and stays reachable from `ghostty.conf`.

Two caveats from the discussion, recorded here rather than in the docs:

- Scripting the shape through a `ghostty.conf` edit plus `agtermctl config reload` keeps working only while the picker sits on From config. Once a shape is picked, the settings conf owns the key.
- "A reload re-applies both to the panes already open" holds only while a pane's cursor still follows the configured default. A program that set its own shape with `DECSCUSR` keeps it until it resets. That is noted at the `SettingsModel` setters.

**Scope**

No `AppActions`/`AppStore` action and no control-channel surface, so the four-part convention (Command case, dispatcher, `agtermctl` subcommand, round-trip tests) does not apply and the bundled agent skill and `site/commands.html` are untouched. Per the discussion, `site/docs.html` gains cursor only in the canonical Appearance list — nothing about precedence, which is being fixed separately.

**Testing**

- `swift test` in `agtermCore`: green, 2625 tests, including two new `AppSettingsTests` cases covering the emit-only-when-picked rule, all three blink states, `block_hollow` and a future shape both falling back to the config chain, JSON round-trip, and forward-compat decode of a settings file written before the fields existed.
- Added `testCursorStyleAndBlinkPickersPersist` to `SettingsUITests`, following the `testToolbarModePickerPersists` file-oracle pattern; it also asserts the hollow-block row is absent.
- **Not run by me:** `make build`, `make test-app`, `make lint` and the XCUITests. This machine has no Xcode (Command Line Tools only) and no `xcodegen`/`swiftlint`/`zig`, so `scripts/setup.sh` cannot build `GhosttyKit.xcframework` here. The app-target changes (`SettingsModel`, `SettingsView`) and the new UI test parse clean (`swiftc -parse`) but are otherwise unverified against a real build. Flagging it rather than claiming a green run; I will push a fixup for whatever CI turns up.
