### PR TITLE
Record the libghostty pin couplings the 492 review surfaced

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -9,6 +9,7 @@ paths:
   - "agterm/Views/SplitRatioAccessor.swift"
   - "agterm/Views/TerminalView.swift"
   - "agterm/Views/TerminalSearchBar.swift"
+  - "scripts/setup.sh"
 ---
 
 ## libghostty gotchas
@@ -43,6 +44,12 @@ paths:
   present after the hide edge rebuilds the swap chain and only an upstream fix can re-release it; the
   hidden janitor sweeps only the layer's retained frame. Reveal draws synchronously
   (`ghostty_surface_draw`) because that sweep cleared `contents` and `refresh` merely queues a render.
+- A hidden pane also clears `needsDisplayOnBoundsChange` on libghostty's layer and restores it on
+  reveal. Without that, a window resize makes CoreAnimation display every mounted hidden pane and
+  rebuild the chain the release just freed. At `683d8db`, `Metal.init` installs one `IOSurfaceLayer`
+  for the surface renderer and sets the flag once; no later Ghostty path replaces the layer or
+  rewrites the flag. A `GHOSTTY_REV` bump has to recheck both, and that the synchronous reveal draw
+  still restores the intended visible-resize path.
 
 ## Theme and sidebar
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ C-boundary concurrency before changing the bridge.
   It sat at `4dcb09ada` (2026-04-30) from June while later builds blanked scrollback on a font-size
   increase; upstream fixed that and the case was re-verified by hand before the bump. Re-test the
   font-increase case when moving it, and check `minimum_zig_version` in `build.zig.zon` against
-  `ZIG_FORMULA` — the 0.15 to 0.16 jump came with this bump.
+  `ZIG_FORMULA`. The 0.15 to 0.16 jump came with the `0ba6250` bump, not this one.
 - `.ghostty-build-stamp` records the rev the staged artifacts came from and is what decides a rebuild.
   Presence alone would serve an xcframework built from a different rev silently, so a `GHOSTTY_REV`
   change costs everyone exactly one libghostty rebuild and nobody keeps a stale core by accident.


### PR DESCRIPTION
follow-up to #492, maintainer side, docs only.

that PR clears `needsDisplayOnBoundsChange` on libghostty's layer while a pane is renderer-hidden and restores it on reveal, because without dropping it a window resize makes CoreAnimation display every mounted hidden pane and rebuild the swap chain the release just freed. It works, and it is checked at `683d8db`: `Metal.init` installs one `IOSurfaceLayer` for the surface renderer and sets the flag once, and no later Ghostty path replaces the layer or rewrites the flag, so nothing desynchronizes from agterm mutating it.

both of those are properties of the current pin rather than of the API, so this records the coupling next to the occlusion rules. A future `GHOSTTY_REV` bump now has a written reason to recheck them, and to recheck that the synchronous reveal draw still restores the visible-resize path, instead of carrying a workaround that has quietly stopped doing anything.

it also adds `scripts/setup.sh` to that rule file's `paths`. Without it the note is scoped to files a pin bump does not touch, so the one person it is written for would never load it.

second commit, same class of defect in the same paragraph family. `CLAUDE.md` says the 0.15 to 0.16 zig jump "came with this bump", and #492 rewrote that paragraph's subject to `683d8db`, so it now credits the wrong revision. The toolchain moved with the `0ba6250` bump; #492 changed only the revision. Names the pin, so someone bisecting a zig build failure does not start at the wrong one.

no code change in either, so no behavior to verify beyond the lint.
