### PR TITLE
fix(cookbook): fail closed when an armed session cannot be badged

### DIFF
--- a/cookbook/close-tab-when-done/agt-autoclose.sh
+++ b/cookbook/close-tab-when-done/agt-autoclose.sh
@@ -71,10 +71,12 @@ session_name() {
 badge_on() {
 	[ -n "$BADGE" ] || return 0
 	name=$(session_name "$1") || return 1
-	# an empty name means the session was not found in any open window; renaming
-	# one that is not there is not worth an error, the marker is what counts
+	# an empty name is a session in no open window - a closed window keeps its
+	# sessions and their ids, so it can come back and fire. Nothing to badge is a
+	# failure like any other, or arm leaves the unbadged marker it exists to prevent.
+	[ -n "$name" ] || return 1
 	case $name in
-	"$BADGE"* | '') return 0 ;;
+	"$BADGE"*) return 0 ;;
 	esac
 	agt session rename "$BADGE$name" --target "$1" >/dev/null
 }


### PR DESCRIPTION
Follow-up to your comment on #488 — the `arm` path that writes a marker with no badge on it.

## What was wrong

`session_name` deliberately separates a read failure (returns 1) from a session that is simply not there (returns 0 with no output), and `badge_on` folded the second case back into success:

```sh
case $name in
"$BADGE"* | '') return 0 ;;
esac
```

So `arm` wrote the marker, badged nothing and exited 0 with no output. `status <that-id>` then reported `on` while the sidebar showed no `⏻` — the one state the function's own comment says must never exist.

Reproduced against a stub CLI reporting one open window and one closed one, with the session in the closed window:

```
exit=0        # silent
status: on
markers: AAAAAAAA-...    # no rename ever issued
```

Two reachable paths, as you described them:

- **inert** — the id form Usage recommends for scripts and agents. One wrong digit still passes `canonical_id` and the liveness probe, so the marker names no session. It can never fire, but `status` lies.
- **destructive** — `session_name` filters on `select(.open)`, so a valid id from a closed window reads as not found. The window bundle keeps its sessions and their ids, so after the window is reopened and an agent finishes a turn in the restored session, the tab closes with no badge ever having warned about it.

## The fix

With a badge to place, an empty name is a failure like a read error: `arm` removes the marker and reports the session left disarmed. The `[ -n "$BADGE" ] || return 0` guard is earlier in the function, so an intentionally empty `AGT_AUTOCLOSE_BADGE` keeps its documented invisible behavior untouched.

No README change: the recipe already says nothing about arming a session in a closed window, and the new behavior is a refusal with a message rather than something the user has to be told about in advance.

## Verified

Same stub, six cases:

| case | before | after |
|---|---|---|
| session only in a closed window | `exit=0`, marker, no badge | `exit=1`, `left disarmed`, no marker |
| mistyped-but-valid id | `exit=0`, marker, no badge | `exit=1`, `left disarmed`, no marker |
| live session in an open window | armed + badged | unchanged |
| `AGT_AUTOCLOSE_BADGE=` | armed, invisible | unchanged |
| CLI unreachable | `cannot reach agterm` | unchanged |
| `off` on any id | fail-open | unchanged |

`shellcheck`, `sh -n` and the cookbook CI steps (layout, index both directions, headings, shebang) run locally; all green.