### PR TITLE
fix(cookbook): find the live Claude composer in two-agent-chat

### DIFF
--- a/cookbook/two-agent-chat/peer-chat.py
+++ b/cookbook/two-agent-chat/peer-chat.py
@@ -26,6 +26,11 @@ RULE_RE = re.compile(r"^\s*[─\u2014-]{10,}(?:\s+[^─\u2014-].*?\s+[─\u2014-
 CODEX_PROMPT_RE = re.compile(r"^\s*›[\s ]*(.*?)\s*$")
 CLAUDE_PROMPT_RE = re.compile(r"^\s*❯[\s ]*(.*?)\s*$")
 PASTED_RE = re.compile(r"\[Pasted Content \d+ chars?\]")
+# loose on purpose: Claude draws "[Pasted text #16]" and "[Pasted text #1 +12 lines]", and a
+# precise pattern would refuse an unseen variant. The body fragment below is what proves
+# whose content the box holds.
+PASTED_TEXT_RE = re.compile(r"^\[Pasted text #\d+[^\]]*\]")
+MESSAGE_FRAGMENT = 20
 
 
 @dataclass(frozen=True)
@@ -226,12 +231,16 @@ def codex_prompt_text(text: str) -> str | None:
 
 def claude_prompt_text(text: str) -> str | None:
     lines = text.splitlines()[-BOX_LINES:]
-    for index in range(len(lines) - 1, 0, -1):
+    for index in range(len(lines) - 1, -1, -1):
         match = CLAUDE_PROMPT_RE.match(lines[index])
-        if not match or not RULE_RE.match(lines[index - 1]):
+        if not match:
             continue
-        if any(RULE_RE.match(line) for line in lines[index + 1 :]):
-            return match.group(1)
+        content = [match.group(1)]
+        for line in lines[index + 1 :]:
+            if RULE_RE.match(line):
+                break
+            content.append(line.strip())
+        return " ".join(part for part in content if part)
     return None
 
 
@@ -253,7 +262,25 @@ def normalize(profile: Profile, message: str) -> str:
 
 def composer_has_message(profile: Profile, content: str, typed: str) -> bool:
     if profile.agent == "claude":
-        return content.startswith(profile.label)
+        shown = " ".join(content.split())
+        sent = " ".join(typed.split())
+        label = profile.label.strip()
+        if not sent.startswith(label):
+            return False
+        if not (shown.startswith(label) or PASTED_TEXT_RE.match(shown)):
+            return False
+
+        body = sent[len(label) :].lstrip()
+        if not body:
+            return False
+        if shown.startswith(label):
+            return body[:MESSAGE_FRAGMENT] in shown
+
+        fragment_len = min(MESSAGE_FRAGMENT, len(body))
+        return any(
+            body[start : start + fragment_len] in shown
+            for start in range(len(body) - fragment_len + 1)
+        )
     required = min(len(typed), MIN_WRAPPED_PROBE)
     literal = typed.startswith(content) and len(content) >= required
     return literal or bool(PASTED_RE.fullmatch(content))

--- a/cookbook/two-agent-chat/test_peer_chat.py
+++ b/cookbook/two-agent-chat/test_peer_chat.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 SCRIPT = runpy.run_path(Path(__file__).with_name("peer-chat.py"))
 CLAUDE_PROMPT_TEXT = SCRIPT["claude_prompt_text"]
+COMPOSER_HAS_MESSAGE = SCRIPT["composer_has_message"]
+CLAUDE_PROFILE = SCRIPT["PROFILES"]["claude"]
 RULE = "─" * 40
 
 
@@ -21,10 +23,88 @@ class ClaudePromptTextTests(unittest.TestCase):
 
         self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
 
-    def test_rule_after_prompt_is_required(self) -> None:
+    def test_wrapped_box_needs_no_rule_above(self) -> None:
+        screen = (
+            "older output\n"
+            "❯ Chat from Codex: a wrapped message\n"
+            "  with a continuation\n"
+            f"{RULE}"
+        )
+
+        self.assertEqual(
+            CLAUDE_PROMPT_TEXT(screen),
+            "Chat from Codex: a wrapped message with a continuation",
+        )
+
+    def test_latest_prompt_wins_over_an_older_ruled_prompt(self) -> None:
+        screen = (
+            f"{RULE}\n"
+            "❯ Chat from Codex: old\n"
+            f"{RULE}\n"
+            "older response\n"
+            "❯ Chat from Codex: current\n"
+            "  continuation\n"
+            f"{RULE}"
+        )
+
+        self.assertEqual(
+            CLAUDE_PROMPT_TEXT(screen),
+            "Chat from Codex: current continuation",
+        )
+
+    def test_labelled_rule_terminates_a_wrapped_box(self) -> None:
+        screen = (
+            "older output\n"
+            "❯ Chat from Codex: wrapped\n"
+            "  tail\n"
+            f"{RULE} e2e ─\n"
+            "  UMBP: agterm [master]"
+        )
+
+        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: wrapped tail")
+
+    def test_rule_after_prompt_is_not_required(self) -> None:
         screen = f"{RULE} e2e ─\n❯ Chat from Codex: ping"
 
-        self.assertIsNone(CLAUDE_PROMPT_TEXT(screen))
+        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
+
+
+class ComposerHasMessageTests(unittest.TestCase):
+    def test_label_leading_summary_keeps_opening_body_fragment(self) -> None:
+        typed = "Chat from Codex: opening transport fragment and more text"
+        shown = "Chat from Codex: opening transport fragment [Pasted text #16]"
+
+        self.assertTrue(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
+
+    def test_label_leading_row_without_opening_body_fragment_is_refused(self) -> None:
+        typed = "Chat from Codex: opening transport fragment and more text"
+        shown = "Chat from Codex: unrelated composer content"
+
+        self.assertFalse(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
+
+    def test_summary_leading_row_keeps_later_body_fragment(self) -> None:
+        typed = (
+            "Chat from Codex: opening transport fragment followed by a later "
+            "acceptance fragment in the body"
+        )
+        shown = "[Pasted text #7 +12 lines] later acceptance fragment"
+
+        self.assertTrue(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
+
+    def test_singular_line_count_summary_is_accepted(self) -> None:
+        typed = "Chat from Codex: opening transport fragment and later acceptance text"
+        shown = "[Pasted text #7 +1 line] later acceptance text"
+
+        self.assertTrue(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
+
+    def test_summary_only_row_is_refused(self) -> None:
+        typed = "Chat from Codex: opening transport fragment and more text"
+
+        for shown in ("[Pasted text #7]", "[Pasted text #7 +12 lines]"):
+            with self.subTest(shown=shown):
+                self.assertFalse(
+                    COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed)
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
refreshes the two-agent-chat recipe with some of the improvements from the local version I actually use.

`claude_prompt_text` depended on a decorative rule directly above the chevron and returned only the first row, so a send to the Claude pane was typed and then refused with `message was typed but not verified in the target composer`. It now takes the newest chevron, joins continuation rows and uses a rule only to end the box.

the Claude-side verification now accepts label-leading and `[Pasted text #N]` renderings when they keep a 20-character body fragment. A summary with no fragment is still refused because it does not identify the message.

related to #502
