### PR TITLE
docs(skill): write every command in the summary with its area prefix

### DIFF
--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -135,8 +135,9 @@ Scripts rarely type ids: create with `*.new` (capture the returned id), or act o
 
 **Agents: `active` is almost never your own session.** `active` is the session the USER has selected in
 the GUI; your shell runs in `$AGTERM_SESSION_ID`, and the user is usually on a different session while
-you work. For any session-scoped command meant to act on *this* session — `overlay open`, `scratch`,
-`type`, `text`, `background`, `status`, `copy`, … — pass `--target "$AGTERM_SESSION_ID"`. Omit it and
+you work. For any session-scoped command meant to act on *this* session — `session overlay open`,
+`session scratch`, `session type`, `session text`, `session background`, `session status`, `session copy`,
+… — pass `--target "$AGTERM_SESSION_ID"`. Omit it and
 you open overlays / type into whatever the user has selected, not your own session.
 
 ## Launching a program in a session
@@ -182,10 +183,10 @@ spec — image/text watermark or solid color — set via `session background`, o
 seen` — omitted when zero), `commandWait` (whether a `--command` session was created with `--wait` to
 hold open after the command exits — the read side of `session new --wait`, omitted for a plain or
 non-holding session), `overlaySizePercent` (an open overlay's floating-panel percent 1–100,
-omitted for a full-pane overlay or no overlay so gate on `overlay` first; the read side of `overlay
-resize` for a record-then-restore zoom), `paneOverlays` (the panes covered by their own overlay —
-`["left"]`, `["right"]` or `["left","right"]`, omitted when neither is; the read side of `overlay open
---pane`, independent of the session-wide `overlay` flag),
+omitted for a full-pane overlay or no overlay so gate on `overlay` first; the read side of `session
+overlay resize` for a record-then-restore zoom), `paneOverlays` (the panes covered by their own overlay —
+`["left"]`, `["right"]` or `["left","right"]`, omitted when neither is; the read side of `session overlay
+open --pane`, independent of the session-wide `overlay` flag),
 `hud` (the message panel occupying the session-wide slot — `{message, detail?, spinner, backgroundColor?,
 textColor?, sizePercent?, heightPercent?, position}`, the two percents being the panel's width and height
 shares — omitted when none is up; the read side of `session hud`. `position` and `spinner`
@@ -226,36 +227,38 @@ given. Use `--json` for one bare event object per line; filter with repeatable o
 one process run. Cursor run changes, expiry, and ahead-of-tail errors are fatal and are never silently
 rebaselined. There is no terminal-output event stream.
 
-**workspace** — `new [name] [--collapsed]` (`--collapsed` creates it closed in the sidebar so you can fill
+**workspace** — `workspace new [name] [--collapsed]` (`--collapsed` creates it closed in the sidebar so you can fill
 it with `session new --no-select` without it opening, and keeps it out of the focus set; a plain create
-joins the marked set while the filter is applied, so it is visible) · `rename <name>` · `delete` · `select` ·
-`go --to next|prev` (step the CURRENT workspace one place through the sidebar's visible order, wrapping,
+joins the marked set while the filter is applied, so it is visible) · `workspace rename <name>` ·
+`workspace delete` · `workspace select` ·
+`workspace go --to next|prev` (step the CURRENT workspace one place through the sidebar's visible order, wrapping,
 and select the first session of the one it lands on — relative, so no `--target`, and unaffected by
-whether a workspace is collapsed; `move` REORDERS instead) ·
-`move --to up|down|top|bottom` ·
-`focus [on|off|toggle|add]` (mark ONE workspace in the sidebar's focus set — `on` marks it alone and
+whether a workspace is collapsed; `workspace move` REORDERS instead) ·
+`workspace move --to up|down|top|bottom` ·
+`workspace focus [on|off|toggle|add]` (mark ONE workspace in the sidebar's focus set — `on` marks it alone and
 applies the filter, `off` unmarks it, `toggle` (default) replace-toggles, and `add` marks it alongside
 the others WITHOUT switching the filter on; read membership back from the tree workspace node's
 `focused` flag) ·
-`filter [on|off|toggle]` (apply or suspend that filter for the whole window WITHOUT losing the marked
+`workspace filter [on|off|toggle]` (apply or suspend that filter for the whole window WITHOUT losing the marked
 set — no `--target`; read it back from the tree top-level `workspaceFilter`. Build a working set with
-repeated `focus add`, then apply it once with `filter on`; a workspace row renders iff
+repeated `workspace focus add`, then apply it once with `workspace filter on`; a workspace row renders iff
 `sidebarVisible && sidebarMode == "tree" && (!workspaceFilter || focused)` — no workspace row renders at
 all with the sidebar hidden or in `flagged` mode, the whole tree renders while the filter is off, and
-only while it is on does visibility narrow to the members — and `filter on` with nothing marked is
+only while it is on does visibility narrow to the members — and `workspace filter on` with nothing marked is
 refused so the pair can never lie) ·
-`collapse [--target W] [--window W]` · `expand [--target W] [--window W]` (collapse/expand ONE workspace
+`workspace collapse [--target W] [--window W]` · `workspace expand [--target W] [--window W]` (collapse/expand ONE workspace
 in the sidebar tree — the per-workspace pair, distinct from the all-workspace `sidebar expand`/`collapse`;
 read the open/closed state back from the tree workspace node's `collapsed` flag, `true` when collapsed and
 omitted when expanded).
 
 **session**
-- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select]` —
+- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select]` —
   create (and focus) a session. Target the workspace by id/prefix (`--workspace`) OR by name
   (`--workspace-name`, mutually exclusive); add `--create-workspace` to reuse-or-create the named
   workspace when absent. `--command` runs that program as the session process instead of a login shell
   (argv-only, and with the app's GUI `PATH` — a Homebrew/non-default binary needs an absolute path or a
-  `zsh -lc '…'` wrapper, else exit 127; same caveat for `scratch --command` and `overlay open` below);
+  `zsh -lc '…'` wrapper, else exit 127; same caveat for `session scratch --command` and `session overlay
+  open` below);
   `--wait` (with `--command`, else an error) HOLDS the session open after the command exits, showing the
   press-any-key prompt with the final output intact instead of closing (persists across restart, unlike an
   overlay's live-only wait; read back on `tree`'s `commandWait`);
@@ -265,64 +268,64 @@ omitted when expanded).
   create right after the current session. `--no-select` creates the session in the BACKGROUND — it is
   added to the sidebar but NOT selected or focused, leaving the current selection untouched (the new node
   is not `active` in `tree`); omit it for the default select-and-focus behavior.
-- `duplicate [--target]` — create a fresh session (a plain login shell) in the target's workspace, right
+- `session duplicate [--target]` — create a fresh session (a plain login shell) in the target's workspace, right
   after it, rooted at the target's focused-pane cwd; selects + focuses it and returns the new id. ONLY the
   directory carries over — no custom name, command, split, scratch, status, flag, font size, or background.
   Equivalent to `session new --cwd <source cwd> --after <source>` in one round-trip. Read it back from
   `tree`: the new node sits directly after its source carrying the source's focused-pane cwd (equal to the
   source node's `tree.cwd` unless the source is a split focused off its primary pane, where `tree.cwd`
   reports the primary).
-- `close [--target T ...]` — close one session, or repeat `--target` to close a batch with one
+- `session close [--target T ...]` — close one session, or repeat `--target` to close a batch with one
   grace-period undo.
-- `select` · `rename <name>` · `reveal` (select the focused pane's cwd in Finder).
-- `go --to next|prev|first|last|next-attention|prev-attention` — move the selection between sessions.
-- `move <workspace>` (relocate) or `move --to up|down|top|bottom` (reorder within the workspace) or
-  `move --after SID | --before SID` (place after/before an anchor session; the anchor carries its own
+- `session select` · `session rename <name>` · `session reveal` (select the focused pane's cwd in Finder).
+- `session go --to next|prev|first|last|next-attention|prev-attention` — move the selection between sessions.
+- `session move <workspace>` (relocate) or `session move --to up|down|top|bottom` (reorder within the
+  workspace) or `session move --after SID | --before SID` (place after/before an anchor session; the anchor carries its own
   workspace, so this relocates + positions in one shot, even cross-workspace). For workspace and
   after/before placement, repeat `--target` to move several sessions as one ordered block. Do not repeat
   `--target` with `--to up|down|top|bottom`.
 - Shared pane selectors accept `primary`/`left`/`top` for the primary pane and
   `split`/`right`/`bottom` for the split pane. Commands supporting scratch also accept `scratch`.
   Syntax and read-back use canonical `left`/`right`/`scratch`; the invalid-value error keeps those names.
-- `type <text> [--stdin] [--select] [--pane left|right|scratch]` — inject keystrokes (real typing, Enter
+- `session type <text> [--stdin] [--select] [--pane left|right|scratch]` — inject keystrokes (real typing, Enter
   included) into the main pane, the split pane with `--pane right`, or the scratch terminal (even hidden)
   with `--pane scratch`. Pass `--target "$AGTERM_SESSION_ID"` to type into YOUR session, not the user's
   active one (see Addressing). Like `session text`, every `--pane` addresses the surface UNDER a covering
   overlay — by design, so a pane stays drivable whatever is drawn over it — meaning text typed while one is
   open runs in the hidden shell and is invisible until it closes. There is no write twin of
   `session overlay text`: an overlay runs the caller's own program, so nothing types into one.
-- `copy` — print the session's selected text (does NOT touch the system clipboard).
-- `paste` — paste the system clipboard into the session (the socket analogue of ⌘V; read it back with
+- `session copy` — print the session's selected text (does NOT touch the system clipboard).
+- `session paste` — paste the system clipboard into the session (the socket analogue of ⌘V; read it back with
   `session text`).
-- `select-all` — select the session's entire terminal buffer (the socket analogue of ⌘A; read the
+- `session select-all` — select the session's entire terminal buffer (the socket analogue of ⌘A; read the
   selection back with `session copy`).
-- `text [--all] [--lines N] [--pane left|right|scratch]` — print the session buffer as plain text. Default
+- `session text [--all] [--lines N] [--pane left|right|scratch]` — print the session buffer as plain text. Default
   is the visible screen of the focused pane; `--pane scratch` reads the scratch terminal even while hidden;
   `--all` adds scrollback; `--lines N` keeps the last N lines.
-- `search [needle] [--next|--prev|--close]` — search the terminal scrollback; prints the "N of M" counter.
-- `split [on|off|toggle] [--axis vertical|horizontal]` · `split close` - second shell, left/right by
+- `session search [needle] [--next|--prev|--close]` — search the terminal scrollback; prints the "N of M" counter.
+- `session split [on|off|toggle] [--axis vertical|horizontal]` · `session split close` - second shell, left/right by
   default or top/bottom with `--axis horizontal`. Omitting `--axis` preserves the current axis and the
   legacy left/right behavior. The GUI actions are ⌘D for vertical and ⌘⇧D for horizontal; either
   transposes a shown split of the other orientation. Hide keeps it alive; `close` destroys the pane and
   whatever runs in it.
-- `scratch [on|off|toggle] [--command CMD]` — full-coverage third shell (hide keeps it alive; `exit`
+- `session scratch [on|off|toggle] [--command CMD]` — full-coverage third shell (hide keeps it alive; `exit`
   recreates). `--command` (when showing) runs a program instead of a shell, run-once like `session new
   --command` (respawns the scratch if one is open). Target your own session with
   `--target "$AGTERM_SESSION_ID"` (see Addressing).
-- `focus [primary|split|left|right|top|bottom|other]` - move focus between split panes. Role and position
+- `session focus [primary|split|left|right|top|bottom|other]` - move focus between split panes. Role and position
   aliases select the same two live terminals; readback remains `left`/`right`.
-- `resize --split-ratio R | --grow-left D | --grow-right D | --grow-primary D | --grow-split D | --grow-top D | --grow-bottom D` - move the split divider (the GUI only drags
+- `session resize --split-ratio R | --grow-left D | --grow-right D | --grow-primary D | --grow-split D | --grow-top D | --grow-bottom D` - move the split divider (the GUI only drags
   it, or double-clicks it for an even split; bind any other fraction via a
   `command "agtermctl session resize …"` custom action). `--split-ratio` sets
   the absolute primary-pane fraction (left or top; 0..1, clamped to 0.05..0.95). The grow options are
   aliases for growing the primary or split pane. Prints the applied fraction.
-- `status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--color #rrggbb] [--shape SHAPE] [--pane left|right|scratch] [--pane-id TOKEN]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound; `--color` tints the glyph for this call only, reverting on the next status set without it; `--shape` (`circle`, `square`, `triangle`, `diamond`, `capsule`, `star`) picks its silhouette for this call only and reverts the same way, read back as the tree `statusShape` field; `--pane` records which pane set it — `left`=main, `right`=split, `scratch` — so foreground typing in another pane won't clear it and any user-initiated GUI selection (auto-follow, attention-nav ⌃⌥↑/↓, plain session nav, the command palettes, a Dock-menu session, a sidebar row click) reveals that pane when the status needs attention (`blocked`/`completed`); `active` preserves the existing pane selection; the pane reads back as the tree `statusPane` field; the socket `session go next-attention` only steps the selection, it does not itself reveal the pane; `--pane-id` is the hook-forwarded stable surface token (`$AGTERM_PANE_ID`) that resolves the pane's live slot and overrides a stale `--pane` after a promote + re-split — scripts set `--pane` directly and leave `--pane-id` to the hook).
-- `flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).
-- `seen [--target] [--window W]` — clear the session's unseen-notification badge WITHOUT changing the
+- `session status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--color #rrggbb] [--shape SHAPE] [--pane left|right|scratch] [--pane-id TOKEN]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound; `--color` tints the glyph for this call only, reverting on the next status set without it; `--shape` (`circle`, `square`, `triangle`, `diamond`, `capsule`, `star`) picks its silhouette for this call only and reverts the same way, read back as the tree `statusShape` field; `--pane` records which pane set it — `left`=main, `right`=split, `scratch` — so foreground typing in another pane won't clear it and any user-initiated GUI selection (auto-follow, attention-nav ⌃⌥↑/↓, plain session nav, the command palettes, a Dock-menu session, a sidebar row click) reveals that pane when the status needs attention (`blocked`/`completed`); `active` preserves the existing pane selection; the pane reads back as the tree `statusPane` field; the socket `session go next-attention` only steps the selection, it does not itself reveal the pane; `--pane-id` is the hook-forwarded stable surface token (`$AGTERM_PANE_ID`) that resolves the pane's live slot and overrides a stale `--pane` after a promote + re-split — scripts set `--pane` directly and leave `--pane-id` to the hook).
+- `session flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).
+- `session seen [--target] [--window W]` — clear the session's unseen-notification badge WITHOUT changing the
   selection or focus (the focus-free counterpart to `notify`, which raises the badge). Idempotent — a
   no-op when already zero. Read the current count from the tree node's `unseen` field. Use it so an
   orchestrator can acknowledge a driven session's notifications without pulling focus to it.
-- `restore ("cmd" | --none | --clear) [--pane left|right] [--pane-id TOKEN]` — pin what a pane re-runs on
+- `session restore ("cmd" | --none | --clear) [--pane left|right] [--pane-id TOKEN]` — pin what a pane re-runs on
   the NEXT launch, overriding the captured foreground command. A `"cmd"` shell line pins it, `--none` pins
   nothing (a plain shell), `--clear` drops the override back to auto-capture. Written now, consumed on the
   next launch (it never touches the running session), and STICKY — fires again on every restart until
@@ -335,40 +338,40 @@ omitted when expanded).
   `SessionStart` hook rewrites the override to the live id on every start so the next restart reattaches
   instead of forking. The pinned value is shell code stored in the state file and readable via `tree`, so
   it must not carry secrets. See examples.md.
-- `background image <path> [--opacity F] [--fit contain|cover|stretch|none] [--position P] [--repeat]` ·
-  `background text <text> [--color #rrggbb] [--opacity F] [--fit ...] [--position ...]` ·
-  `background color <#rrggbb>` · `background clear` — composite an image (PNG/JPEG) or rasterized text
+- `session background image <path> [--opacity F] [--fit contain|cover|stretch|none] [--position P] [--repeat]` ·
+  `session background text <text> [--color #rrggbb] [--opacity F] [--fit ...] [--position ...]` ·
+  `session background color <#rrggbb>` · `session background clear` — composite an image (PNG/JPEG) or rasterized text
   behind the terminal as a watermark (auto-fitting the window, re-fits on resize), or set a solid
   terminal background color. Per session; survives restart. `--opacity` 0.0–1.0. (An image/text watermark
   renders the pane opaque, overriding window translucency, so it shows; a `color` takes no opacity and
   honors the Settings window translucency instead.)
-- `overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--background-color #rrggbb] [--follow] [--pane left|right]` ·
-  `overlay resize (--size-percent N | --full)` ·
-  `overlay close [--pane left|right]` ·
-  `overlay result [--pane left|right]` ·
-  `overlay copy [--pane left|right]` ·
-  `overlay text [--all] [--lines N] [--pane left|right]` — run a program on top of a session; `--block`
+- `session overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--background-color #rrggbb] [--follow] [--pane left|right]` ·
+  `session overlay resize (--size-percent N | --full)` ·
+  `session overlay close [--pane left|right]` ·
+  `session overlay result [--pane left|right]` ·
+  `session overlay copy [--pane left|right]` ·
+  `session overlay text [--all] [--lines N] [--pane left|right]` — run a program on top of a session; `--block`
   waits and exits with its status.
-  `overlay copy` returns the selection made INSIDE the overlay and `overlay text` its terminal buffer:
+  `session overlay copy` returns the selection made INSIDE the overlay and `session overlay text` its terminal buffer:
   `session copy` and `session text` both address the pane the overlay COVERS, so a selection made in the
   overlay reads there as `no selection` and `session text --pane right` returns the shell underneath.
   Reach for them when the read is NOT chord-driven — polling from outside, or reading some time after the
   fact. A chord already gets the firing surface's selection synchronously in `$AGT_SELECTION`, the
   overlay's included, so a custom command should use that rather than a later socket read.
-  `overlay text` returns a TUI's drawn screen wrapped as rendered — for a program's OUTPUT, still prefer
+  `session overlay text` returns a TUI's drawn screen wrapped as rendered — for a program's OUTPUT, still prefer
   its own output file.
-  `overlay resize` changes an ALREADY-OPEN overlay: `--size-percent N` (1-100) makes it a floating panel,
+  `session overlay resize` changes an ALREADY-OPEN overlay: `--size-percent N` (1-100) makes it a floating panel,
   `--full` switches it back to the full-pane overlay; the program keeps running (no re-spawn).
   `--pane left|right` scopes the overlay to ONE split pane instead of the whole session, leaving the
   sibling pane live and interactive; left and right are independent and may both be open at once. A pane
-  overlay is ALWAYS full-pane, so `--pane` cannot combine with `--size-percent` and `overlay resize`
+  overlay is ALWAYS full-pane, so `--pane` cannot combine with `--size-percent` and `session overlay resize`
   takes no `--pane`. Everything else is identical to the session-wide overlay. A non-split session
   accepts `--pane left` (it reports `AGTERM_PANE=left`), so you can pass `--pane "$AGTERM_PANE"` without checking
   the split state; a pane that is not currently rendered is refused with `pane not visible` — a SHOWN
   split renders both panes, a HIDDEN one renders only the FOCUSED pane, so the refused one is the pane
   that does not have focus.
   Target with `--target "$AGTERM_SESSION_ID"` for YOUR session (default `active` is the user's selection).
-  **By default `overlay open` does NOT switch the user** — full and floating (`--size-percent N`, 1-100)
+  **By default `session overlay open` does NOT switch the user** — full and floating (`--size-percent N`, 1-100)
   both open on `--target` and run their program in the background; the panel appears when the user visits
   that session. **Pass `--follow` to select the target after opening** (a no-op if it is already active):
   use `--follow` when you want the user pulled to the overlay, omit it to open quietly on your own or
@@ -376,14 +379,14 @@ omitted when expanded).
   `--background-color` gives the overlay pane its own solid color, independent of the session's. An
   overlay is a real terminal (pty), which is also how you **display an image inline** — via the bundled
   `scripts/show-image.sh` (see below).
-- `hud [open] <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N]` ·
-  `hud update <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--text-color #rrggbb] [--size-percent N]` ·
-  `hud close` — post a small **passive** panel over the session saying what you are doing
+- `session hud [open] <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N]` ·
+  `session hud update <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--text-color #rrggbb] [--size-percent N]` ·
+  `session hud close` — post a small **passive** panel over the session saying what you are doing
   ("gathering options…"). Unlike an overlay it takes no input and steals nothing: the session keeps first
   responder, the user keeps typing, and the terminal behind it is neither dimmed nor click-blocked. Use it
   for the seconds an agent needs before it can show something (computing picker items, waiting on a slow
-  command), then take it down. `open` is the default subcommand, so `hud "…"` posts; a message that is
-  literally `update` or `close` needs the explicit `hud open` verb. `--detail` adds a dim second line,
+  command), then take it down. `open` is the default subcommand, so `session hud "…"` posts; a message that is
+  literally `update` or `close` needs the explicit `session hud open` verb. `--detail` adds a dim second line,
   `--spinner` animates a glyph in the default `bar` style and `--spinner-style bar|braille|circle|blocks|dot`
   picks another, turning the spinner on by itself (`dot` blinks instead of animating, for a panel up for
   minutes; an update may switch style in place). `--spinner-style none` is accepted and leaves the panel
@@ -397,27 +400,29 @@ omitted when expanded).
   panel, not a square one. `--size-percent N` (1-100) overrides the WIDTH only, bounded to 10-80% of the
   pane, since a message must never cover the session it is about, so a requested 100 reads back as 80. The
   height always follows the message. `--text-color` colors the panel's TEXT and `--background-color` its
-  backing, independently. `hud update` repaints in place with no re-spawn and no blink,
+  backing, independently. `session hud update` repaints in place with no re-spawn and no blink,
   and REPLACES the whole spec — repeat `--detail`/`--spinner`/`--text-color` to keep them, since an omitted
   one drops. It takes no `--background-color`: the surface reads that once at creation, so only a fresh
-  `hud` changes it and `tree` keeps reporting the creation color across updates, while the text color rides
+  `session hud` changes it and `tree` keeps reporting the creation color across updates, while the text color rides
   the panel's body file and an update recolors it in place. Message and detail are capped at 256 characters and reject control characters, newline included.
-  It occupies the SAME slot as `overlay open`, so: a second `hud` replaces the first, `overlay open`
-  replaces a HUD (a running program is never replaced), `overlay close` and ⌘W take a HUD down,
-  `overlay result` refuses with `no overlay result: the slot holds a hud`, `overlay resize --size-percent`
+  It occupies the SAME slot as `session overlay open`, so: a second `session hud` replaces the first,
+  `session overlay open` replaces a HUD (a running program is never replaced), `session overlay close`
+  and ⌘W take a HUD down, `session overlay result` refuses with
+  `no overlay result: the slot holds a hud`, `session overlay resize --size-percent`
   works on it while `--full` is refused (`a hud is always floating: pass --size-percent, not --full`),
-  and `surface zoom` will not address it. `hud update`/`hud close` with none up answer `no hud`. Read it
+  and `surface zoom` will not address it. `session hud update`/`session hud close` with none up answer `no hud`. Read it
   back from the tree node's `hud` object; nothing announces it as an event, so poll `tree`.
 
-**window** — `new [name] [--minimized]` · `list` · `select <id>` · `close <id>` · `rename <id> <name>` ·
-`delete <id>` · `resize <id> --width W --height H` · `move <id> --x X --y Y [--display N]` ·
-`zoom <id>` (maximize-to-screen toggle, the double-click-header gesture; a plain green-button click does full screen) ·
-`fullscreen <id>` (toggle native macOS full screen, the green-button / ⌃⌘F action) ·
-`minimize <id> [on|off|toggle]` (minimize to the Dock or restore, the ⌘M / yellow-button action; default
+**window** — `window new [name] [--minimized]` · `window list` · `window select <id>` · `window close <id>` ·
+`window rename <id> <name>` ·
+`window delete <id>` · `window resize <id> --width W --height H` · `window move <id> --x X --y Y [--display N]` ·
+`window zoom <id>` (maximize-to-screen toggle, the double-click-header gesture; a plain green-button click does full screen) ·
+`window fullscreen <id>` (toggle native macOS full screen, the green-button / ⌃⌘F action) ·
+`window minimize <id> [on|off|toggle]` (minimize to the Dock or restore, the ⌘M / yellow-button action; default
 `toggle`, the id may be omitted so `window minimize on` targets the active window; errors on a full-screen
 window; read back as `minimized` on `window list`).
 
-**surface** — `zoom [show|hide|toggle] [--target surface:<session-id>:left|right|scratch|overlay|overlay-left|overlay-right|quick] [--window W]`
+**surface** — `surface zoom [show|hide|toggle] [--target surface:<session-id>:left|right|scratch|overlay|overlay-left|overlay-right|quick] [--window W]`
 — zoom a terminal surface to fill the window (sidebar hidden; a slim title-bar strip with an exit
 button remains). Omit `--target` to use the active surface;
 copy an explicit surface id from `tree --json` to address a hidden split/scratch or a background
@@ -463,18 +468,18 @@ result. `--no-block` prints the picker id instead;
 Only one picker may be pending per window. It opens without raising a background target unless
 `--follow` is set. Read the live picker id from the tree's top-level `pickPending` field.
 
-**quick** — `[show|hide|toggle]` (visibility; read back from the tree's `quickVisible`; a panel YOU open
+**quick** — `quick [show|hide|toggle]` (visibility; read back from the tree's `quickVisible`; a panel YOU open
 with `quick show` stays up when agterm loses focus, unlike one the user summoned by hotkey, so a following
 `quick type` / `quick text` / `surface zoom --target quick` still finds it) ·
-`type TEXT` (or `--stdin`) inject keystrokes into the quick terminal ·
-`text [--all] [--lines N]` read its screen back — the twins of `session type`/`session text`. There is one
+`quick type TEXT` (or `--stdin`) inject keystrokes into the quick terminal ·
+`quick text [--all] [--lines N]` read its screen back — the twins of `session type`/`session text`. There is one
 per app, so none of them take `--target`/`--window`/`--pane`; all three still need an open window.
 
-**sidebar** — `[show|hide|toggle]` (visibility; read back from the tree's `sidebarVisible`) ·
-`mode [tree|flagged|toggle]` (flip between the workspace tree and the flat flagged working-set list; read
-back from the tree's top-level `sidebarMode`) · `expand [--window W]` (expand every workspace) ·
-`collapse [--window W]` (collapse all workspaces except the active one, which stays expanded).
-Visibility/mode act on the frontmost window; `expand`/`collapse` default to the frontmost but take a
+**sidebar** — `sidebar [show|hide|toggle]` (visibility; read back from the tree's `sidebarVisible`) ·
+`sidebar mode [tree|flagged|toggle]` (flip between the workspace tree and the flat flagged working-set list; read
+back from the tree's top-level `sidebarMode`) · `sidebar expand [--window W]` (expand every workspace) ·
+`sidebar collapse [--window W]` (collapse all workspaces except the active one, which stays expanded).
+Visibility/mode act on the frontmost window; `sidebar expand`/`sidebar collapse` default to the frontmost but take a
 `--window` selector to target any open window.
 
 **notify** — `notify <body> [--title T]` — post a desktop notification attributed to a session. To signal that you need the user, prefer `session status` (`blocked`/`completed`), a persistent typed attention state rather than a one-shot banner; keep `notify` for a one-off nudge.

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -865,7 +865,7 @@ choice=$(printf '%s\n' "$branches" | agtermctl pick --prompt "Check out which br
 agtermctl session hud close --target "$me"
 ```
 
-`hud update` repaints in place, no re-spawn and no blink, and it replaces the whole spec: `--detail`,
+`session hud update` repaints in place, no re-spawn and no blink, and it replaces the whole spec: `--detail`,
 the spinner and `--text-color` are dropped unless repeated. `--spinner-style bar|braille|circle|blocks|dot` picks the look and
 turns the spinner on by itself (`dot` blinks instead of animating, for a panel up for minutes), and an
 update may switch style mid-flight; `--spinner-style none` stops it, which is also what a read-back's
@@ -886,8 +886,9 @@ agtermctl tree --json | jq -r --arg s "$me" '
 ```
 
 Nothing announces a HUD as an event, so poll `tree` when another process owns the lifecycle. The slot is
-shared with `session overlay open`, which means a second `hud` replaces the first, an `overlay open`
-replaces a HUD, and `overlay result` over one errors `no overlay result: the slot holds a hud`. A HUD over
+shared with `session overlay open`, which means a second `session hud` replaces the first, a
+`session overlay open` replaces a HUD, and `session overlay result` over one errors
+`no overlay result: the slot holds a hud`. A HUD over
 a RUNNING program is refused instead: a message is replaceable, a program is not.
 
 ## Navigate and manage windows

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -81,7 +81,7 @@ SIGTERM use normal process behavior.
   session or to none at all, as when you close the last one — or `workspace select` names another, it is
   deleted, or the workspace filter hides it. Hiding drops it for good, so turning the filter off does not
   restore it. Reselecting the already-selected session does not count: `session select`,
-  `overlay open --follow` and single-session `session go` leave it in place. `workspace select` on an EMPTY
+  `session overlay open --follow` and single-session `session go` leave it in place. `workspace select` on an EMPTY
   workspace has no session to select, so it takes the target instead (and is revealed if the filter was
   hiding it). Else the selected session's workspace, else the last one. A background create (`workspace new --collapsed`,
   `session new --create-workspace --no-select`) never takes it. The tree workspace node's `active` flag
@@ -89,9 +89,10 @@ SIGTERM use normal process behavior.
   different workspace than `--target active` resolves to; address by id when the two must agree.
 - **For an agent, `active` is the USER's GUI-selected session, not yours.** Your shell is
   `$AGTERM_SESSION_ID`; the user is usually on a different session while you work. Pass
-  `--target "$AGTERM_SESSION_ID"` on any session-scoped command (`overlay open`, `scratch`, `type`,
-  `text`, `background`, `status`, `copy`, …) that must act on the session you run in — otherwise it hits
-  whatever the user has selected. `overlay open` opens in the background without switching the user
+  `--target "$AGTERM_SESSION_ID"` on any session-scoped command (`session overlay open`, `session scratch`,
+  `session type`, `session text`, `session background`, `session status`, `session copy`, …) that must act
+  on the session you run in — otherwise it hits
+  whatever the user has selected. `session overlay open` opens in the background without switching the user
   (both full and floating); pass `--follow` to additionally SELECT the target, switching the user to it.
 - `--window <id|prefix|active>` (on session/workspace/tree/font/notify/pick commands) picks which window's
   tree to act on; default is the frontmost. With `--window` set, that window must be open. Without it,
@@ -606,7 +607,7 @@ error keeps those names for compatibility.
   — run `command` in an ephemeral terminal on top of the session; it closes when the command exits.
   `command` runs through `sh -c` (so shell operators DO work here) but with the app's GUI `PATH` (no
   `/opt/homebrew/bin`), so a bare Homebrew or other non-default binary fails with exit 127 — the overlay
-  flashes open then vanishes and `overlay result` reports 127; give an absolute path or wrap in
+  flashes open then vanishes and `session overlay result` reports 127; give an absolute path or wrap in
   `"zsh -lc '…'"`.
   Full-size by default (hides the session); `--size-percent N` (1–100) makes it a floating framed panel
   with the session visible behind, and a percent outside that range is an error. **By default the
@@ -680,7 +681,7 @@ error keeps those names for compatibility.
   Meant for the seconds before an agent can show anything — computing the items for `pick`, waiting on a
   slow command — so the user reads what is happening in the session he is about to be pulled into.
   `open` is the group's default subcommand (`session hud "gathering options…"`); a message that is
-  literally `update` or `close` needs the explicit `hud open` verb. `--detail` adds a dim second line,
+  literally `update` or `close` needs the explicit `session hud open` verb. `--detail` adds a dim second line,
   `--spinner` animates a glyph beside the message in the default `bar` style, `--spinner-style` picks
   another from `bar|braille|circle|blocks|dot` and turns the spinner on by itself — `dot` blinks rather than
   animating, for a panel that sits up for minutes. `--spinner-style none` is accepted too and leaves the


### PR DESCRIPTION
the bundled skill's Command summary wrote `session`, `workspace`, `window`, `surface`, `quick` and
`sidebar` commands bare under their bold area heading, while `reference.md` and `examples.md` write
all of them with the area prefix. An agent that copies a summary line verbatim gets
`Error: Unknown option '--target'`, which names an option rather than an unknown subcommand, so it
reads as wrong flags or a stale build instead of a missing `session` prefix.

`overlay` and `hud` are where the reporter hit it, but they were not special: all 23 session bullets
were bare, and so were workspace, window, surface, quick and sidebar. The other eleven areas
(`tree`, `events`, `notify`, `font`, `keymap`, `config`, `theme`, `restore`, `dashboard`, `pick`,
`version`) already carried the prefix, so the summary disagreed with itself as well as with the
other two files.

**changes**

- every command form in those six areas now carries its area prefix, matching `reference.md`
- prose cross-references in the same bullets, plus the session-scoped command list in Addressing
- five stragglers in `reference.md` and three in `examples.md`

tree field names (`overlay`, `hud`, `status`, `workspaceFilter`), flag values (`on`/`off`/`toggle`)
and surface addresses (`overlay-left`) stay bare, they are not commands.

docs only, no Swift touched. `swift test` green (2654 tests), `make lint` clean.

Fix #503
