### PR TITLE
Three follow-ups from the PR 492 review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Building needs macOS 14 or later, Xcode 26 with `xcodegen` on `PATH`, and Homebr
 scripts/setup.sh
 ```
 
-It builds `GhosttyKit.xcframework` and the ghostty resources from upstream ghostty source at a pinned commit, which needs the `zig@0.15` keg and Xcode's Metal Toolchain (downloaded automatically on the first run). It takes a few minutes. Later runs skip the build once the artifacts are present, so day-to-day work pays nothing.
+It builds `GhosttyKit.xcframework` and the ghostty resources from upstream ghostty source at a pinned commit, which needs the `zig@0.16` keg and Xcode's Metal Toolchain (downloaded automatically on the first run). It takes a few minutes. Later runs skip the build once the artifacts are present, so day-to-day work pays nothing.
 
 After that:
 

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -181,7 +181,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     var deckActive = true
 
     /// Whether this surface's deck slot is on-screen (session selected, not hidden by a full overlay/scratch).
-    /// UNLIKE `deckActive` it is NOT focus-gated, so both panes of a visible split are `deckVisible`.
+    /// Unlike `deckActive` it is not split-pane-focus-gated, so both panes of a visible split are
+    /// `deckVisible`; it still drops while the quick terminal owns focus to suppress AppKit mouse routing.
     /// Load-bearing for drag-and-drop: every surface is eagerly realized, and SwiftUI's `.opacity(0)`/
     /// `.allowsHitTesting(false)` never reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and
     /// drag-destination resolution does NOT consult `hitTest`), so with every surface registered a file drop

--- a/agtermUITests/ClipboardPromptUITests.swift
+++ b/agtermUITests/ClipboardPromptUITests.swift
@@ -34,6 +34,10 @@ final class ClipboardPromptUITests: ControlAPITestCase {
 
     private func base64(_ value: String) -> String { Data(value.utf8).base64EncodedString() }
 
+    private func occurrences(of needle: String, in text: String) -> Int {
+        text.components(separatedBy: needle).count - 1
+    }
+
     /// Type a `printf '<body>'` line into `target` and wait for the named clipboard sheet to appear,
     /// retrying the injection (a freshly realized shell can drop the first keystrokes; a re-emitted OSC 52
     /// from the same surface just coalesces into the one prompt). Returns the Allow/Deny sheet buttons.
@@ -82,9 +86,14 @@ final class ClipboardPromptUITests: ControlAPITestCase {
         let secret = "SECRETREADXYZ"
         setSystemClipboard(secret)
         let deny = try emitOSC52(printfBody: "\\033]52;c;?\\007", sheetButton: "Deny", target: id)
+        // The shell has already echoed the typed `printf` command, which itself contains `52;c;`. Count that
+        // baseline before clicking so only the terminal's later empty OSC 52 response can satisfy the poll.
+        let responseCountBefore = occurrences(of: "52;c;", in: try sessionText(target: id))
         deny.click()
         // deny delivers an EMPTY OSC 52 response, so the shell echoes "52;c;" with no clipboard base64.
-        let buffer = pollSessionText(target: id, timeout: 6) { $0.contains("52;c;") && !$0.contains(self.base64(secret)) }
+        let buffer = pollSessionText(target: id, timeout: 6) {
+            self.occurrences(of: "52;c;", in: $0) > responseCountBefore && !$0.contains(self.base64(secret))
+        }
         XCTAssertNotNil(buffer, "a denied read must not deliver the clipboard base64 (\(base64(secret)))")
     }
 


### PR DESCRIPTION
three follow-ups from reviewing #492, none of them touching behavior.

**the OSC 52 denial test could not fail.** `testReadPromptDenyWithholdsClipboard` polled for `$0.contains("52;c;") && !$0.contains(base64)`. The command it types is `printf '\033]52;c;?\007'`, and the tty echoes that line before the shell runs it, so `52;c;` is already in the buffer when polling starts. The command echo alone satisfies both halves, so the assertion passes even if the denial reply never reaches the pty. It now requires a NEW response after the typed command, so it fails on a missing denial reply and on leaked clipboard data alike. This is the only end-to-end check that a denied read withholds the clipboard.

**`deckVisible`'s doc contradicted its own expression.** It read "UNLIKE `deckActive` it is NOT focus-gated", but the ordinary deck gate includes `!quickTerminal.holdsKey`, which is focus ownership.

**`CONTRIBUTING.md` still asked for the `zig@0.15` keg.** `scripts/setup.sh` has pinned `zig@0.16` since a3641c6. It is the first file a new contributor reads and the only surface still saying the old line.

no behavior change in any of the three.
