### PR TITLE
fix: reject an out-of-range --size-percent on session.overlay.open

### DIFF
--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -639,6 +639,9 @@ public struct ControlDispatcher {
             if pane != nil, request.args?.sizePercent != nil {
                 return ControlResponse(ok: false, error: PaneOverlayError.sizePercentConflict)
             }
+            if let percent = request.args?.sizePercent, !(1...100).contains(percent) {
+                return ControlResponse(ok: false, error: "session.overlay.open: --size-percent must be 1...100")
+            }
             return actions.openSessionOverlay(request.target, window: request.args?.window,
                                               options: ControlSessionOverlayOpenOptions(
                                                 command: command,

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -677,6 +677,7 @@ struct Session: ParsableCommand {
                 if pane != nil, sizePercent != nil {
                     throw ValidationError("--pane cannot be combined with --size-percent (pane overlays are always full)")
                 }
+                try Hud.validateSizePercent(sizePercent)
             }
 
             func makeRequest() throws -> ControlRequest {

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherOverlayTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherOverlayTests.swift
@@ -148,6 +148,27 @@ struct ControlDispatcherOverlayTests {
         #expect(actions.calls.isEmpty)
     }
 
+    // `open` and `resize` share the field, the documented 1...100 range and the host clamp behind it, so
+    // they have to share the refusal too: without this, `open` answers ok and silently clamps while the
+    // sibling errors on the same value. The conflict check stays ahead of the range check, as in `resize`.
+    @Test func sessionOverlayOpenRejectsOutOfRangeSizePercent() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let tooBig = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayOpen, target: "session", args: ControlArgs(command: "cat", sizePercent: 101)))
+        let tooSmall = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayOpen, target: "session", args: ControlArgs(command: "cat", sizePercent: 0)))
+        let withPane = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayOpen, target: "session",
+            args: ControlArgs(command: "cat", sizePercent: 500, pane: "right")))
+
+        #expect(tooBig == ControlResponse(ok: false, error: "session.overlay.open: --size-percent must be 1...100"))
+        #expect(tooSmall == ControlResponse(ok: false, error: "session.overlay.open: --size-percent must be 1...100"))
+        #expect(withPane == ControlResponse(ok: false, error: PaneOverlayError.sizePercentConflict))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionOverlayOpenRoutesPaneAndClearsSizePercent() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)


### PR DESCRIPTION
`session overlay open --size-percent 500` answered ok and opened a full-size panel. The sibling refuses the same value.

```
over the raw socket, where the CLI cannot pre-validate:
$ {"cmd":"session.overlay.open","args":{"command":"sleep 60","sizePercent":500}}
{"error":"session.overlay.open: --size-percent must be 1...100","ok":false}
$ {"cmd":"session.overlay.resize","args":{"sizePercent":500}}          # the sibling, unchanged
{"error":"session.overlay.resize: --size-percent must be 1...100","ok":false}
$ agtermctl session overlay open "sleep 60" --size-percent 500          # and locally
Error: --size-percent must be between 1 and 100
$ agtermctl session overlay open "sleep 60" --size-percent 40           # a legal one still works
ok
```

The value reached `AppStore.openOverlay`, which clamps with `min(100, max(1, $0))`, so a typo landed a 1% strip or a full panel and reported success either way. `session.overlay.resize` and both `session.hud.*` arms already refuse out-of-range, and `ControlArgs.sizePercent` documents 1...100 for all of them, so `open` was the one consumer that read the range as a suggestion.

**Same words, same order as the sibling.** `resize` checks combinations first and the range last, so the `--pane` conflict still wins: a pane overlay takes no size at all, which is the more useful complaint when both are wrong.

**Both sides, because only one of them was reachable before.** The dispatcher is the fix; the CLI gained the check too, through the `validateSizePercent` helper the hud commands already use, so an `agtermctl` user gets a usage error without the round trip. A raw-socket caller was the only one who could reach the clamp, and now cannot.

No doc change: the reference already states `--size-percent N` (1-100) for `open`, and nothing ever promised clamping. This makes the code agree with what was written.

`make test` 2634, `make test-app` 259, `make lint`, `make build`, all green. `ControlDispatcherOverlayTests/sessionOverlayOpenRejectsOutOfRangeSizePercent` covers both bounds and pins that the conflict still precedes the range. Run against the unfixed dispatcher it fails on all three, and the third is the one that matters, since it shows the value reaching the host rather than merely being accepted:

```
Expectation failed: (tooBig → ControlResponse(ok: true, result: nil, error: nil)) == ...
Expectation failed: (actions.calls → [.overlayOpen(... sizePercent: Optional(101) ...)]).isEmpty → false
```
