### PR TITLE
fix(agent-status): refuse a hooks value the merge cannot read, and silence a regex compile error

### DIFF
--- a/agterm/AgentHooksInstaller.swift
+++ b/agterm/AgentHooksInstaller.swift
@@ -339,8 +339,9 @@ enum AgentHooksInstaller {
     // the success-alert text, calling out anything an integration could not safely update and left alone.
     private static func successText(_ outcome: InstallOutcome) -> String {
         let claudeLine = outcome.settingsSkipped
-            ? "Your ~/.claude/settings.json isn't valid JSON (or couldn't be read), so the Claude Code hooks were NOT added "
-              + "(the file was left untouched). Fix it and run this again, or add the hooks manually."
+            ? "Your ~/.claude/settings.json couldn't be safely read or merged, so the Claude Code hooks were NOT added "
+              + "(the file was left untouched). It is unreadable, not valid JSON, or has a hooks entry in a shape we "
+              + "don't recognize. Fix it and run this again, or add the hooks manually."
             : "Claude Code hooks merged into ~/.claude/settings.json."
         return """
         Scripts installed to \(destinationFolder.path).

--- a/agterm/Resources/agent-status/shell/integration.sh
+++ b/agterm/Resources/agent-status/shell/integration.sh
@@ -30,7 +30,9 @@ fi
 
 if [ -n "${ZSH_VERSION:-}" ]; then
   autoload -Uz add-zsh-hook
-  _ags_preexec() { [[ "$1" =~ $AGTERM_AGENT_RE ]] && { "$AGTERM_AGENT_BIN" active --blink; _ags_active=1; }; }
+  # the redirect stays on the match, not the whole hook: an override valid as the PCRE fish and
+  # RE_MATCH_PCRE zsh accept can be invalid here, and zsh prints the compile error once per prompt
+  _ags_preexec() { [[ "$1" =~ $AGTERM_AGENT_RE ]] 2>/dev/null && { "$AGTERM_AGENT_BIN" active --blink; _ags_active=1; }; }
   _ags_precmd()  { [[ -n "${_ags_active:-}" ]] && { "$AGTERM_AGENT_BIN" idle; unset _ags_active; }; }
   add-zsh-hook preexec _ags_preexec
   add-zsh-hook precmd  _ags_precmd
@@ -40,7 +42,7 @@ elif [ -n "${BASH_VERSION:-}" ]; then
     local cmd="${1:-$BASH_COMMAND}"               # bash-preexec passes the command as $1; a raw DEBUG trap uses $BASH_COMMAND
     [ -n "${COMP_LINE:-}" ] && return             # ignore tab-completion
     case "$cmd" in _ags_*) return ;; esac
-    if [[ "$cmd" =~ $AGTERM_AGENT_RE ]]; then
+    if [[ "$cmd" =~ $AGTERM_AGENT_RE ]] 2>/dev/null; then
       "$AGTERM_AGENT_BIN" active --blink
       _ags_active=1
     fi

--- a/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
+++ b/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
@@ -17,7 +17,7 @@ public enum AgentHooksInstall {
     /// spawned from inside a session inherits the spawner's `AGTERM_*` environment, so its hooks would repaint
     /// the SPAWNER's row. The adapter answers that ownership question from process topology and delegates,
     /// keeping the Claude-specific knowledge in the hook resource the way the Codex adapter does.
-    public static let claudeWrapperName = "agterm-claude-status.sh"
+    static let claudeWrapperName = "agterm-claude-status.sh"
 
     /// The bundled Pi extension's path relative to the agent-status package, and its destination filename.
     public static let piExtensionRelativePath = "pi/agterm-status.ts"
@@ -113,17 +113,18 @@ public enum AgentHooksInstall {
     ///
     /// `existing` is the current contents (nil/empty = start from a fresh object). Returns the new JSON and
     /// whether it differs; idempotent — hooks already present (detected by the adapter command) return the
-    /// input with `changed == false`. Unrelated hooks and keys are preserved; invalid JSON throws. Entries a
+    /// input with `changed == false`. Unrelated hooks and keys are preserved; invalid JSON, and a `hooks` or
+    /// written-event value of the wrong shape, throw rather than overwrite what could not be read. Entries a
     /// PRIOR install pointed straight at the generic wrapper are migrated onto the Claude adapter first, so
     /// the ownership guard reaches an existing install rather than only a fresh one.
     public static func mergeClaudeSettings(existing: String?, scriptDir: String) throws -> (json: String, changed: Bool) {
         let command = wrapperCommand(scriptDir: scriptDir)
         var root = try parsedObject(existing)
 
-        var hooks = root["hooks"] as? [String: Any] ?? [:]
+        var hooks = try claudeHooksObject(root)
         var didChange = migrateClaudeEntriesToAdapter(&hooks, scriptDir: scriptDir)
         for hook in claudeHooks {
-            var entries = hooks[hook.event] as? [[String: Any]] ?? []
+            var entries = hooks[hook.event] as? [[String: Any]] ?? [] // shape already checked above
             if entries.contains(where: { entryUsesWrapper($0, scriptDir: scriptDir) }) {
                 continue
             }
@@ -345,7 +346,7 @@ public enum AgentHooksInstall {
         scriptDir + "/" + codexWrapperName
     }
 
-    public static func claudeWrapperPath(scriptDir: String) -> String {
+    static func claudeWrapperPath(scriptDir: String) -> String {
         scriptDir + "/" + claudeWrapperName
     }
 
@@ -395,9 +396,11 @@ public enum AgentHooksInstall {
     // is Codex-only), so an existing settings.json would keep its unguarded entries forever.
     //
     // The match is BYTE-EXACT against the command this installer generates for that same event — the quoted
-    // wrapper path plus the state — which is what makes the rewrite safe: a hand-edited entry, an entry
-    // carrying extra flags, and a user's own hook that merely mentions the wrapper all fail the comparison and
-    // are left alone, and only the command string is replaced, so a matcher and any sibling keys survive.
+    // wrapper path plus the state — which is what makes the rewrite safe: an entry carrying extra flags and a
+    // user's own hook that merely mentions the wrapper both fail the comparison and are left alone, and only
+    // the command string is replaced, so a matcher and any sibling keys survive. One hand edit is NOT left
+    // alone: deleting `--blink` from UserPromptSubmit reproduces the pre-`a9e678d9` form byte for byte, so it
+    // migrates and the flag returns; the installer's `.bak` is the recovery.
     // Idempotent, because a migrated entry names the adapter and no longer matches.
     private static func migrateClaudeEntriesToAdapter(_ hooks: inout [String: Any], scriptDir: String) -> Bool {
         let generated = shellQuote(wrapperPath(scriptDir: scriptDir)) + " "
@@ -459,6 +462,18 @@ public enum AgentHooksInstall {
 
     // absent/empty/whitespace-only → fresh empty object; a non-empty file that is not a valid JSON object →
     // throw rather than silently discard the user's file.
+    // a wrong-TYPED value is not an absent one: `as?` plus an empty default would read it as missing and then
+    // write over it, deleting the key the merge could not understand. Only the four events this merge writes
+    // are checked; an unrelated event of any shape is never read and round-trips.
+    private static func claudeHooksObject(_ root: [String: Any]) throws -> [String: Any] {
+        guard let value = root["hooks"] else { return [:] }
+        guard let hooks = value as? [String: Any] else { throw MergeError.malformedExistingSettings }
+        for hook in claudeHooks where hooks[hook.event] != nil {
+            guard hooks[hook.event] is [[String: Any]] else { throw MergeError.malformedExistingSettings }
+        }
+        return hooks
+    }
+
     private static func parsedObject(_ text: String?) throws -> [String: Any] {
         guard let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [:] }
         guard let data = text.data(using: .utf8),

--- a/agtermCore/Tests/agtermCoreTests/AgentHooksInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AgentHooksInstallTests.swift
@@ -232,6 +232,27 @@ struct AgentHooksInstallTests {
         }
     }
 
+    @Test func mergeRefusesWrongShapedHooksValue() {
+        // `as? ... ?? [:]` treated a wrong-typed value as absent and wrote over it, so the merge deleted the
+        // very key it could not read; the .bak made that recoverable, not safe
+        #expect(throws: AgentHooksInstall.MergeError.self) {
+            try AgentHooksInstall.mergeClaudeSettings(existing: #"{"hooks": "nope"}"#, scriptDir: scriptDir)
+        }
+        #expect(throws: AgentHooksInstall.MergeError.self) {
+            try AgentHooksInstall.mergeClaudeSettings(existing: #"{"hooks": [1, 2]}"#, scriptDir: scriptDir)
+        }
+    }
+
+    @Test func mergeRefusesWrongShapedEventValue() {
+        for malformed in [#"{"hooks": {"Stop": "nope"}}"#,
+                          #"{"hooks": {"Stop": [1, 2]}}"#,
+                          #"{"hooks": {"Stop": {"command": "x"}}}"#] {
+            #expect(throws: AgentHooksInstall.MergeError.self) {
+                try AgentHooksInstall.mergeClaudeSettings(existing: malformed, scriptDir: scriptDir)
+            }
+        }
+    }
+
     @Test func mergeWhitespaceOnlyStartsFresh() throws {
         // a whitespace-only file has no content to lose, so it starts fresh like an empty file
         let result = try AgentHooksInstall.mergeClaudeSettings(existing: "   \n\t\n", scriptDir: scriptDir)
@@ -459,11 +480,8 @@ struct AgentHooksInstallTests {
     }
 
     @Test func fishIntegrationExportsAnExistingAgentRegexOverride() throws {
-        // the export must run on BOTH branches of the set -q guard: an override set before sourcing —
-        // in the `set -g` form this file itself documented until the adapter consumed the value —
-        // satisfies set -q with the export bit off, so only a re-export on that branch gets it into
-        // the adapter's environment. Exporting just the default is the inverted shape this pins
-        // against: that value duplicates the adapter's literal list and needs no export at all.
+        // asserting the re-export line alone passes with the guard inverted, which silently swaps the two
+        // branches and replaces a user's override with the default, so pin the polarity and the order too
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -471,8 +489,21 @@ struct AgentHooksInstallTests {
             .deletingLastPathComponent()
         let fish = root.appendingPathComponent("agterm/Resources/agent-status/shell/integration.fish")
         let text = try String(contentsOf: fish, encoding: .utf8)
-        #expect(text.contains("set -gx AGTERM_AGENT_RE $AGTERM_AGENT_RE"),
-                "integration.fish must re-export a pre-existing AGTERM_AGENT_RE override")
+        let code = text.split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        guard let guardIndex = code.firstIndex(of: "if set -q AGTERM_AGENT_RE") else {
+            Issue.record("integration.fish must guard the regex block with `if set -q AGTERM_AGENT_RE`")
+            return
+        }
+        let block = Array(code[guardIndex...].prefix(5))
+        #expect(block.count == 5)
+        #expect(block[1] == "set -gx AGTERM_AGENT_RE $AGTERM_AGENT_RE",
+                "the set branch must re-export the override the user set before sourcing")
+        #expect(block[2] == "else")
+        #expect(block[3].hasPrefix("set -gx AGTERM_AGENT_RE '^("),
+                "the else branch must export the default")
+        #expect(block[4] == "end")
     }
 
     @Test func shippedShellIntegrationsOmitLifecycleAgentsFromDefaultRegex() throws {

--- a/agtermCore/Tests/agtermCoreTests/ClaudeStatusHookTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ClaudeStatusHookTests.swift
@@ -162,6 +162,35 @@ struct ClaudeStatusHookTests {
         #expect(result.exit == 0)
     }
 
+    @Test func isAgentCoversTheShippedDefaultRegexNames() throws {
+        // the script's own comment states this invariant in prose and round 1 of #461 shipped it broken:
+        // a name added to the default regex and forgotten here stops counting that agent as a spawner
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let integration = try String(contentsOf: root
+            .appendingPathComponent("agterm/Resources/agent-status/shell/integration.sh"), encoding: .utf8)
+        guard let alternation = integration
+            .components(separatedBy: "AGTERM_AGENT_RE:=^(").dropFirst().first?
+            .components(separatedBy: ")").first, !alternation.isEmpty else {
+            Issue.record("integration.sh must define the default AGTERM_AGENT_RE as an anchored alternation")
+            return
+        }
+        let hookText = try String(contentsOf: URL(fileURLWithPath: Self.hook), encoding: .utf8)
+        guard let arm = hookText.components(separatedBy: "case \"$1\" in ").dropFirst().first?
+            .components(separatedBy: ")").first else {
+            Issue.record("agterm-claude-status.sh must classify agents with a `case \"$1\" in ... )` arm")
+            return
+        }
+        let literals = Set(arm.components(separatedBy: "|").map { $0.trimmingCharacters(in: .whitespaces) })
+        // subset, never equality: the arm also carries the hook-driven agents, which the regex must not
+        for name in alternation.components(separatedBy: "|") {
+            #expect(literals.contains(name), "is_agent must count \(name) from integration.sh's default regex")
+        }
+    }
+
     @Test func outsideAgtermExitsSilently() throws {
         // no session id: nothing to address, and a hook must never fail the turn it fired from
         let result = try run(chain: ["login", "claude"], args: ["completed", "--auto-reset"], sessionID: nil)

--- a/site/docs.html
+++ b/site/docs.html
@@ -2840,6 +2840,8 @@
               matching <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">AGTERM_AGENT_RE</span> runs;
               the default set is gemini, cursor-agent, aider, crush, goose), four Claude Code hooks (prompt → active,
               tool run → active, Stop → completed, permission prompt → blocked), and an OpenCode lifecycle plugin.
+              When Claude Code runs as a worker under another agent, its hooks stay silent, so the status of the pane
+              that spawned it is not overwritten.
             </p>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               The scripts go to


### PR DESCRIPTION
follow-ups from the #461 review, all maintainer-side. One is a data-loss fix that the review turned up
late and did not belong on the contributor's branch.

**the merge could overwrite a hooks value it could not read**

`mergeClaudeSettings` read `hooks`, and each of the four events it writes, with `as?` and an empty
default, so a wrong-typed value was indistinguishable from an absent one and the merge wrote over it. A
hand-edited `"hooks": "nope"` lost the whole key. A `"Stop"` holding anything but an array of objects
lost that event. The `.bak` made this recoverable, not safe.

Both shapes now throw `malformedExistingSettings`, which `AgentHooksInstaller` already handles by
leaving the file untouched and showing the manual instructions. Only the four events this merge writes
are checked, so an unrelated event of any shape still round-trips.

The install alert claimed the file "isn't valid JSON", which `{"hooks": "nope"}` is, so it would have
sent the user hunting for a syntax error that isn't there. It now names all three causes.

**a PCRE override printed a compile error before every zsh prompt**

`AGTERM_AGENT_RE` is documented as overridable, and fish and zsh under `RE_MATCH_PCRE` both accept PCRE.
That expression is invalid as the ERE `integration.sh` matches with. Bash returns 2 quietly; zsh prints
`failed to compile regex` from a preexec hook, so it appears before every prompt. The Claude adapter
already suppressed the identical construct.

The redirect goes on the match, not the whole hook, so an error from the status wrapper still reaches
the user. Exit status is unchanged: 2 for an invalid expression, 1 for no match, 0 for a match.

**two invariants had no test that could fail**

The fish export test asserted only that the re-export line was present, so flipping `if set -q` to
`if not set -q` kept it green while swapping the branches, which drops a user's override and exports the
default in its place. It now pins the block's shape and order.

Nothing bound the adapter's `is_agent` literals to `integration.sh`'s default regex either, though the
script's own comment states the invariant and #461 shipped it broken once. That test asserts a subset
rather than equality, since the arm also carries the hook-driven agents the default regex omits.

Each new pin was checked by mutation: reverting the guard polarity and dropping a name from the case arm
each fail their test, and passed before this change.

**smaller**

`claudeWrapperName` and `claudeWrapperPath` lose `public`. Neither has a caller outside agtermCore, the
tests reach them through `@testable`, and the same pass in ca75136 narrowed `wrapperPath` and
`codexWrapperPath` on this file. Both arrived in d020a50 and no tag carries them.

`site/docs.html` now says a worker's hooks stay silent, which someone whose spawned agent stopped
updating the row had nowhere to read. The migration comment claimed every hand-edited entry fails the
byte comparison; deleting `--blink` from `UserPromptSubmit` reproduces the pre-`a9e678d9` form exactly,
so that one edit migrates and the flag comes back.

Related to #461.
