### PR TITLE
Harden peer chat composer detection and message input

### DIFF
--- a/cookbook/two-agent-chat/README.md
+++ b/cookbook/two-agent-chat/README.md
@@ -24,7 +24,14 @@ agterm 0.24.0 or later, which added `surface cursor`. The recipe refuses to type
 2. Copy `SKILL-claude.md` to `~/.claude/skills/peer-chat/SKILL.md` and `SKILL-codex.md` to `~/.codex/skills/peer-chat/SKILL.md`. Both loaders require the installed file to be named exactly `SKILL.md`, so the suffix here only says which agent the file is for. Each one tells its own agent how to send, how to recognise an incoming message, and what it may not do to the other pane.
 3. Edit both copies so the path they name for `peer-chat.py` matches where you put it.
 4. If you start either agent through a wrapper script rather than as `claude` or `codex`, put that wrapper's name in the same file, as the `--target-command` value the agent should pass when sending to it. Without this the first send refuses, saying the target pane is not running the expected command.
-5. Start Codex so it can tell which pane it is in. Codex strips `AGTERM_SESSION_ID` from tool subprocesses, so start it with `codex -c "shell_environment_policy.set.AGTERM_SESSION_ID=\"$AGTERM_SESSION_ID\""` to copy the current pane's session id into every tool command, adding your normal Codex options to the same command. Without this injection the script can still resolve one matching repository checkout, but it refuses when several sessions share that checkout. If you launch Codex through a wrapper, put the flag in the wrapper and it applies to every pane.
+5. To let Codex reserve and send file-backed messages without separate approvals, add these two entries to `~/.codex/rules/default.rules`, creating the file if needed and using the command name or path from step 1:
+
+   ```python
+   prefix_rule(pattern=["peer-chat.py", "--prepare-message"], decision="allow")
+   prefix_rule(pattern=["peer-chat.py", "--to", "claude", "--message-file"], decision="allow")
+   ```
+
+6. Start Codex so it can tell which pane it is in. Codex strips `AGTERM_SESSION_ID` from tool subprocesses, so start it with `codex -c "shell_environment_policy.set.AGTERM_SESSION_ID=\"$AGTERM_SESSION_ID\""` to copy the current pane's session id into every tool command, adding your normal Codex options to the same command. Without this injection the script can still resolve one matching repository checkout, but it refuses when several sessions share that checkout. If you launch Codex through a wrapper, put the flag in the wrapper and it applies to every pane.
 
 If your `agtermctl` is not on `PATH` under that name, set `AGTERMCTL` to its full path; the script reads that variable and falls back to `agtermctl`.
 
@@ -42,6 +49,20 @@ MSG
 
 `--to claude` sends the other way. `--session` names a session explicitly; without it the script uses `AGTERM_SESSION_ID` when the caller has one, and otherwise looks for a single session whose target pane is running the expected agent.
 
+Codex can keep the send as plain command arguments by using a private one-shot message file. Reserve a fresh name first:
+
+```sh
+peer-chat.py --prepare-message peer-chat-codex-a91f.txt
+```
+
+The command prints the absolute `messageFile` path. Write the UTF-8 message to that exact file without replacing its mode, then send it by name:
+
+```sh
+peer-chat.py --to claude --message-file peer-chat-codex-a91f.txt
+```
+
+This form matches the two Codex execution rules in *Setup*. A heredoc uses shell redirection, so Codex evaluates the whole request as a shell wrapper and cannot match the inner command.
+
 Before every send the script confirms that the pane it is about to type into really is running the agent named by `--to`, reading the command from agterm's own view of the pane. It looks for `claude` and `codex`. If you start an agent through a wrapper script, that name is what agterm sees instead, and the send is refused until you say so:
 
 ```sh
@@ -58,13 +79,13 @@ On success it prints `{"sent": N}` and exits 0. Any refusal or failure exits 1 w
 
 The message is typed into the other pane's composer through `agtermctl session type`, which is real typing rather than a paste, so a newline would submit a half-written line. The script collapses the message to one paragraph before sending, which is why the examples above are written as one.
 
-Two checks stand in front of every send, and they refuse for different reasons. Before a single character is typed, `agtermctl surface cursor` must report the caret at column 2, where it rests in an empty composer. Pane text cannot answer this question: both agents draw a placeholder hint in an empty box, so a hint and something you half-typed read alike, while the caret sits past the chevron whenever real text is present. A refusal here means nothing was written. After typing, the script confirms the line is visible where a message goes before it sends the submit key, so a dialog can be typed at but never answered. A refusal there means the text may still be sitting in the composer, which is why the script stops rather than retrying.
+Three checks guard every send. The script first confirms that the pane contains a recognisable composer prompt, then `agtermctl surface cursor` must report the caret at column 2, where it rests in an empty composer. The caret read is the final pre-write check. Pane text cannot prove the composer is empty: both agents draw a placeholder hint in an empty box, so a hint and something you half-typed read alike, while the caret sits past the chevron whenever real text is present. A pre-write refusal means nothing was written. After typing, the script confirms that the line is visible where a message goes before it sends the submit key, so a dialog can receive text but cannot be answered. A refusal there means the text may still be sitting in the composer, which is why the script stops instead of retrying.
 
 The two agents need different submit keys. Codex takes Tab, which queues the line as a follow-up when it is mid-turn and submits on an idle composer; Return would steer a running turn instead. Claude Code takes Return. Getting this backwards is the single easiest way to break the exchange.
 
 Messages carry a label, `Chat from Claude:` or `Chat from Codex:`, which is what lets the receiving agent read an arriving prompt as the next line of a conversation rather than as a fresh instruction from you. The script adds the label, so the skills tell each agent not to write one.
 
-`--stdin` is required rather than optional. A message passed as an argument would sit in the process list and have its punctuation mangled by the shell, so the script refuses to accept one that way at all.
+Sending requires exactly one of `--stdin` and `--message-file NAME`. Both keep the message text out of the process list and protect its punctuation from the shell. `--prepare-message NAME` creates the named file with mode 0600 in a per-user directory with mode 0700. A file-backed send resolves and checks the target session before opening the file. It accepts only a reserved basename, rejects links, non-regular files, files accessible to other users, and bodies over 64 KiB, then removes the directory entry before reading the message.
 
 The recipe deliberately does not start agents. Deciding that a pane is safe to type a startup command into means guessing from what the pane has drawn, and agterm reports no foreground process for both an idle shell and a program that hides its argv. Every prompt looks different, so that guess is wrong on somebody's machine, and being wrong means typing a command into whatever holds focus.
 
@@ -72,11 +93,13 @@ The recipe deliberately does not start agents. Deciding that a pane is safe to t
 
 **The script types into another pane's composer, and it can submit text you did not write.** The caret check is one-way evidence: a caret at column 2 rules out a draft whose cursor sits after the text, but it cannot tell an empty composer from a draft whose cursor was moved back to the start. In that state the message is inserted in front of your draft and both are submitted together. The check made after typing cannot rule that out either: only the composer's first rendered row is identifiable, so once a message wraps, anything left on a continuation row is invisible to it, in both directions. Do not leave half-written input in a pane you are about to receive a message in.
 
-**In practice it does not type into dialogs, but a short window exists where it could.** A dialog already on screen stops the send: the caret must be at rest before a single character goes anywhere. The window is only the moment between that check and the typing, which are separate `agtermctl` calls, so a chooser or trust prompt appearing inside it would receive the message text. Even then the second check fails and the submit key is withheld, so nothing is answered and no choice is confirmed, though characters reaching a picker can move its selection.
+**In practice it does not type into dialogs, but a short window exists where it could.** A dialog already on screen stops the send: the pane must contain a recognisable composer prompt and the caret must be at rest before a single character goes anywhere. The window is only the moment between the caret check and the typing, which are separate `agtermctl` calls, so a chooser or trust prompt appearing inside it would receive the message text. Even then the post-write check fails and the submit key is withheld, so nothing is answered and no choice is confirmed, though characters reaching a picker can move its selection.
 
 **The first exchange may stop and wait for you.** An agent asked to run this script may put up its own approval request before running anything, and neither skill will answer it: a permission prompt carries your authority, so both are told to leave it alone. Until you approve it in that pane, the exchange simply sits there, which looks like a hang rather than a question.
 
 **A busy composer is waited out, but only for about forty seconds.** If the other pane's composer is not confirmably empty, the script retries five times at ten-second intervals, printing each attempt to stderr, then gives up with exit 1 and types nothing. A pane left sitting on a dialog therefore costs about forty seconds before the send fails rather than blocking forever.
+
+**A multi-row Codex shortcut overlay is treated as busy.** The parser ignores one trailing status row. It does not strip a whole indented region because shortcut rows and modal choices have the same shape; the send therefore retries and refuses until a multi-row overlay closes.
 
 **Only the pre-write refusal is retried.** Nothing has been typed at that point, so trying again is safe. Every failure after the text has gone in stops on the first occurrence and is never retried, because retrying there would duplicate a message that is already sitting in the composer.
 
@@ -94,4 +117,4 @@ An agent whose launcher leaves no stable name in the pane's command line cannot 
 
 A reply is not promised. An agent's model can decline to answer a message that arrived perfectly well, and nothing on either side reports that. If an exchange goes quiet, read the other pane rather than waiting.
 
-No transcript is kept. The conversation lives in the two panes and is gone when the session ends.
+No transcript is kept. A one-shot message file remains untouched until the target session resolves. Once its identity, ownership and link checks pass, its directory entry is removed before mode, size and body validation, so those validation failures and every later send failure consume it. A prepared file that never reaches that point remains in the private spool. The conversation lives in the two panes and is gone when the session ends.

--- a/cookbook/two-agent-chat/SKILL-codex.md
+++ b/cookbook/two-agent-chat/SKILL-codex.md
@@ -18,17 +18,29 @@ The session needs both panes running, with Claude Code on the left, started by t
 never starts an agent and never opens a pane. If the left pane is not running Claude Code, say so
 and stop.
 
+File-backed sends avoid per-call approvals only when the two `peer-chat.py` command-prefix rules from
+the recipe's *Setup* section are in `~/.codex/rules/default.rules`. If they are absent, leave any
+approval to the user.
+
 ## Sending
 
 ```bash
-peer-chat.py --to claude --stdin <<'CHAT'
-the message goes here, as one paragraph
-CHAT
+peer-chat.py --prepare-message peer-chat-codex-a91f.txt
 ```
 
-Pass the message on stdin through a quoted heredoc, never as an argument. The script collapses all
-whitespace to single spaces before typing, because typing a newline submits the fragment before it,
-so write for one paragraph.
+The command creates a private one-shot file and prints its absolute `messageFile` path. Use
+`apply_patch` to fill that exact file without replacing the file or its mode, using one paragraph and
+omitting the `Chat from Codex:` label, then send the reserved name:
+
+```bash
+peer-chat.py --to claude --message-file peer-chat-codex-a91f.txt
+```
+
+Choose a fresh literal suffix for every send. Do not use stdin, a heredoc, shell redirection,
+variables or substitutions in either invocation: Codex then evaluates the request as a `zsh -lc`
+wrapper, so the two command-prefix rules from *Setup* cannot match it. Never put the message text
+directly in an argument. The send consumes the file, and the script collapses whitespace before
+typing.
 
 If a send refuses saying more than one session shares this checkout, stop. It means this Codex was
 started without its pane's session id injected, and the fix is a launch flag only the user can apply.

--- a/cookbook/two-agent-chat/peer-chat.py
+++ b/cookbook/two-agent-chat/peer-chat.py
@@ -7,23 +7,37 @@ import argparse
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import Any
 
 SUBMIT_DELAY = 0.15
-PROBE_TIMEOUT = 0.6
+# A long body takes longer than half a second to land and render in the composer.
+PROBE_TIMEOUT = 2.0
 RETRY_ATTEMPTS = 5
 RETRY_DELAY = 10.0
 BOX_LINES = 40
 EMPTY_CURSOR_COLUMN = 2
 MIN_WRAPPED_PROBE = 40
+MAX_MESSAGE_BYTES = 64 * 1024
 # Claude can put a short context label inside the top composer rule, for example `e2e`.
 RULE_RE = re.compile(r"^\s*[─\u2014-]{10,}(?:\s+[^─\u2014-].*?\s+[─\u2014-]+)?\s*$")
-CODEX_PROMPT_RE = re.compile(r"^\s*›[\s ]*(.*?)\s*$")
+# Codex draws the composer prompt as `›`; with reasoning effort set to ultra it upgrades
+# the glyph to `»` (codex-rs/tui/src/bottom_pane/effort_ignition.rs). Both prompt patterns
+# are anchored at column zero so prompt-shaped output cannot be mistaken for live input.
+# Shell mode shows `!` and is deliberately not matched, so nothing is ever typed there.
+CODEX_PROMPT_RE = re.compile(r"^[›»][\s ]*(.*?)\s*$")
+CODEX_SHELL_PROMPT_RE = re.compile(r"^![\s ]*(.*?)\s*$")
+# Codex prefixes footer rows with two spaces. Only the final row is stripped: a
+# multi-row shortcut overlay is indistinguishable from indented modal choices and
+# therefore fails closed instead of weakening the live-prompt guard.
+CODEX_FOOTER_RE = re.compile(r"^ {2}\S.*$")
 CLAUDE_PROMPT_RE = re.compile(r"^\s*❯[\s ]*(.*?)\s*$")
 PASTED_RE = re.compile(r"\[Pasted Content \d+ chars?\]")
 # loose on purpose: Claude draws "[Pasted text #16]" and "[Pasted text #1 +12 lines]", and a
@@ -31,6 +45,8 @@ PASTED_RE = re.compile(r"\[Pasted Content \d+ chars?\]")
 # whose content the box holds.
 PASTED_TEXT_RE = re.compile(r"^\[Pasted text #\d+[^\]]*\]")
 MESSAGE_FRAGMENT = 20
+MESSAGE_NAME_RE = re.compile(r"peer-chat-[a-z0-9][a-z0-9-]{2,48}\.txt")
+MESSAGE_SPOOL = Path(tempfile.gettempdir()) / f"agterm-peer-chat-{os.getuid()}"
 
 
 @dataclass(frozen=True)
@@ -222,11 +238,36 @@ def type_text(sid: str, profile: Profile, text: str) -> None:
     )
 
 
+def trailing_input_block(text: str) -> list[str]:
+    lines = text.splitlines()[-BOX_LINES:]
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if lines and CODEX_FOOTER_RE.match(lines[-1]):
+        lines.pop()
+        while lines and not lines[-1].strip():
+            lines.pop()
+    start = len(lines)
+    while start and lines[start - 1].strip():
+        start -= 1
+    return lines[start:]
+
+
 def codex_prompt_text(text: str) -> str | None:
-    for line in reversed(text.splitlines()[-BOX_LINES:]):
+    content = None
+    for line in trailing_input_block(text):
+        if CODEX_SHELL_PROMPT_RE.match(line):
+            content = None
         if match := CODEX_PROMPT_RE.match(line):
-            return match.group(1)
-    return None
+            content = match.group(1)
+    return content
+
+
+def codex_live_prompt_text(text: str) -> str | None:
+    block = trailing_input_block(text)
+    if not block or any(CODEX_SHELL_PROMPT_RE.match(line) for line in block):
+        return None
+    match = CODEX_PROMPT_RE.match(block[-1])
+    return match.group(1) if match else None
 
 
 def claude_prompt_text(text: str) -> str | None:
@@ -244,10 +285,33 @@ def claude_prompt_text(text: str) -> str | None:
     return None
 
 
+def claude_live_prompt_text(text: str) -> str | None:
+    lines = text.splitlines()[-BOX_LINES:]
+    for index in range(len(lines) - 1, -1, -1):
+        match = CLAUDE_PROMPT_RE.match(lines[index])
+        if not match:
+            continue
+        content = [match.group(1)]
+        for line in lines[index + 1 :]:
+            if RULE_RE.match(line):
+                return " ".join(part for part in content if part)
+            content.append(line.strip())
+        if index == len(lines) - 1:
+            return match.group(1)
+        return None
+    return None
+
+
 def prompt_text(profile: Profile, text: str) -> str | None:
     if profile.agent == "codex":
         return codex_prompt_text(text)
     return claude_prompt_text(text)
+
+
+def live_prompt_text(profile: Profile, text: str) -> str | None:
+    if profile.agent == "codex":
+        return codex_live_prompt_text(text)
+    return claude_live_prompt_text(text)
 
 
 def normalize(profile: Profile, message: str) -> str:
@@ -261,6 +325,7 @@ def normalize(profile: Profile, message: str) -> str:
 
 
 def composer_has_message(profile: Profile, content: str, typed: str) -> bool:
+    pasted = bool(PASTED_RE.fullmatch(content))
     if profile.agent == "claude":
         shown = " ".join(content.split())
         sent = " ".join(typed.split())
@@ -283,7 +348,7 @@ def composer_has_message(profile: Profile, content: str, typed: str) -> bool:
         )
     required = min(len(typed), MIN_WRAPPED_PROBE)
     literal = typed.startswith(content) and len(content) >= required
-    return literal or bool(PASTED_RE.fullmatch(content))
+    return literal or pasted
 
 
 def wait_for_composed(sid: str, profile: Profile, typed: str) -> str | None:
@@ -310,10 +375,22 @@ def wait_for_accepted(sid: str, profile: Profile, held: str) -> bool:
 
 def send(sid: str, profile: Profile, message: str) -> int:
     typed = normalize(profile, message)
+    pane = pane_text(sid, profile)
+    if live_prompt_text(profile, pane) is None:
+        raise PromptBlocked(
+            "target composer prompt is not recognisable (shell mode, disabled input, a "
+            "trailing modal or status row, or an unknown prompt glyph); nothing was typed"
+        )
     if cursor_column(sid, profile) != EMPTY_CURSOR_COLUMN:
         raise PromptBlocked("target composer is not confirmably empty; nothing was typed")
 
-    type_text(sid, profile, typed)
+    if profile.agent == "claude":
+        # Type the routing label on its own so it stays visible when Claude compacts the
+        # body into a paste marker.
+        type_text(sid, profile, profile.label)
+        type_text(sid, profile, typed[len(profile.label) :])
+    else:
+        type_text(sid, profile, typed)
     held = wait_for_composed(sid, profile, typed)
     if held is None:
         raise RuntimeError(
@@ -347,9 +424,108 @@ def send_with_retry(sid: str, profile: Profile, message: str) -> int:
     raise AssertionError("unreachable")
 
 
-def parse_args() -> argparse.Namespace:
+def message_name(value: str) -> str:
+    if not MESSAGE_NAME_RE.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            "message name must match peer-chat-<sender>-<suffix>.txt"
+        )
+    return value
+
+
+def private_spool_fd(create: bool) -> int:
+    if create:
+        try:
+            MESSAGE_SPOOL.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+    spool_fd = os.open(
+        MESSAGE_SPOOL,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+    )
+    info = os.fstat(spool_fd)
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+        os.close(spool_fd)
+        raise ValueError("message spool must be a private directory owned by this user")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        os.close(spool_fd)
+        raise ValueError(
+            f"message spool is accessible by other users; run chmod 700 {MESSAGE_SPOOL}"
+        )
+    return spool_fd
+
+
+def prepare_message(name: str) -> Path:
+    spool_fd = private_spool_fd(create=True)
+    try:
+        message_fd = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o600,
+            dir_fd=spool_fd,
+        )
+        os.fchmod(message_fd, 0o600)
+        os.close(message_fd)
+    finally:
+        os.close(spool_fd)
+    return MESSAGE_SPOOL / name
+
+
+def read_message(use_stdin: bool, message_file: str | None) -> str:
+    if use_stdin:
+        return sys.stdin.read()
+    if message_file is None:
+        raise ValueError("provide --stdin or --message-file NAME")
+
+    spool_fd = private_spool_fd(create=False)
+    message_fd = -1
+    try:
+        message_fd = os.open(
+            message_file,
+            os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=spool_fd,
+        )
+        info = os.fstat(message_fd)
+        entry = os.stat(message_file, dir_fd=spool_fd, follow_symlinks=False)
+        same_entry = (entry.st_dev, entry.st_ino) == (info.st_dev, info.st_ino)
+        is_owned_regular = (
+            same_entry
+            and stat.S_ISREG(info.st_mode)
+            and info.st_uid == os.getuid()
+            and info.st_nlink == 1
+        )
+        if is_owned_regular:
+            os.unlink(message_file, dir_fd=spool_fd)
+        if not is_owned_regular:
+            raise ValueError("message file must be an owned regular file with one link")
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            raise ValueError(
+                "message file is accessible by other users and was consumed; "
+                "run --prepare-message again"
+            )
+        if info.st_size > MAX_MESSAGE_BYTES:
+            raise ValueError(
+                f"message file exceeds {MAX_MESSAGE_BYTES} bytes and was consumed; "
+                "run --prepare-message again"
+            )
+
+        with os.fdopen(message_fd, encoding="utf-8") as stream:
+            message_fd = -1
+            message = stream.read(MAX_MESSAGE_BYTES + 1)
+        if len(message.encode("utf-8")) > MAX_MESSAGE_BYTES:
+            raise ValueError(
+                f"message file exceeds {MAX_MESSAGE_BYTES} bytes and was consumed; "
+                "run --prepare-message again"
+            )
+        return message
+    finally:
+        if message_fd >= 0:
+            os.close(message_fd)
+        os.close(spool_fd)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--to", choices=PROFILES, required=True)
+    parser.add_argument("--to", choices=PROFILES)
     parser.add_argument("--session")
     parser.add_argument(
         "--target-command",
@@ -357,16 +533,40 @@ def parse_args() -> argparse.Namespace:
         metavar="NAME",
         help="target agent executable or wrapper name",
     )
-    parser.add_argument("--stdin", action="store_true", required=True)
-    return parser.parse_args()
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--stdin", action="store_true")
+    source.add_argument(
+        "--message-file",
+        type=message_name,
+        metavar="NAME",
+        help="consume a prepared UTF-8 message from the private spool",
+    )
+    source.add_argument(
+        "--prepare-message",
+        type=message_name,
+        metavar="NAME",
+        help="create a private one-shot message file and print its path",
+    )
+    args = parser.parse_args(argv)
+    if args.prepare_message:
+        if args.to or args.session or args.target_command:
+            parser.error("--prepare-message does not accept target options")
+    elif not args.to:
+        parser.error("--to is required when sending")
+    return args
 
 
 def main() -> int:
     args = parse_args()
     try:
+        if args.prepare_message:
+            path = prepare_message(args.prepare_message)
+            print(json.dumps({"messageFile": str(path)}))
+            return 0
         profile = target_profile(args.to, args.target_command)
         sid = resolve_session(args.session, profile)
-        sent = send_with_retry(sid, profile, sys.stdin.read())
+        message = read_message(args.stdin, args.message_file)
+        sent = send_with_retry(sid, profile, message)
         print(json.dumps({"sent": sent}))
         return 0
     except KeyboardInterrupt:

--- a/cookbook/two-agent-chat/test_peer_chat.py
+++ b/cookbook/two-agent-chat/test_peer_chat.py
@@ -1,15 +1,34 @@
 #!/usr/bin/env python3
 """Regression checks for the two-agent chat composer parser."""
 
+import argparse
+import io
+import os
 import runpy
+import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 SCRIPT = runpy.run_path(Path(__file__).with_name("peer-chat.py"))
 CLAUDE_PROMPT_TEXT = SCRIPT["claude_prompt_text"]
+CODEX_PROMPT_TEXT = SCRIPT["codex_prompt_text"]
 COMPOSER_HAS_MESSAGE = SCRIPT["composer_has_message"]
-CLAUDE_PROFILE = SCRIPT["PROFILES"]["claude"]
+LIVE_PROMPT_TEXT = SCRIPT["live_prompt_text"]
+MAIN = SCRIPT["main"]
+MAX_MESSAGE_BYTES = SCRIPT["MAX_MESSAGE_BYTES"]
+MESSAGE_NAME = SCRIPT["message_name"]
+PASTED_RE = SCRIPT["PASTED_RE"]
+PROFILES = SCRIPT["PROFILES"]
+PROMPT_BLOCKED = SCRIPT["PromptBlocked"]
+SEND = SCRIPT["send"]
+CLAUDE_PROFILE = PROFILES["claude"]
+PARSE_ARGS = SCRIPT["parse_args"]
+PREPARE_MESSAGE = SCRIPT["prepare_message"]
+READ_MESSAGE = SCRIPT["read_message"]
 RULE = "─" * 40
+CODEX_FOOTER = "  repo · master · gpt-5.6 high · Context 0% used"
 
 
 class ClaudePromptTextTests(unittest.TestCase):
@@ -68,6 +87,138 @@ class ClaudePromptTextTests(unittest.TestCase):
 
         self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
 
+    def test_wrapped_box_needs_no_closing_rule(self) -> None:
+        screen = (
+            "older output\n"
+            "❯ Chat from Codex: a wrapped message\n"
+            "  with a continuation"
+        )
+
+        self.assertEqual(
+            CLAUDE_PROMPT_TEXT(screen),
+            "Chat from Codex: a wrapped message with a continuation",
+        )
+
+    def test_live_wrapped_box_without_closing_rule_is_refused(self) -> None:
+        screen = (
+            "older output\n"
+            "❯ Chat from Codex: a wrapped message\n"
+            "  with a continuation"
+        )
+
+        self.assertIsNone(LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen))
+
+    def test_live_stale_prompt_under_a_dialog_is_refused(self) -> None:
+        screen = "❯ previous user prompt\nAllow this command?\n  1. Yes\n  2. No"
+
+        self.assertIsNone(LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen))
+
+
+class CodexPromptTextTests(unittest.TestCase):
+    def test_default_glyph(self) -> None:
+        screen = f"› Chat from Claude: ping\n{CODEX_FOOTER}"
+
+        self.assertEqual(CODEX_PROMPT_TEXT(screen), "Chat from Claude: ping")
+
+    def test_ultra_effort_glyph(self) -> None:
+        screen = f"» [Pasted Content 1868 chars]\n{CODEX_FOOTER}"
+
+        self.assertEqual(CODEX_PROMPT_TEXT(screen), "[Pasted Content 1868 chars]")
+
+    def test_empty_composer_placeholder(self) -> None:
+        screen = f"» Ask Codex to do anything\n{CODEX_FOOTER}"
+
+        self.assertEqual(CODEX_PROMPT_TEXT(screen), "Ask Codex to do anything")
+
+    def test_shell_mode_is_not_a_prompt(self) -> None:
+        screen = f"! ls -la\n{CODEX_FOOTER}"
+
+        self.assertIsNone(CODEX_PROMPT_TEXT(screen))
+
+    def test_live_shell_blocks_an_older_composer(self) -> None:
+        screen = (
+            "› earlier prompt\n"
+            "  some response output\n"
+            "! ls -la\n"
+            "  shell mode active"
+        )
+
+        self.assertIsNone(CODEX_PROMPT_TEXT(screen))
+
+    def test_prompt_shaped_shell_output_is_not_a_composer(self) -> None:
+        screen = f"! printf output\n  › fake output\n{CODEX_FOOTER}"
+
+        self.assertIsNone(CODEX_PROMPT_TEXT(screen))
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
+
+    def test_live_prompt_is_adjacent_to_the_footer(self) -> None:
+        screen = f"» Ask Codex to do anything\n\n{CODEX_FOOTER}"
+
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(PROFILES["codex"], screen),
+            "Ask Codex to do anything",
+        )
+
+    def test_live_prompt_accepts_configurable_footers(self) -> None:
+        footers = (
+            "  repo · master · gpt-5.6 high",
+            "  Context 100% left · repo · master",
+            "  Context 0% used · repo · master",
+            "  Context 100% left",
+            "  gpt-5.6 high",
+        )
+
+        for footer in footers:
+            with self.subTest(footer=footer):
+                screen = f"» Ask Codex to do anything\n{footer}"
+                self.assertEqual(
+                    LIVE_PROMPT_TEXT(PROFILES["codex"], screen),
+                    "Ask Codex to do anything",
+                )
+
+    def test_transcript_history_above_live_prompt_is_ignored(self) -> None:
+        screen = (
+            "› earlier prompt\n"
+            "response output\n"
+            "! old shell transcript\n"
+            "old shell output\n"
+            "\n"
+            "» Ask Codex to do anything\n"
+            "\n"
+            f"{CODEX_FOOTER}"
+        )
+
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(PROFILES["codex"], screen),
+            "Ask Codex to do anything",
+        )
+
+    def test_unrecognised_trailing_row_is_not_live(self) -> None:
+        screen = "» Ask Codex to do anything\nkey hint whose layout is unknown"
+
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
+
+    def test_dialog_without_a_footer_is_not_live(self) -> None:
+        screen = (
+            "› previous user prompt\n"
+            "Approval required\n"
+            "  1. Allow\n"
+            "  2. Deny"
+        )
+
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
+
+    def test_stale_prompt_under_a_dialog_is_not_live(self) -> None:
+        screen = (
+            "› previous user prompt\n"
+            "Approval required\n"
+            "  1. Allow\n"
+            "  2. Deny\n"
+            f"{CODEX_FOOTER}"
+        )
+
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
+
 
 class ComposerHasMessageTests(unittest.TestCase):
     def test_label_leading_summary_keeps_opening_body_fragment(self) -> None:
@@ -79,6 +230,12 @@ class ComposerHasMessageTests(unittest.TestCase):
     def test_label_leading_row_without_opening_body_fragment_is_refused(self) -> None:
         typed = "Chat from Codex: opening transport fragment and more text"
         shown = "Chat from Codex: unrelated composer content"
+
+        self.assertFalse(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
+
+    def test_label_leading_bare_paste_marker_is_refused(self) -> None:
+        typed = "Chat from Codex: opening transport fragment and more text"
+        shown = "Chat from Codex: [Pasted text #16]"
 
         self.assertFalse(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
 
@@ -105,6 +262,209 @@ class ComposerHasMessageTests(unittest.TestCase):
                 self.assertFalse(
                     COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed)
                 )
+
+    def test_codex_accepts_paste_marker(self) -> None:
+        typed = "Chat from Claude: " + "x" * 2000
+
+        self.assertTrue(
+            COMPOSER_HAS_MESSAGE(
+                PROFILES["codex"], "[Pasted Content 2018 chars]", typed
+            )
+        )
+
+    def test_codex_requires_literal_prefix(self) -> None:
+        typed = "Chat from Claude: ping pong " + "x" * 40
+
+        self.assertTrue(COMPOSER_HAS_MESSAGE(PROFILES["codex"], typed[:45], typed))
+        self.assertFalse(COMPOSER_HAS_MESSAGE(PROFILES["codex"], "Chat from", typed))
+        self.assertFalse(
+            COMPOSER_HAS_MESSAGE(PROFILES["codex"], "something else", typed)
+        )
+
+
+class PastedMarkerTests(unittest.TestCase):
+    def test_codex_marker(self) -> None:
+        self.assertTrue(PASTED_RE.fullmatch("[Pasted Content 1 char]"))
+        self.assertTrue(PASTED_RE.fullmatch("[Pasted Content 1868 chars]"))
+
+    def test_claude_marker_is_checked_separately(self) -> None:
+        self.assertIsNone(PASTED_RE.fullmatch("[Pasted text #1 +12 lines]"))
+
+    def test_other_brackets_are_not_markers(self) -> None:
+        self.assertIsNone(PASTED_RE.fullmatch("[Image #1]"))
+
+
+class SendPreflightTests(unittest.TestCase):
+    def test_prompt_is_checked_before_cursor(self) -> None:
+        pane_text = Mock(return_value=f"! ls -la\n{CODEX_FOOTER}")
+        cursor_column = Mock(return_value=2)
+        replacements = {
+            "pane_text": pane_text,
+            "cursor_column": cursor_column,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaises(
+            PROMPT_BLOCKED
+        ):
+            SEND("session-id", PROFILES["codex"], "ping")
+
+        pane_text.assert_called_once()
+        cursor_column.assert_not_called()
+
+
+class MessageInputTests(unittest.TestCase):
+    def test_private_message_is_consumed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            name = "peer-chat-codex-a91f.txt"
+            replacements = {"MESSAGE_SPOOL": spool}
+            with patch.dict(PREPARE_MESSAGE.__globals__, replacements):
+                path = PREPARE_MESSAGE(name)
+                self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+                path.write_text("a message\nwith two lines\n", encoding="utf-8")
+
+                args = PARSE_ARGS(["--to", "claude", "--message-file", name])
+
+                self.assertFalse(args.stdin)
+                self.assertEqual(
+                    READ_MESSAGE(args.stdin, args.message_file),
+                    "a message\nwith two lines\n",
+                )
+                self.assertFalse(path.exists())
+                self.assertEqual(spool.stat().st_mode & 0o777, 0o700)
+
+    def test_world_readable_message_is_rejected_and_consumed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            name = "peer-chat-codex-b82d.txt"
+            with patch.dict(PREPARE_MESSAGE.__globals__, {"MESSAGE_SPOOL": spool}):
+                path = PREPARE_MESSAGE(name)
+                path.write_text("private text", encoding="utf-8")
+                path.chmod(0o644)
+
+                with self.assertRaisesRegex(ValueError, "--prepare-message again"):
+                    READ_MESSAGE(False, name)
+
+                self.assertFalse(path.exists())
+
+    def test_oversized_message_is_rejected_and_consumed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            name = "peer-chat-codex-c73e.txt"
+            with patch.dict(PREPARE_MESSAGE.__globals__, {"MESSAGE_SPOOL": spool}):
+                path = PREPARE_MESSAGE(name)
+                path.write_text("x" * (MAX_MESSAGE_BYTES + 1), encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, "--prepare-message again"):
+                    READ_MESSAGE(False, name)
+
+                self.assertFalse(path.exists())
+
+    def test_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spool = root / "spool"
+            name = "peer-chat-codex-d64f.txt"
+            with patch.dict(PREPARE_MESSAGE.__globals__, {"MESSAGE_SPOOL": spool}):
+                path = PREPARE_MESSAGE(name)
+                path.unlink()
+                secret = root / "secret.txt"
+                secret.write_text("secret", encoding="utf-8")
+                path.symlink_to(secret)
+
+                with self.assertRaises(OSError):
+                    READ_MESSAGE(False, name)
+
+                self.assertEqual(secret.read_text(encoding="utf-8"), "secret")
+
+    def test_non_regular_message_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            name = "peer-chat-codex-e55a.txt"
+            with patch.dict(PREPARE_MESSAGE.__globals__, {"MESSAGE_SPOOL": spool}):
+                spool.mkdir(mode=0o700)
+                path = spool / name
+                os.mkfifo(path, mode=0o600)
+
+                with self.assertRaisesRegex(ValueError, "regular file"):
+                    READ_MESSAGE(False, name)
+
+                self.assertTrue(path.exists())
+
+    def test_multiply_linked_message_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            name = "peer-chat-codex-f46b.txt"
+            with patch.dict(PREPARE_MESSAGE.__globals__, {"MESSAGE_SPOOL": spool}):
+                path = PREPARE_MESSAGE(name)
+                path.write_text("private text", encoding="utf-8")
+                second_link = spool / "second-link"
+                second_link.hardlink_to(path)
+
+                with self.assertRaisesRegex(ValueError, "one link"):
+                    READ_MESSAGE(False, name)
+
+                self.assertTrue(path.exists())
+                self.assertTrue(second_link.exists())
+
+    def test_message_name_rejects_paths(self) -> None:
+        with self.assertRaisesRegex(argparse.ArgumentTypeError, "message name"):
+            MESSAGE_NAME("../secret.txt")
+
+    def test_public_spool_error_names_the_mode_repair(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            spool.mkdir()
+            spool.chmod(0o755)
+            name = "peer-chat-codex-h28d.txt"
+            replacements = {"MESSAGE_SPOOL": spool}
+
+            with (
+                patch.dict(PREPARE_MESSAGE.__globals__, replacements),
+                self.assertRaisesRegex(ValueError, r"chmod 700 .*/spool"),
+            ):
+                PREPARE_MESSAGE(name)
+
+    def test_prepare_mode_needs_no_target(self) -> None:
+        args = PARSE_ARGS(["--prepare-message", "peer-chat-codex-g37c.txt"])
+
+        self.assertEqual(args.prepare_message, "peer-chat-codex-g37c.txt")
+        self.assertIsNone(args.to)
+
+    def test_stdin_mode_remains_available(self) -> None:
+        args = PARSE_ARGS(["--to", "codex", "--stdin"])
+
+        self.assertTrue(args.stdin)
+        self.assertIsNone(args.message_file)
+
+    def test_target_refusal_preserves_prepared_message(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spool = Path(directory) / "spool"
+            name = "peer-chat-codex-j04f.txt"
+            replacements = {"MESSAGE_SPOOL": spool}
+            with patch.dict(PREPARE_MESSAGE.__globals__, replacements):
+                path = PREPARE_MESSAGE(name)
+                path.write_text("message to retry", encoding="utf-8")
+                args = argparse.Namespace(
+                    prepare_message=None,
+                    stdin=False,
+                    message_file=name,
+                    to="claude",
+                    session=None,
+                    target_command=None,
+                )
+                main_replacements = {
+                    "parse_args": Mock(return_value=args),
+                    "resolve_session": Mock(side_effect=RuntimeError("no target")),
+                }
+
+                with (
+                    patch.dict(MAIN.__globals__, main_replacements),
+                    redirect_stderr(io.StringIO()),
+                ):
+                    self.assertEqual(MAIN(), 1)
+
+                self.assertEqual(path.read_text(encoding="utf-8"), "message to retry")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Codex draws its composer prompt as `›`, but the glyph changes to `»` at ultra reasoning effort. The peer-chat parser matched only `›`, so it could type a long message into an ultra session, fail to recognise the compacted composer content and withhold submission.

This change:

- recognises both Codex prompt glyphs and configurable two-column-indented status lines;
- treats a newer column-zero `!` shell prompt, a multi-row shortcut overlay or an unknown trailing UI row as a pre-write refusal;
- reads pane text before the caret check, leaving the caret as the final pre-write sample;
- keeps master's Claude post-write parser byte-identical while applying stricter dialog refusal through a separate live-prompt parser;
- preserves master's 20-character Claude body-fragment verification while typing the routing label separately;
- accepts both agents' compacted-paste forms and allows two seconds for a long body to render.

The branch also adds private file-backed input for Codex callers. A heredoc is evaluated as a shell wrapper and cannot match a `peer-chat.py` execution rule, while a reserved basename keeps both invocations matchable without exposing message text in process arguments. Prepared files use a mode-0700 per-user spool and mode-0600 one-shot entries. Target and session resolution completes before the file is opened, so an unrelated target refusal preserves it for retry. Once identity, ownership and link checks pass, the entry is removed before mode, size and body validation. Setup includes two narrow Codex execution rules for reserving and sending these files.

Known limitations:

- Post-type verification confirms a 40-character Codex prefix or a 20-character Claude body fragment, so it can miss a dropped middle segment in a long message. Chunked typing with per-chunk verification is outside this patch.
- A multi-row Codex shortcut overlay is treated as busy. Stripping every indented row would also strip modal choices, so the send fails closed until the overlay closes.

Checks:

- `python3 cookbook/two-agent-chat/test_peer_chat.py` (44 tests)
- `python3 cookbook/codex-session-resume/test_codex_resume.py` (7 tests)
- `find cookbook -type f -name '*.py' -print0 | xargs -0 ruff check --ignore EXE001`
- Reinstating the shared Claude parser fails both live-prompt refusal tests; moving `read_message` ahead of target resolution fails `test_target_refusal_preserves_prepared_message`.
- `codex execpolicy check` accepts both documented file-backed command prefixes.
