### PR TITLE
docs: explain why a shell wrapper stops the working directory being reported

### DIFF
--- a/docs/backlog/wrapper-pane-foreground-capture-unverified.md
+++ b/docs/backlog/wrapper-pane-foreground-capture-unverified.md
@@ -1,0 +1,23 @@
+---
+worth: maybe
+where: agterm/Ghostty/ForegroundProcess.swift:22
+added: 2026-08-28
+---
+# what a wrapper pane actually captures on restore is unverified
+
+Reading `command(for:)`, a pane whose shell was replaced by a terminal wrapper (`kiro-cli-term`, `qterm`,
+`figterm`) should capture the wrapper itself. `tcgetpgrp` returns the wrapper's group, `procArgs` succeeds
+because the wrapper runs as the user, and `isIdleShell` does not match — `basename("zsh (kiro-cli-term)")`
+is the whole string, not `zsh`. So the capture is non-nil, which sets `hadForeground` and drops a
+`--command` session's `initialCommand`, and `shouldRestore` passes the argv, so restore would type
+`'zsh (kiro-cli-term)'` into the pane.
+
+The reporter of discussion #497 observed the opposite: a session running `sleep 600` came back as a plain
+shell with `foregroundCommand: null`. `WindowLibrary.stripCaptures` nils that field in the window file on
+every launch restore, so a null read after relaunching proves nothing either way — but "came back as a
+bare shell" is not what typing a bad command produces.
+
+Two possibilities and they want different fixes: if the capture is non-nil, a `--command` session under a
+wrapper silently loses its exec path and every pane gets a `command not found` on launch; if it is nil, the
+pane just loses its program, which is what the docs now say. Settling it needs a wrapper installed, so the
+cheapest route is to ask on #497 rather than to install one.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,6 +136,52 @@ Reload with **File ▸ Reload Config** or `agtermctl config reload`. The keybind
 - **Agent-status glyph does not update.** Install the hooks from Help ▸ Install Agent Status Hooks…. For shell-integrated agents, start a fresh shell so the `source` line added to your shell rc takes effect. For Pi, restart it or run `/reload` so it loads `~/.pi/agent/extensions/agterm-status.ts`; Pi status is only installed when `~/.pi/agent` already exists. For OpenCode, restart it so it loads `~/.config/opencode/plugins/agterm-status.js`; the plugin installs only when `~/.config/opencode` already exists. The hooks call `agtermctl session status`, so `agtermctl` must resolve first (see above).
 - **Agent-status glyph updates the wrong session.** One session's glyph blinks while the work happens in another — typically when agents run inside tmux (or a tmux-backed session manager such as agent-deck). The working process inherited another session's `AGTERM_SESSION_ID`: the status hooks target whatever id is in their environment, and a long-lived daemon started from inside an agterm session (a tmux server is the usual carrier) captures that session's `AGTERM_*` variables into its global environment and passes them to every child it ever creates. Check `tmux show-environment -g | grep AGTERM` — if present, clear them with `tmux set-environment -g -r AGTERM_SESSION_ID` (and the other `AGTERM_*` names), then restart the affected panes. To avoid it, start such daemons with the variables scrubbed (`env -u AGTERM_SESSION_ID … <command>`) or from a terminal outside agterm.
 
+## Every session restores to the directory it was created in
+
+Sessions come back in the directory they were opened in rather than the one you left them in, the directory
+shown under the session name never follows a `cd`, `session reveal` opens the wrong folder, and
+`{AGT_SESSION_PWD}` in a custom command expands to the creation directory.
+
+agterm learns a session's working directory only from OSC 7, which Ghostty's shell integration reports.
+That integration is injected into the shell agterm spawns and does not survive that shell replacing itself.
+A startup file that `exec`s another shell replaces it before it ever reaches a prompt, so the directory is
+never reported at all and every consumer falls back to the one the session started in. Shell-wrapper
+installers do exactly this: Amazon Q CLI, Kiro CLI and Fig add an `exec` block at the top of `.zshrc`.
+
+To confirm it, `cd` somewhere in the session and run `agtermctl tree --json`: if the session's `cwd` does
+not follow the `cd`, nothing is reporting it.
+
+The fix is Ghostty's own recipe — load the integration explicitly, below the block that replaced your
+shell:
+
+```zsh
+if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
+  builtin source "$GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration"
+fi
+```
+
+It is a no-op in a shell that already loaded it, so it is safe to add unconditionally. bash, fish and
+nushell have their own integration files in the same `shell-integration` directory. Removing the wrapper
+works too.
+
+Three neighbouring cases share the cause, and the block above covers all but the last:
+
+- **`exec zsh` typed at a prompt** replaces a shell that has already reported, so the directory freezes
+  where it was rather than never being set. The replacement reads `.zshrc`, so the block fixes it.
+- **`sudo -E zsh` or any other nested shell** is a child rather than a replacement: the directory stays
+  frozen while it runs, then the outer shell resumes reporting at its next prompt.
+- **A shell running inside tmux** needs the block *and* a tmux setting. tmux is a terminal emulator rather
+  than a passthrough, so the pane shell's report goes to tmux, which forwards it to agterm only with its
+  `osc7` terminal feature on — and its default `terminal-features` does not grant that to `xterm-ghostty`.
+  Add `set -as terminal-features ',xterm-ghostty:osc7'` to `~/.tmux.conf` as well, then restart the tmux
+  server.
+
+Restoring a running command has its own limit, unrelated to the block above: with **Restore running
+commands on restart** on, the captured foreground command is the wrapper's own process rather than the
+program running behind it, because that program runs on a second terminal the wrapper owns and agterm
+cannot see. Pin what such a pane should re-run with `agtermctl session restore '<command>'`, which is read
+back on `tree` and wins over the capture.
+
 ## ⌘-hover does not underline links inside tmux or vim
 
 Inside a program that has turned mouse reporting on, ⌘-hover stops underlining URLs, the pointer stays a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -177,9 +177,9 @@ Three neighbouring cases share the cause, and the block above covers all but the
   server.
 
 Restoring a running command has its own limit, unrelated to the block above: with **Restore running
-commands on restart** on, the captured foreground command is the wrapper's own process rather than the
-program running behind it, because that program runs on a second terminal the wrapper owns and agterm
-cannot see. Pin what such a pane should re-run with `agtermctl session restore '<command>'`, which is read
+commands on restart** on, a pane behind a wrapper does not come back running what it was running. The
+program is on a second terminal the wrapper owns, which agterm cannot see into, so the capture never
+reaches it. Pin what such a pane should re-run with `agtermctl session restore '<command>'`, which is read
 back on `tree` and wins over the capture.
 
 ## ⌘-hover does not underline links inside tmux or vim

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -229,8 +229,8 @@ report reaches tmux, which forwards it on only with its `osc7` terminal feature 
 `terminal-features` does not grant that to `xterm-ghostty`: add
 `set -as terminal-features ',xterm-ghostty:osc7'` to `~/.tmux.conf` and restart the tmux server.
 
-Separate limit, unrelated to the block: the captured foreground is the wrapper's own process, not the
-program behind it on the wrapper's inner pty, so restore cannot bring that program back — pin it with
+Separate limit, unrelated to the block: the program runs on the wrapper's inner pty, which agterm cannot
+see into, so the capture never reaches it and restore cannot bring that program back — pin it with
 `session restore '<command>'` instead.
 
 ### "⌘-hover does not underline links inside tmux or vim"

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -208,6 +208,31 @@ refocus click is not forwarded into the pty), so the terminal is not at fault. T
 anthropics/claude-code#72188 (mouse-click variant #72273). Workaround: answer before switching away, or
 `Esc` the stuck prompt and let it re-ask.
 
+### "Every session restores to the directory it was created in"
+
+NOT an agterm bug when a shell wrapper is in play. agterm learns a session's cwd only from OSC 7, reported
+by Ghostty's shell integration, which is injected into the shell agterm spawns and does NOT survive that
+shell replacing itself. A `.zshrc` that `exec`s a wrapper (Amazon Q CLI, Kiro CLI, Fig) replaces it before
+the first prompt, so `currentCwd` is never written and every cwd consumer falls back to the creation
+directory: restore, the directory under the session name, `session reveal`, and `{AGT_SESSION_PWD}`.
+Confirm with `cd` then `agtermctl tree --json` — the session's `cwd` does not follow the `cd`. Fix in
+`.zshrc`, below the block that replaced the shell:
+`[[ -n "$GHOSTTY_RESOURCES_DIR" ]] && builtin source "$GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration"`
+(a no-op where it already loaded; bash, fish and nushell have their own files in that directory).
+
+Three neighbouring cases share the cause; the block covers all but the last. `exec zsh` at a prompt
+replaces a shell that already reported, so the cwd FREEZES at that moment rather than never being set —
+the replacement reads `.zshrc`, so the block fixes it. `sudo -E zsh` and other nested shells are children,
+not replacements: the cwd stays frozen while one runs, then the outer shell resumes at its next prompt. A shell inside tmux
+needs the block AND a tmux setting — tmux is a terminal rather than a passthrough, so the pane shell's
+report reaches tmux, which forwards it on only with its `osc7` terminal feature on, and its default
+`terminal-features` does not grant that to `xterm-ghostty`: add
+`set -as terminal-features ',xterm-ghostty:osc7'` to `~/.tmux.conf` and restart the tmux server.
+
+Separate limit, unrelated to the block: the captured foreground is the wrapper's own process, not the
+program behind it on the wrapper's inner pty, so restore cannot bring that program back — pin it with
+`session restore '<command>'` instead.
+
 ### "⌘-hover does not underline links inside tmux or vim"
 
 By design, NOT a bug. Do not file an agterm issue for it. libghostty detects links only while the

--- a/site/docs.html
+++ b/site/docs.html
@@ -3079,7 +3079,16 @@ command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' stop"
                   >›</span
                 ><strong style="color: #e6e1d7">The saved directory depends on OSC 7.</strong> It relies on Ghostty
                 shell-integration (auto-injected for zsh, bash, fish, and nu). If the working directory is never reported, a
-                session restores to the directory it was created in.
+                session restores to the directory it was created in. The integration does not survive a shell replacing itself,
+                so a startup file that
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">exec</span>s another shell — what
+                the Amazon Q CLI, Kiro CLI and Fig wrappers install — silently leaves it unreported;
+                <a
+                  href="https://github.com/umputun/agterm/blob/master/docs/troubleshooting.md#every-session-restores-to-the-directory-it-was-created-in"
+                  style="color: #6d82f3"
+                  >troubleshooting.md</a
+                >
+                has the fix.
               </li>
               <li style="font-size: 15px; line-height: 1.65; color: #cbc6bc; padding-left: 22px; position: relative">
                 <span


### PR DESCRIPTION
a shell wrapper `exec`d from `.zshrc` (Amazon Q CLI, Kiro CLI, Fig) leaves a shell without ghostty's integration, so OSC 7 never fires and `currentCwd` is never written. Every consumer then falls back to `initialCwd` with no diagnostic anywhere: restore, the directory under the session name, `session reveal`, `{AGT_SESSION_PWD}`, and new-session inheritance. It reinstates exactly the "opens in $HOME" behavior #82 and #69 were closed to fix, and the reported `cwd` carries no indication that it is stale; every consumer treats it as current.

`docs/troubleshooting.md` gets the entry: symptom list, the `agtermctl tree` check, and ghostty's own recipe for loading the integration from `.zshrc`. The bundled skill copy mirrors it, and `site/docs.html`'s existing OSC 7 restore bullet gets a clause naming the cause and a link.

The entry covers the neighbouring cases too, because they differ and one of them needed a different fix. `exec zsh` at a prompt freezes the last reported directory rather than never setting one, and the same block fixes it. A nested `sudo -E zsh` freezes it only while it runs. Under tmux you need the block **and** `set -as terminal-features ',xterm-ghostty:osc7'`, since tmux is a terminal rather than a passthrough and its default `terminal-features` does not give `xterm-ghostty` the `osc7` feature.

Also records that sourcing the integration does not bring back a running command: that program is on the wrapper's inner pty, which agterm cannot see into, so the capture never reaches it. Points at `agtermctl session restore` for that case.

Second commit files a backlog item: reading `ForegroundProcess.command`, a wrapper pane should capture the wrapper's argv and re-type it on restore, which contradicts the reporter's observed bare shell. Settling it needs the wrapper installed.

Docs only, no code. Related to #497, whose second proposal (foreground capture descending through a wrapper to a second pty) is declined: no wrapper-specific cross-pty traversal; `session restore` is the vendor-neutral override.
