### PR TITLE
feat(cookbook): add the close-tab-when-done recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -39,6 +39,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [claude-clear](claude-clear/) | one chord sends /clear to the pane's Claude Code run, and nothing when it is not running | 0.13.0, python3, Claude Code |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
+| [close-tab-when-done](close-tab-when-done/) | arm a tab with a chord and it closes itself when the agent stops replying | 0.22.0, jq, Claude Code |
 | [container-agent-status](container-agent-status/) | a containerized agent reports status onto its sidebar row via a TCP notification to the host | 0.7.1, nc, timeout, Claude Code |
 | [copilot-agent-status](copilot-agent-status/) | Copilot CLI sessions report active, blocked, and completed onto their sidebar row | 0.7.1, Copilot CLI |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |

--- a/cookbook/close-tab-when-done/README.md
+++ b/cookbook/close-tab-when-done/README.md
@@ -1,0 +1,128 @@
+# Close tab when done
+
+Arm a tab with one chord and it closes itself the moment the agent stops replying.
+
+## What it does
+
+The last prompt of a task is usually the last thing that tab is for. What is left is a finished agent sitting in a session you have to come back to and close by hand, and a sidebar that slowly fills up with them.
+
+Asking the agent to close the tab itself does not work well. It closes the session in the middle of its own final message, so the reply you were waiting for is killed half-drawn, and it only happens at all if the agent remembers to run the command and is allowed to.
+
+So the chord marks the tab instead, and the agent's stop hook is what closes it. Press it before you send the prompt you expect to be the last one, or while that prompt is being worked on. A `⏻` appears in front of the session's name in the sidebar, and the tab closes when the agent next finishes a turn. Press it again to disarm.
+
+**Firing closes the session and kills every process in it, with no undo.** The agent, whatever ran in its split pane, and the scrollback all go with it. This is a chord that arms a destructive action a turn in advance, so *Limits* is the section of this README worth reading twice.
+
+The marker is one shot: the hook consumes it on the first turn that ends, so a tab cannot close twice or take a second task down with it.
+
+## Requirements
+
+- agterm 0.22.0 or later, which fixed a custom command spawning with a `PATH` that could not resolve a bare `agtermctl`.
+- `jq`
+- Claude Code, whose `Stop` hook fires the close. Any agent that can run a command when it finishes a turn works the same way; *How it works* says what that hook has to inherit.
+
+## Setup
+
+Copy the script somewhere and make it executable. Anywhere works as long as the keymap line and the hook point at it:
+
+```sh
+mkdir -p ~/bin
+cp agt-autoclose.sh ~/bin/
+chmod +x ~/bin/agt-autoclose.sh
+```
+
+Add an entry to `~/.config/agterm/keymap.conf` and apply it with File ▸ Reload Keymap or `agtermctl keymap reload`:
+
+```
+command "Autoclose" ctrl+shift+w ~/bin/agt-autoclose.sh toggle "{AGT_SESSION_ID}"
+```
+
+Any free chord works; `agtermctl keymap list` shows what every chord currently resolves to. A custom command cannot shadow a built-in, so one that collides is quietly demoted to palette-only and the chord appears to do nothing — the entry is still reachable by name from the action palette, which is the quickest way to tell a bad chord from a broken script.
+
+`{AGT_SESSION_ID}` is the session the chord fired in. Without it the script falls back to `$AGTERM_SESSION_ID`, which a chord does not have: a custom command inherits the app's launch environment, not a terminal's.
+
+Then register the stop hook by adding an entry to the `Stop` array in `~/.claude/settings.json`, alongside anything already there:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/bin/agt-autoclose.sh fire",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`fire` takes no argument: it reads `$AGTERM_SESSION_ID` from the environment the agent inherited from its session, so the same hook line serves every tab. Leave `async` off it, which is what lets the agent tear the hook down before it has detached the close.
+
+Fired from a chord or the palette, the script runs under the app's `PATH` rather than your shell's. That is the launchd default: `/usr/local/bin` plus the system directories, with no `/opt/homebrew/bin` and nothing else your profile adds. Both binaries this recipe needs resolve there — `jq` from `/usr/bin`, which recent macOS ships, and `agtermctl` from `/usr/local/bin`, where **Help ▸ Install Command Line Tool…** symlinks it. A Homebrew `jq` is out of reach from a chord; set `AGTERMCTL` to the CLI's full path, and `PATH` in front of the keymap line, if either binary sits somewhere unusual. The hook half has no such problem: it runs under the agent's own environment, which is your shell's.
+
+Three settings, all read from the environment, all optional:
+
+- `AGT_AUTOCLOSE_DIR` — where the markers live, `~/.agterm-autoclose` by default. The chord and the hook must agree on it, and they read it from different environments, so change the default in the script rather than exporting it in one place only.
+- `AGT_AUTOCLOSE_BADGE` — what goes in front of the session name while it is armed, `⏻ ` by default, trailing space included. Set it to an empty string for no badge at all, which also stops the recipe renaming sessions; the arming state is then invisible except through `agt-autoclose.sh status`.
+- `AGT_AUTOCLOSE_GRACE` — seconds between the hook firing and the session closing, `0.4` by default. It is there so the agent finishes drawing its last reply before the terminal goes away, and it is the only delay involved: the close itself is immediate.
+
+## Usage
+
+Press the chord. A `⏻` appears in front of the session name, the tab closes when the agent finishes its next turn, and the row is gone from the sidebar as it does.
+
+Press it again before that happens and the tab is disarmed, badge and all.
+
+From a shell inside the session:
+
+```sh
+agt-autoclose.sh status            # on | off
+agt-autoclose.sh on                # arm this session
+agt-autoclose.sh off               # disarm it
+agt-autoclose.sh on <session-id>   # arm another one
+```
+
+The id form is what to use from a script, or from an agent driving another session: everything except `fire` takes one, and `fire` deliberately does not, so a hook can never be pointed at a session other than its own.
+
+## How it works
+
+An armed session is an empty file named after its session id, under `~/.agterm-autoclose`. The chord creates or removes it; the stop hook looks for one, and does nothing at all when there is none — which is what makes it safe to leave the hook installed in every session forever.
+
+The hook is the whole point of the recipe. `Stop` fires after Claude Code has finished the turn, so the reply is on screen and complete before anything closes; an agent that closes its own session does it from inside the turn, killing the message it is still writing. It also means no instruction, no tool permission, and no cooperation from the model is involved: the tab closes because the turn ended, not because the agent decided to.
+
+`session close` kills the agent, and the agent is the hook's own parent process. A close called straight from the hook is a process closing the terminal its own caller lives in, and it can die with the session before the server acts on it. So `fire` detaches the work: `nohup` makes it ignore the `SIGHUP` that reaches the session's processes as the terminal goes away, and it re-enters this same script with an internal `close-later` verb rather than composing an `sh -c` line, which keeps the socket path — it holds a space on a default install — out of a second round of shell quoting.
+
+That socket is read from `$AGT_SOCKET` when a chord fired the script, and from `$AGTERM_SOCKET` when a session's shell or one of its hooks did. Passing it explicitly keeps a second agterm, running from a different state directory, from being the one that gets closed.
+
+Not every Claude Code run belongs to the tab whose id it carries. A background or adopted session runs inside a daemon-hosted worker — `claude daemon run`, `bg-spare`, `bg-pty-host` — and that worker keeps the `AGTERM_SESSION_ID` of whichever tab first started the daemon, which is usually a tab closed long ago and in any case says nothing about where this agent is running. Firing on that id would close a session that has nothing to do with the turn that just ended, so `fire` walks up from `$CLAUDE_PID` and stays silent when it finds one of those workers above it. The walk is bounded to twelve hops and reads `ps` only, so it costs nothing on an ordinary turn.
+
+The session id is validated as a UUID before it is ever used as a file name, and upper-cased on the way in. Both halves matter: the id is an argument this README tells you to pass, so `on ../../notes.md` is a plausible typo, and it would truncate that file rather than arm anything. The case fold is what makes a hand-typed lower-case id arm the marker the hook will actually look for.
+
+The badge costs a read that is easy to get wrong. `tree` reports one window — the frontmost — and an armed session is very often not in it: the agent works in a background window while you use another. So the script walks `window list` and reads each window's tree until it finds the session, rather than reading the frontmost tree and treating a miss as "no such session". `window list` also reports windows that are closed, and `tree` answers a null tree for one of those, so the walk filters on `open` or every read drags a jq error onto stderr. Addressing is the other way round: `session rename --target` and `session close --target` resolve a session id across every window, so the write half needs no window at all.
+
+`fire` does none of that walking. It removes the marker, detaches the close and returns; the sidebar row is about to disappear, and a window walk there would spend the hook's timeout on a badge nobody will see. Every path out of it exits 0, and it is a silent no-op without `agtermctl` on `PATH` or `$AGTERM_SESSION_ID` in the environment — a hook that fails reports an error at the end of a turn that went fine, which the user can do nothing about.
+
+## Limits
+
+**Firing closes the session and kills everything in it.** Whatever ran there dies with it — the agent, a server in its split pane, an SSH connection — and the scrollback goes with the session. There is no undo: the grace-period reopen agterm offers covers closing sessions from the GUI, not a single close over the control API. `AGT_AUTOCLOSE_GRACE` only delays the close, it does not make it recoverable.
+
+**A stop hook fires at the end of every turn, including one that ends with a question to you.** If the agent stops to ask which of two approaches you want, that is a finished turn, and an armed tab closes while the question is on screen. Arm the tab on the prompt you expect to be the last one, not at the start of a long task.
+
+**A second agent started inside an armed session closes the tab when *it* finishes.** A `claude -p` run from a script in that shell inherits the session's environment and fires this same `Stop` hook, so the tab goes at the end of the child's turn rather than yours. The hook's payload does not say which agent it belongs to, and the process tree is no help: Claude Code's own daemon and pty-host processes are called `claude` as well, so counting agents among the ancestors finds several on a perfectly ordinary turn. Either arm the tab after that kind of work, or run the nested agent with its hooks disabled.
+
+A run the daemon hosts never fires, by the rule above. An armed tab whose agent has been adopted that way stays armed and keeps its badge until a foreground turn ends in it, or until you disarm it.
+
+**The badge renames the session.** A session that had an automatic name — the one agterm derives for you — comes back from a disarm with that same text as an explicit custom name, and it no longer follows what the session is doing. Set `AGT_AUTOCLOSE_BADGE=` to an empty string if you would rather keep automatic names, and lose the visible arming state with it.
+
+The marker is per session, not per pane. A split running two agents shares one session id: whichever finishes first closes the tab, taking the other agent's pane with it.
+
+Interrupting the agent does not fire the hook. Claude Code reports an interrupted turn as `StopFailure` rather than `Stop`, so an armed tab stays armed and closes at the end of the next turn instead — which may be one you did not mean to be the last.
+
+A chord fired inside a scratch terminal or an overlay can resolve against whichever session is active rather than the one it was pressed in, so it may arm the wrong tab. The badge is the check: if it appears somewhere you did not expect, press the chord again in that session to disarm it.
+
+A session closed by hand while armed leaves its marker behind. Session ids are never reused, so a stale marker can never fire; it is an empty file, and the directory is yours to clear whenever it bothers you.
+
+Sub-agents are not covered. Claude Code reports those to `SubagentStop`, which this recipe deliberately does not hook: a finished sub-agent is not a finished task.

--- a/cookbook/close-tab-when-done/agt-autoclose.sh
+++ b/cookbook/close-tab-when-done/agt-autoclose.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+# agt-autoclose.sh - arm a session to close itself when the agent stops replying.
+#
+# DESTRUCTIVE: firing closes the session, killing every process in it and
+# discarding its scrollback. There is no undo. Read the README's Limits.
+#
+# toggle|on|off|status take a session id, defaulting to $AGTERM_SESSION_ID, so a
+# chord passes "{AGT_SESSION_ID}" and a shell inside the session passes nothing.
+# fire is what the agent's stop hook calls; it reads the environment only.
+set -e
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+STATE_DIR=${AGT_AUTOCLOSE_DIR:-$HOME/.agterm-autoclose}
+# no colon: an empty AGT_AUTOCLOSE_BADGE means "no badge", not "the default"
+BADGE=${AGT_AUTOCLOSE_BADGE-⏻ }
+GRACE=${AGT_AUTOCLOSE_GRACE:-0.4}
+
+# A chord exports AGT_SOCKET; a session's shell, and every hook it spawns,
+# exports AGTERM_SOCKET. Addressing the socket the caller came from is what
+# keeps a second agterm, running from another state directory, out of it.
+socket=${AGT_SOCKET:-${AGTERM_SOCKET:-}}
+
+# The socket path holds a space on a default install, so it can never be pasted
+# into a command line as bare words. One wrapper keeps every call quoted.
+agt() {
+	if [ -n "$socket" ]; then
+		"$AGTERMCTL" "$@" --socket "$socket"
+	else
+		"$AGTERMCTL" "$@"
+	fi
+}
+
+# A session id becomes a file name, so it is validated rather than trusted: an id
+# is a UUID and nothing else. Without this, `on ../../notes.md` truncates that
+# file and `off` deletes it - and the id is an advertised argument, so a typo
+# reaches it, not only malice. Upper-cased because agterm reports ids upper-case:
+# a lower-case id would arm one marker while fire looks for another.
+canonical_id() {
+	printf '%s' "$1" | tr '[:lower:]' '[:upper:]' |
+		grep -Ex '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}'
+}
+
+marker_for() { printf '%s/%s\n' "$STATE_DIR" "$1"; }
+
+# `tree` reports one window, the frontmost, but an armed session can be anywhere:
+# the agent works in a background window while you use another. So walk the
+# windows rather than reading the frontmost tree and calling a miss "not found".
+# select(.open): `window list` reports closed windows too, and `tree` answers a
+# null tree for one, which jq then fails to iterate over.
+# Returns 1 when a read failed and 0 with no output when the session is simply
+# not there. A pipeline would report neither: jq on empty input and a `while`
+# loop both succeed, so a missing CLI would read as "session not found" and the
+# caller would arm a tab it could not badge.
+session_name() {
+	windows=$(agt window list --json) || return 1
+	ids=$(printf '%s' "$windows" | jq -r '.result.windows[] | select(.open) | .id') || return 1
+	for w in $ids; do
+		tree=$(agt tree --window "$w" --json) || return 1
+		n=$(printf '%s' "$tree" | jq -r --arg s "$1" '
+			(.result.tree.workspaces // [])[].sessions[]?
+			| select((.id | ascii_upcase) == $s)
+			| .name // empty') || return 1
+		if [ -n "$n" ]; then
+			printf '%s\n' "$n"
+			return 0
+		fi
+	done
+	return 0
+}
+
+badge_on() {
+	[ -n "$BADGE" ] || return 0
+	name=$(session_name "$1") || return 1
+	# an empty name means the session was not found in any open window; renaming
+	# one that is not there is not worth an error, the marker is what counts
+	case $name in
+	"$BADGE"* | '') return 0 ;;
+	esac
+	agt session rename "$BADGE$name" --target "$1" >/dev/null
+}
+
+badge_off() {
+	[ -n "$BADGE" ] || return 0
+	name=$(session_name "$1") || return 1
+	case $name in
+	"$BADGE"*) agt session rename "${name#"$BADGE"}" --target "$1" >/dev/null ;;
+	esac
+}
+
+# Fail closed. A marker with no badge on it is a tab that closes with no warning
+# at all, so an arm that cannot reach agterm leaves nothing behind: one live read
+# proves the CLI resolves, the socket answers, and jq is there to parse it.
+arm() {
+	if ! windows=$(agt window list --json 2>/dev/null) ||
+		! printf '%s' "$windows" | jq -e '.result.windows' >/dev/null 2>&1; then
+		echo "${0##*/}: cannot reach agterm - check agtermctl, the socket and jq" >&2
+		return 1
+	fi
+	mkdir -p "$STATE_DIR"
+	: >"$(marker_for "$1")"
+	if ! badge_on "$1"; then
+		rm -f "$(marker_for "$1")"
+		echo "${0##*/}: could not badge the session, left disarmed" >&2
+		return 1
+	fi
+}
+
+disarm() {
+	rm -f "$(marker_for "$1")"
+	badge_off "$1"
+}
+
+# Claude Code runs a background or adopted session inside a daemon-hosted worker
+# (`claude daemon run`, `bg-pty-host`, `bg-spare`), and such a worker carries the
+# AGTERM_SESSION_ID of whichever tab first started the daemon - usually a tab
+# that has since been closed, and whose id says nothing about where this agent is
+# running. Firing on that id closes a session that has nothing to do with this
+# turn, so a daemon-hosted run does not fire at all. $CLAUDE_PID is the Claude
+# process that spawned the hook; its ancestors are what tell the two apart.
+daemon_hosted() {
+	pid=${CLAUDE_PID:-$PPID}
+	hops=0
+	while [ "$hops" -lt 12 ]; do
+		hops=$((hops + 1))
+		{ [ -n "$pid" ] && [ "$pid" -gt 1 ]; } 2>/dev/null || break
+		cmd=$(ps -o command= -p "$pid" 2>/dev/null) || break
+		[ -n "$cmd" ] || break
+		case $cmd in
+		*bg-spare* | *bg-pty-host* | *"daemon run"*) return 0 ;;
+		esac
+		pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+	done
+	return 1
+}
+
+# Every path out of here exits 0. A stop hook that fails makes the agent report a
+# hook error at the end of a turn that went fine, and there is nothing the user
+# can do about it from there. Outside agterm, or without the CLI, it is a silent
+# no-op, which is what makes it safe to install once and leave alone.
+fire() {
+	sid=$(canonical_id "${AGTERM_SESSION_ID:-}") || exit 0
+	[ -n "$sid" ] || exit 0
+	command -v "$AGTERMCTL" >/dev/null 2>&1 || exit 0
+	m=$(marker_for "$sid")
+	[ -f "$m" ] || exit 0
+	! daemon_hosted || exit 0
+
+	# one shot, and the marker goes first: a close that fails for any reason leaves
+	# a disarmed session rather than one closing at an unrelated moment. Plain
+	# `rm`, not `rm -f`: removing the marker is what CLAIMS the close, and -f
+	# succeeds on a file that is already gone - a disarm racing this hook, or a
+	# second Stop arriving alongside it, would both go on to close the tab.
+	rm "$m" 2>/dev/null || exit 0
+
+	# `session close` kills the agent, which is this hook's own parent, so the
+	# call has to outlive the hook: nohup makes it ignore the SIGHUP that reaches
+	# the session's processes. Re-entering this script rather than composing an
+	# `sh -c` line keeps the socket path, which holds a space, out of a second
+	# round of shell quoting. The badge is left alone - the row it sits on is
+	# about to go, and a window walk here would spend the hook's timeout.
+	nohup "$0" close-later "$sid" >/dev/null 2>&1 &
+	exit 0
+}
+
+cmd=${1:-}
+case $cmd in
+fire)
+	fire
+	;;
+close-later)
+	# internal, detached by fire: wait out the grace period so the agent finishes
+	# drawing the reply, then close. Never bind this to a chord.
+	sleep "$GRACE"
+	agt session close --target "$2" >/dev/null 2>&1 || true
+	;;
+toggle | on | off | status)
+	if ! sid=$(canonical_id "${2:-${AGTERM_SESSION_ID:-}}"); then
+		echo "${0##*/}: not a session id: '${2:-${AGTERM_SESSION_ID:-}}'" >&2
+		exit 2
+	fi
+	case $cmd in
+	toggle) if [ -f "$(marker_for "$sid")" ]; then disarm "$sid"; else arm "$sid"; fi ;;
+	on) arm "$sid" ;;
+	off) disarm "$sid" ;;
+	status) if [ -f "$(marker_for "$sid")" ]; then echo on; else echo off; fi ;;
+	esac
+	;;
+*)
+	echo "usage: ${0##*/} toggle|on|off|status [session-id]" >&2
+	echo "       ${0##*/} fire        (called by the agent's stop hook)" >&2
+	exit 2
+	;;
+esac


### PR DESCRIPTION
## What is the problem?

A tab that finished its task keeps a finished agent in it. Closing it is manual, and the sidebar fills up with tabs whose only remaining content is a reply you have already read.

Asking the agent to close its own tab does not solve it. The close runs from inside the turn, so the final reply is killed half-drawn, and it happens only if the model remembers to run the command and is allowed to.

## How does this solve it?

A chord marks the session; the agent's `Stop` hook is what closes it. The hook runs after the turn ends, so the reply is complete on screen first, and no instruction, tool permission or model cooperation is involved. The marker is an empty file named after the session id, consumed on the first turn that ends, with a `⏻` in the sidebar name while it is armed.

The recipe is one POSIX `sh` script plus a README and the index row, in the `Agent status and workflows` group.

## Notes for review

Things the recipe deliberately does, since they are the parts worth checking:

- The session id is validated as a UUID and upper-cased before it is used as a file name. It is an argument the README tells you to pass, so `on ../../notes.md` is a plausible typo, and agterm reports ids upper-case, so a hand-typed lower-case id would otherwise arm a marker the hook never looks for.
- `arm` is fail-closed: it proves the CLI, socket and `jq` answer before writing a marker, and removes the marker if the badge rename fails. An unbadged marker is a tab that closes with no warning.
- `fire` exits 0 on every path and is a silent no-op outside agterm. Removing the marker is what claims the close — plain `rm`, not `rm -f`, so a disarm racing the hook wins.
- The close is detached with `nohup` and re-enters the script, because `session close` kills the hook's own parent.
- A run hosted by Claude Code's daemon (`claude daemon run`, `bg-spare`, `bg-pty-host`) does not fire: such a worker keeps the `AGTERM_SESSION_ID` of whichever tab started the daemon, which is not the tab it runs in. Verified live — a background agent launched with a victim tab's id left that tab open, and a probe from inside that context reported the ancestor chain and the guard's verdict.
- The badge walk reads every open window, since `tree` reports only the frontmost one while `--target` addresses ids globally; `window list` also reports closed windows, whose tree is null.

`Limits` states the destructive behavior plainly: firing kills every process in the session with no undo, and a `Stop` at the end of a turn that ended with a question to the user closes the tab with the question on screen.

Ran `shellcheck`, `sh -n` and the cookbook CI steps (layout, index both directions, headings, shebang) locally; all green. It is installed in my own setup in exactly the form committed here — same script, same chord, same hook line — rather than written for the collection.
