### PR TITLE
feat: report the pane session.restore wrote

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -117,6 +117,13 @@ paths:
   never the error:
   `DecodingError.debugDescription` is macOS 26.4+, so at the 14.0 deployment target `String(describing:)`
   degrades to a reflection dump that hides the sentence inside `DecodingError.Context(...)`.
+- An unknown ARGUMENT is not symmetric with an unknown command. `ControlArgs` is synthesized `Codable` with
+  no `CodingKeys`, so a server that predates a field drops it and runs the command without it, answering ok:
+  there is no "unknown field" error and no way to ask. A new field that only narrows or decorates is fine
+  that way. One that changes WHERE a mutation lands is not: give it a read-back so a caller can see what the
+  server did, rather than leaving the two outcomes indistinguishable. Since `agtermctl` ships inside the
+  bundle, the CLI that sends a field and the app that reads it are the same build, so the exposure is a
+  stale RUNNING process across an upgrade, not a mismatched install.
 - Human output shows IDs only for created session/workspace/window, retains them in JSON, uses
   `result.affected` for session counts, and reserves `result.count` for diagnostics/search.
   A command that reuses `count` for something else must carry its own `result.text`, which the shared
@@ -536,7 +543,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   blocked/completed reveal. Control attention navigation changes selection only.
 - `--pane-id` (#199) is a stable per-surface token that overrides stale baked role after promote/re-split,
   then falls back to role when absent/unknown. Inject `AGTERM_PANE_ID`, resolve against live surface tokens,
-  and report only resolved `statusPane`. This alternative addressing adds no read-back field.
+  and report only resolved `statusPane`. For `session.status` this addressing adds no read-back field. For
+  `session.restore` it does: every success carries `result.pane`, the `StatusPane` raw value written, since a
+  token names a surface rather than a role and the caller would otherwise have to diff `restoreCommand`
+  against `splitRestoreCommand` on the tree to find out where its pin landed.
 - Auto-reset clears both session entered and session left. Status renders on selected sessions too.
 - `session.flag on|off|toggle|clear` is idempotent; clear ignores target and clears the store.
   Read `flagged`.

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -458,7 +458,7 @@ extension ControlServer: ControlActions {
                 return ControlResponse(ok: false,
                                        error: "failed to save the restore override, the previous value is still in effect")
             }
-            var result = ControlResult(id: id.uuidString)
+            var result = ControlResult(id: id.uuidString, pane: pane.rawValue)
             if case .pin = update.pin, self.settingsModel.settings.restoreRunningCommand != true {
                 result.text = "saved, but \"Restore running commands on restart\" is off, so the override will not run"
             }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -862,6 +862,12 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var themes: [String]?
     /// The applied primary-pane split fraction echoed by `session.resize`, after clamping / a relative nudge.
     public var ratio: Double?
+    /// The pane `session.restore` wrote, as a `StatusPane` raw value, echoed like `ratio` is for
+    /// `session.resize`. It earns its place for `--pane-id`: that addressing names a surface token rather
+    /// than a role, so the caller cannot know which pane it hit without reading the tree back and diffing
+    /// `restoreCommand` against `splitRestoreCommand`. Present on every success, including the `--pane`
+    /// and default-to-main paths, so a caller never has to branch on how it addressed the pane.
+    public var pane: String?
     /// The light/dark syncing state for `theme.set`/`theme.list`, from the stored theme: `sync` = whether it
     /// is ghostty's dual `light:,dark:` form (the terminal tracks the macOS appearance), `light`/`dark` its
     /// sides. While syncing `theme` is absent; otherwise `theme` is the plain single theme, these absent.
@@ -882,7 +888,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
                 affected: Int? = nil,
-                theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil,
+                theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil, pane: String? = nil,
                 sync: Bool? = nil, light: String? = nil, dark: String? = nil,
                 events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil,
                 pick: ControlPickResult? = nil, cursor: ControlCursor? = nil,
@@ -897,6 +903,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.theme = theme
         self.themes = themes
         self.ratio = ratio
+        self.pane = pane
         self.sync = sync
         self.light = light
         self.dark = dark

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -652,4 +652,29 @@ final class ControlServerSessionActionsTests: XCTestCase {
         XCTAssertTrue(resized.ok, resized.error ?? "")
         XCTAssertEqual(bodyText(session), body, "a resize must rewrite the header the helper reads")
     }
+    // The pane is echoed on every success, not only on the interesting path: `--pane-id` addresses a surface
+    // token, so its caller has no other way to learn which pane was pinned, and the default-to-main path is
+    // covered too so a caller never has to branch on how it addressed the pane.
+    func testRestoreReportsThePaneItActuallyWrote() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let session = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        session.hasSplit = true
+
+        let toSplit = server.setSessionRestore(
+            session.id.uuidString, window: nil,
+            update: ControlSessionRestoreUpdate(pin: .pin("echo split"), pane: .right, paneID: "unresolvable"))
+        XCTAssertTrue(toSplit.ok, toSplit.error ?? "")
+        XCTAssertEqual(toSplit.result?.pane, "right")
+        XCTAssertEqual(session.splitRestoreCommand, "echo split")
+
+        // neither selector given: the documented main-pane default, reported like any other
+        let toMain = server.setSessionRestore(
+            session.id.uuidString, window: nil,
+            update: ControlSessionRestoreUpdate(pin: .pin("echo main"), pane: nil, paneID: nil))
+        XCTAssertTrue(toMain.ok, toMain.error ?? "")
+        XCTAssertEqual(toMain.result?.pane, "left")
+        XCTAssertEqual(session.restoreCommand, "echo main")
+    }
+
 }

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -565,6 +565,9 @@ error keeps those names for compatibility.
   `$AGTERM_PANE_ID`) resolves the pane's LIVE slot, so a hook in a promoted-then-re-split pane still pins
   the right one; UNLIKE `session status`, a token that does not resolve is an error unless `--pane` is also
   given as the fallback (a silent main-pane default here would overwrite the wrong pane).
+  Every success names the pane it wrote in `result.pane` (`left`/`right`), which is the read-back for
+  `--pane-id`: a token names a surface rather than a role, so without it the caller has to re-read the tree
+  and diff `restoreCommand` against `splitRestoreCommand` to find out where the pin landed.
   The pinned value is SHELL CODE: it persists in the window's state file (`windows/<id>.json`), is readable
   via `tree`, and may enter shell history when it runs — so it must not carry secrets, and only
   safely-interpolated values (a UUID-shaped session id) belong in it. It persists immediately, so a

--- a/site/commands.html
+++ b/site/commands.html
@@ -1417,7 +1417,12 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">$AGTERM_PANE_ID</span>) resolves the pane's live slot; unlike
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session status</span>, a token that does
                 not resolve is an error unless <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span> is also given
-                as the fallback. The pinned value is shell code stored in the window's state file and readable via
+                as the fallback. Every success names the pane it wrote in
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.pane</span>, the read-back for
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane-id</span>: a token names a surface rather than a role, so without it the caller has to re-read
+                the tree and diff <span style="font-family: &quot;JetBrains Mono&quot;, monospace">restoreCommand</span> against
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitRestoreCommand</span> to find out where the pin landed.
+                The pinned value is shell code stored in the window's state file and readable via
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span>, so it must not carry secrets. Not to be confused
                 with <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">restore clear</span>, which is
                 app-global and clears every session's <em>captured</em> command.


### PR DESCRIPTION
Echoes the pane `session.restore` wrote, so a caller that addressed it by token can read back where the pin landed.

```
$ agtermctl session restore "claude --resume abc" --pane-id $AGTERM_PANE_ID
ok
$ ... --json
{"ok":true,"result":{"id":"EB8AE210-992C-44E9-81AF-CB575D4B0241","pane":"right"}}
$ agtermctl session restore "npm run dev" --json          # no selector, the main-pane default
{"ok":true,"result":{"pane":"left","id":"EB8AE210-992C-44E9-81AF-CB575D4B0241"}}
$ agtermctl session restore --clear --pane right --json
{"ok":true,"result":{"id":"EB8AE210-992C-44E9-81AF-CB575D4B0241","pane":"right"}}
```

`--pane-id` names a surface by its spawn token rather than by a role, which is the point of it: a hook in a promoted-then-re-split pane pins the right slot without knowing which slot that is. The cost was that the caller could not find out either, short of re-reading `tree` and diffing `restoreCommand` against `splitRestoreCommand`. `result.ratio` already does this for `session.resize`, so the shape is not new.

**On every success, not only for `--pane-id`.** The `--pane` and default-to-main paths report it too, so a caller never has to branch on how it addressed the pane to know how to read the answer. It costs one field and removes the only reason to special-case the token form.

**The rule this exposed, recorded in the contract.** `ControlArgs` is synthesized `Codable` with no `CodingKeys`, so an app that predates a field drops it and runs the command without it, answering an ordinary ok. That is unlike an unknown *command*, which fails to decode and names itself, and the asymmetry was not written down anywhere. `.claude/rules/control-api.md` now says it, and says that a field deciding *where* a mutation lands wants a read-back rather than leaving the two outcomes indistinguishable. It also notes the exposure is narrow, since `agtermctl` ships inside the bundle: the CLI that sends a field and the app that reads it are the same build, so only a stale running process across an upgrade can split them.

Surfaces synced: `site/commands.html`, the bundled skill reference, and the `--pane-id` paragraph in `control-api.md`, which said this addressing "adds no read-back field" and is now true only of `session.status`.

`make test` 2632, `make test-app` 259, `make lint`, `make build`, all green. The transcript above is a scratch instance with its own state dir and socket. `ControlServerSessionActionsTests/testRestoreReportsThePaneItActuallyWrote` covers the split, the explicit-pane and the default paths; with `pane:` dropped from the result it goes red on both panes rather than only the interesting one:

```
ControlServerSessionActionsTests.swift:669: error: XCTAssertEqual failed: ("nil") is not equal to ("Optional("right")")
ControlServerSessionActionsTests.swift:677: error: XCTAssertEqual failed: ("nil") is not equal to ("Optional("left")")
```

No UI test: this path has none.
