### PR TITLE
fix(settings): tidy the Appearance cursor and font controls

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -51,6 +51,12 @@ paths:
   `3024 Night`. It always owns and emits `mouse-scroll-multiplier` (nil = 3 for wheel and trackpad) and
   `right-click-action` (nil/on = paste, off = ignore), overriding earlier config layers. Their Settings
   controls map defaults back to nil; right-click changes reload surfaces.
+  The settings conf loads last among the top-level config sources, but `ghostty_config_load_recursive_files`
+  expands `config-file` includes AFTER it, so an included value for a SCALAR key replaces what Settings
+  wrote — `cursor-style`, `font-size`, `right-click-action` and the rest.
+  `font-family` is ghostty's `RepeatableString` and ACCUMULATES instead, so the merge rule is per key and
+  not a single precedence order.
+  Never tell a user a picked value beats their `ghostty.conf`; it beats a scalar key written directly in it.
 - Non-Ghostty settings update app mirrors and `.agtermAppearanceChanged`, not surfaces. The mute wash
   fades text toward terminal color; with transparency it also tints the see-through area. Sidebar tint
   composes over opaque or blurred backgrounds; AppKit must leave the sidebar unfilled.
@@ -186,6 +192,14 @@ paths:
   values fall back home. Resolve once from active session's `focusedCwd` for every GUI creation path,
   including a right-clicked workspace; setters save only. Control `session.new --cwd` remains explicit
   and ignores this setting.
+- `cursorStyle` is a raw string that `effectiveCursorStyle` recognizes only as `block|bar|underline`, and
+  `cursorBlink` is ghostty's own `?bool`. Unlike the two keys above, neither is emitted unconditionally:
+  only a RECOGNIZED style emits `cursor-style`, and `cursorBlink` emits whenever it is non-nil.
+  nil, and any unoffered name including ghostty's real `block_hollow`, resolve to nil and emit nothing,
+  leaving the config chain to pick the shape — an unknown value is stored yet still silent.
+  `block_hollow` is excluded because an unfocused surface is already marked by drawing its cursor hollow.
+  nil `cursorBlink` is a third state rather than off: the cursor blinks AND DEC mode 12 can still change it,
+  while either explicit value takes DEC mode 12 away. `DECSCUSR` wins over all three.
 - `inheritGlobalGhosttyConfig` defaults off. It changes which files load, so its setter saves then reloads
   unconditionally; it is not a config line or live mirror. Scoped config always loads.
 - `attentionButtonEnabled` defaults off and mirrors to `GhosttyApp` for live titlebar redraw. Its three

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -211,36 +211,47 @@ private struct AppearanceSettingsView: View {
     var body: some View {
         Form {
             Section("Terminal") {
-                Picker("Font", selection: fontFamily) {
-                    Text("Default").tag(String?.none)
-                    ForEach(fonts, id: \.self) { Text($0).tag(String?.some($0)) }
-                }
-                .accessibilityIdentifier("settings-font-family")
+                HStack(spacing: 16) {
+                    Picker("Font name", selection: fontFamily) {
+                        Text("Default").tag(String?.none)
+                        ForEach(fonts, id: \.self) { Text($0).tag(String?.some($0)) }
+                    }
+                    .accessibilityIdentifier("settings-font-family")
+                    .frame(maxWidth: .infinity)
 
-                Stepper(value: fontSize, in: 8 ... 32, step: 1) {
-                    Text("Default font size: \(Int(model.settings.fontSize ?? 13))")
-                }
-                .accessibilityIdentifier("settings-font-size")
+                    Divider()
 
-                // "From config" is a state, not a synonym for Block: it emits no `cursor-style`, so the
-                // config chain still picks the shape, where Block writes an override that beats it.
-                Picker("Cursor", selection: cursorStyle) {
-                    Text("From config").tag(AppSettings.CursorStyle?.none)
-                    Text("Block").tag(AppSettings.CursorStyle?.some(.block))
-                    Text("Bar").tag(AppSettings.CursorStyle?.some(.bar))
-                    Text("Underline").tag(AppSettings.CursorStyle?.some(.underline))
+                    Stepper(value: fontSize, in: 8 ... 32, step: 1) {
+                        Text("Font size: \(Int(model.settings.fontSize ?? 13))")
+                    }
+                    .accessibilityIdentifier("settings-font-size")
+                    .frame(maxWidth: .infinity)
                 }
-                .accessibilityIdentifier("settings-cursor-style")
-                SettingHint("A picked shape overrides cursor-style in ghostty.conf; From config leaves it in charge.")
 
-                // three rows, not a toggle: Program controlled emits nothing, which is the only state that
-                // leaves DEC mode 12 able to drive the blink.
-                Picker("Cursor blink", selection: cursorBlink) {
-                    Text("Program controlled").tag(Bool?.none)
-                    Text("Blink by default").tag(Bool?.some(true))
-                    Text("Steady by default").tag(Bool?.some(false))
+                HStack(spacing: 16) {
+                    // "Default" is a state, not a synonym for Block: it emits no `cursor-style`, so the
+                    // config chain still picks the shape, where Block writes an override that beats it.
+                    Picker("Cursor shape", selection: cursorStyle) {
+                        Text("Default").tag(AppSettings.CursorStyle?.none)
+                        Text("Block").tag(AppSettings.CursorStyle?.some(.block))
+                        Text("Bar").tag(AppSettings.CursorStyle?.some(.bar))
+                        Text("Underline").tag(AppSettings.CursorStyle?.some(.underline))
+                    }
+                    .accessibilityIdentifier("settings-cursor-style")
+                    .frame(maxWidth: .infinity)
+
+                    Divider()
+
+                    // three rows, not a toggle: Default emits nothing, which is the only state that leaves
+                    // DEC mode 12 able to drive the blink.
+                    Picker("Cursor blink", selection: cursorBlink) {
+                        Text("Default").tag(Bool?.none)
+                        Text("Blink").tag(Bool?.some(true))
+                        Text("Steady").tag(Bool?.some(false))
+                    }
+                    .accessibilityIdentifier("settings-cursor-blink")
+                    .frame(maxWidth: .infinity)
                 }
-                .accessibilityIdentifier("settings-cursor-blink")
 
                 // the CURRENT appearance's theme; while following, the on-screen side. The "default ghostty"
                 // row shows only when NOT following — a dual conditional needs two named themes.

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -510,6 +510,12 @@ struct AppSettingsTests {
         #expect(AppSettings().cursorStyle == nil)
         #expect(AppSettings().effectiveCursorStyle == nil)
         #expect(!AppSettings().ghosttyConfigLines().contains { $0.hasPrefix("cursor-style") })
+        // ghostty's own wire vocabulary, so the set and the emitted spelling are pinned as literals here
+        // rather than derived from the enum a typo would carry into both sides of the comparison.
+        #expect(AppSettings.CursorStyle.allCases.map(\.rawValue) == ["block", "bar", "underline"])
+        #expect(AppSettings(cursorStyle: "block").ghosttyConfigLines().contains("cursor-style = block"))
+        #expect(AppSettings(cursorStyle: "bar").ghosttyConfigLines().contains("cursor-style = bar"))
+        #expect(AppSettings(cursorStyle: "underline").ghosttyConfigLines().contains("cursor-style = underline"))
         for style in AppSettings.CursorStyle.allCases {
             let settings = AppSettings(cursorStyle: style.rawValue)
             #expect(settings.effectiveCursorStyle == style)

--- a/agtermUITests/SettingsUITests.swift
+++ b/agtermUITests/SettingsUITests.swift
@@ -220,31 +220,26 @@ final class SettingsUITests: XCTestCase {
                       "selecting Bar should persist cursorStyle=bar to settings.json")
 
         picker.click()
-        let fromConfig = app.menuItems["From config"]
-        XCTAssertTrue(fromConfig.waitForExistence(timeout: 5), "the cursor dropdown should offer a From config item")
-        fromConfig.click()
+        let shapeDefault = app.menuItems["Default"]
+        XCTAssertTrue(shapeDefault.waitForExistence(timeout: 5), "the cursor dropdown should offer a Default item")
+        shapeDefault.click()
         XCTAssertTrue(poll { self.settingsObject()?["cursorStyle"] == nil },
-                      "selecting From config should remove the cursorStyle key from settings.json")
-
-        // block_hollow is deliberately not offered; an unfocused pane already renders its cursor hollow.
-        picker.click()
-        XCTAssertFalse(app.menuItems["Hollow block"].exists, "the cursor dropdown should not offer a hollow block")
-        app.typeKey(.escape, modifierFlags: [])
+                      "selecting Default should remove the cursorStyle key from settings.json")
 
         let blink = settingsControl(tab: "Appearance", control: "settings-cursor-blink")
         blink.click()
-        let steady = app.menuItems["Steady by default"]
-        XCTAssertTrue(steady.waitForExistence(timeout: 5), "the blink dropdown should offer a Steady by default item")
+        let steady = app.menuItems["Steady"]
+        XCTAssertTrue(steady.waitForExistence(timeout: 5), "the blink dropdown should offer a Steady item")
         steady.click()
         XCTAssertTrue(poll { self.settingsBool("cursorBlink") == false },
-                      "selecting Steady by default should persist cursorBlink=false")
+                      "selecting Steady should persist cursorBlink=false")
 
         blink.click()
-        let programControlled = app.menuItems["Program controlled"]
-        XCTAssertTrue(programControlled.waitForExistence(timeout: 5), "the blink dropdown should offer a Program controlled item")
-        programControlled.click()
+        let blinkDefault = app.menuItems["Default"]
+        XCTAssertTrue(blinkDefault.waitForExistence(timeout: 5), "the blink dropdown should offer a Default item")
+        blinkDefault.click()
         XCTAssertTrue(poll { self.settingsObject()?["cursorBlink"] == nil },
-                      "selecting Program controlled should remove the cursorBlink key from settings.json")
+                      "selecting Default should remove the cursorBlink key from settings.json")
     }
 
     func testQuickTerminalSizePickerPersists() throws {


### PR DESCRIPTION
follow-up to #487.

Font name now pairs with Font size, and Cursor shape with Cursor blink, two per row as the Interface tab does. Four rows and a hint became two.

the cursor hint is gone. It said a picked shape overrides `cursor-style` in `ghostty.conf`, but `config-file` includes load after the settings conf, so an included `cursor-style` can still override a picked shape.

both nil rows now read Default, matching the Font picker. The blink rows dropped "by default", which only two of the three carried even though `DECSCUSR` overrides all of them.

the core test pins the `CursorStyle` raw values and the emitted lines as literals instead of deriving them from the enum under test, and `.claude/rules/settings.md` records both cursor fields plus the include precedence. The label-based UI check for the `block_hollow` omission is gone, since the core test now owns the supported set.
