### PR TITLE
Fix peer chat for labelled Claude composers

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -50,9 +50,10 @@ paths:
 - The cookbook job builds nothing. It compares the `cookbook/README.md` table and recipe directories in
   both directions; requires kebab-case directories, a `README.md` with all six exact
   (`grep -qxF`) headings, and shebangs for `.sh`/`.zsh`/`.py`; runs `shellcheck` on `.sh`; parses `.zsh`
-  with `zsh -n`; and runs `ruff check` on `.py`. `shellcheck` is preinstalled. Install absent `zsh` and
-  `ruff` in separate steps immediately before their own; shellcheck cannot lint zsh, and `ruff` needs
-  `pipx` because the runner's python is externally managed.
+  with `zsh -n`; runs `ruff check` on `.py`; and executes every `test_*.py` regression script directly.
+  `shellcheck` is preinstalled. Install absent `zsh` and `ruff` in separate steps immediately before
+  their own; shellcheck cannot lint zsh, and `ruff` needs `pipx` because the runner's python is externally
+  managed.
 - Recipes are not shell-only. A language gains a gate by adding its extension to the shebang glob plus a
   lint or parse step; until then it merges unchecked, which is why `cookbook/CONTRIBUTING.md` tells a
   contributor to flag any other language in the pull request. Keep that file, `cookbook/README.md` and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,8 @@ jobs:
         # out. bash explicitly, for pipefail, same reason as the shellcheck step above
         shell: bash
         run: find cookbook -type f -name '*.py' -print0 | xargs -0 -r ruff check --ignore EXE001
+      - name: Python recipe tests
+        # One process per file keeps recipes independent and gives each test script its own argv.
+        # Bash explicitly, for pipefail, same reason as the ruff step above.
+        shell: bash
+        run: find cookbook -type f -name 'test_*.py' -print0 | xargs -0 -r -n1 python3

--- a/cookbook/CONTRIBUTING.md
+++ b/cookbook/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Name scripts by their language, because the extension decides what CI does with 
 
 - `.sh` is POSIX or bash. CI runs `shellcheck` over every one, and it has to be clean.
 - `.zsh` is zsh. CI parses every one with `zsh -n`, so a syntax error is caught, but shellcheck cannot read zsh and nothing lints these. A parse is not a lint, so run `zsh -n` yourself and read the script over before sending.
-- `.py` is Python 3. CI runs `ruff check` over every one, and it has to be clean. Say which Python version the recipe needs in *Requirements*, the same as any other external tool, and depend on the standard library unless the recipe genuinely cannot.
+- `.py` is Python 3. CI runs `ruff check` over every one, and it has to be clean. A regression script named `test_*.py` is also executed directly by CI. Say which Python version the recipe needs in *Requirements*, the same as any other external tool, and depend on the standard library unless the recipe genuinely cannot.
 
 A recipe in another language is welcome, but say so in the pull request: nothing lints an extension CI does not know, and a recipe that arrives ungated is one the reader has to trust entirely on review.
 

--- a/cookbook/two-agent-chat/peer-chat.py
+++ b/cookbook/two-agent-chat/peer-chat.py
@@ -21,7 +21,8 @@ RETRY_DELAY = 10.0
 BOX_LINES = 40
 EMPTY_CURSOR_COLUMN = 2
 MIN_WRAPPED_PROBE = 40
-RULE_RE = re.compile(r"^\s*[─—-]{10,}\s*$")
+# Claude can put a short context label inside the top composer rule, for example `e2e`.
+RULE_RE = re.compile(r"^\s*[─\u2014-]{10,}(?:\s+[^─\u2014-].*?\s+[─\u2014-]+)?\s*$")
 CODEX_PROMPT_RE = re.compile(r"^\s*›[\s ]*(.*?)\s*$")
 CLAUDE_PROMPT_RE = re.compile(r"^\s*❯[\s ]*(.*?)\s*$")
 PASTED_RE = re.compile(r"\[Pasted Content \d+ chars?\]")

--- a/cookbook/two-agent-chat/test_peer_chat.py
+++ b/cookbook/two-agent-chat/test_peer_chat.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Regression checks for the two-agent chat composer parser."""
+
+import runpy
+import unittest
+from pathlib import Path
+
+SCRIPT = runpy.run_path(Path(__file__).with_name("peer-chat.py"))
+CLAUDE_PROMPT_TEXT = SCRIPT["claude_prompt_text"]
+RULE = "─" * 40
+
+
+class ClaudePromptTextTests(unittest.TestCase):
+    def test_plain_rule(self) -> None:
+        screen = f"{RULE}\n❯ Chat from Codex: ping\n{RULE}"
+
+        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
+
+    def test_rule_with_context_label(self) -> None:
+        screen = f"{RULE} e2e ─\n❯ Chat from Codex: ping\n{RULE}"
+
+        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
+
+    def test_rule_after_prompt_is_required(self) -> None:
+        screen = f"{RULE} e2e ─\n❯ Chat from Codex: ping"
+
+        self.assertIsNone(CLAUDE_PROMPT_TEXT(screen))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Claude Code can place a context label inside the top composer rule, for example `──── e2e ─`. The peer-chat parser required that rule to contain line characters only, so it could type a message but could not verify the composed text and deliberately withheld Return.

This change accepts the optional context label while retaining the closing-rule check that distinguishes the composer from ordinary terminal output.

A standard-library regression script covers plain rules, labelled rules, and a prompt missing its closing rule. The cookbook CI job now executes every `test_*.py` recipe check in its own process, alongside the existing Ruff gate.

Checks completed:

- `python3 cookbook/two-agent-chat/test_peer_chat.py`
- `ruff check --ignore EXE001 cookbook/two-agent-chat/peer-chat.py cookbook/two-agent-chat/test_peer_chat.py`
- `actionlint .github/workflows/ci.yml`
- `make test`
- live Claude send through the corrected parser: `{"sent": 354}`
