### PR TITLE
Fix Codex resume for multi-agent sessions

### DIFF
--- a/cookbook/codex-session-resume/README.md
+++ b/cookbook/codex-session-resume/README.md
@@ -45,6 +45,8 @@ To remove it, delete the function block, or the `source` line, from `~/.zshrc`, 
 
 Run `codex` the way you always do. Start codex, run a command, then restart agterm: the tab resumes that session.
 
+Launch options remain explicit. `codex --yolo` resumes the mapped conversation with `--yolo`, and agterm preserves that invocation across an app restart. A later plain `codex` resumes the same conversation without `--yolo`; the mapping stores only the conversation id, never permission flags.
+
 Mappings live one file per tab under `~/.codex/agterm/`, each holding a single codex session id. Deleting one unbinds that tab, and the next `codex` in it starts fresh.
 
 ## How it works
@@ -53,7 +55,7 @@ agterm can remember the command running in a tab and re-run it on restart. It re
 
 Every agterm tab has a stable identifier, `AGTERM_SESSION_ID`, that survives a restart. Claude Code can be handed a session id at launch and so needs no state at all, but codex cannot, so this function keeps the one piece of state that difference forces: a file named after the tab, holding the codex session id that tab owns.
 
-On each `codex` the function reads `~/.codex/agterm/<tab-id>`. If it holds an id and the matching `rollout-*-<id>.jsonl` is still under `~/.codex/sessions/`, it runs `codex resume <id>` and is done. Otherwise it records a timestamp, runs codex plainly, and afterwards takes the newest rollout file. If that file is newer than the timestamp it is the conversation this run created, so the function pulls the uuid off the end of the filename, checks the shape, and writes it to the mapping file for next time.
+On each `codex` the function reads `~/.codex/agterm/<tab-id>`. If it holds an id and the matching `rollout-*-<id>.jsonl` is still under `~/.codex/sessions/`, it reads the first line's `session_meta.payload.session_id` and resumes that root conversation. Root rollouts carry their own id there, while multi-agent child rollouts carry the resumable root id; older rollouts without the field fall back to the UUID at the end of the filename. The function also repairs an existing child mapping when it finds one. Otherwise it records a timestamp, runs codex plainly, and afterwards takes the newest rollout file. If that file is newer than the timestamp it is the conversation this run created, so the same lookup writes its root id to the mapping file for next time.
 
 On the agterm side the replay is a foreground-process capture. At quit agterm records the argv of whatever the pane was running, and on relaunch it types that line back into the tab's fresh login shell with each argument single-quoted. Quoting suppresses alias expansion but not function lookup, which is why a shell function named `codex` still catches the replayed line and an alias would not.
 
@@ -63,7 +65,7 @@ On the agterm side the replay is a foreground-process capture. At quit agterm re
 - **Rests on restore behavior that is verified empirically, not documented.** It could change between agterm versions.
 - **One conversation per tab.** A split pane, a scratch pane and any overlay all run under the same `AGTERM_SESSION_ID` as the main pane, so a second codex started in one of them reads and overwrites the same mapping file as the first.
 - **It shadows the `codex` command** with a shell function. Passthrough is handled, but the list of subcommands and flags that must not be touched has to be kept current if the CLI grows new ones.
-- **It knows codex's on-disk layout** (`~/.codex/sessions/**/rollout-*.jsonl`). If that storage location or the filename shape changes, the mapping stops being written and every tab starts fresh.
+- **It knows codex's on-disk layout** (`~/.codex/sessions/**/rollout-*.jsonl`) and the first-line `session_meta.payload.session_id` field. If that layout changes, it falls back to the filename UUID when possible; otherwise the mapping stops being written and every tab starts fresh.
 - **zsh only** (`${:l}`, the `(N)` and `(om)` glob qualifiers, `emulate`, `setopt local_options`). Bash needs a rewrite.
 
 Two observations from reading the function rather than claims by its author:

--- a/cookbook/codex-session-resume/codex-resume.zsh
+++ b/cookbook/codex-session-resume/codex-resume.zsh
@@ -6,6 +6,20 @@
 # Maps the tab's own uuid (AGTERM_SESSION_ID) to a codex session id under ~/.codex/agterm/,
 # so restoring the terminal resumes that tab's own conversation instead of starting fresh.
 # Requires: agterm (exports AGTERM_SESSION_ID, restores running commands) + zsh.
+_codex_rollout_root_id() {
+  emulate -L zsh
+  local file=$1 line candidate
+  local id=${${file:t:r}[-36,-1]}
+  # Codex currently writes compact session_meta JSON with payload.session_id as the
+  # first session_id field; the UUID shape check preserves the filename fallback.
+  if IFS= read -r line < "$file" &&
+      [[ $line == *'"type":"session_meta"'* && $line == *'"session_id":"'* ]]; then
+    candidate=${${line#*'"session_id":"'}%%\"*}
+    [[ $candidate == ????????-????-????-????-???????????? ]] && id=$candidate
+  fi
+  [[ $id == ????????-????-????-????-???????????? ]] && print -r -- $id
+}
+
 codex() {
   emulate -L zsh
   setopt local_options null_glob
@@ -26,15 +40,20 @@ codex() {
   local cid; [[ -f $mapf ]] && cid=$(<$mapf)
   local -a s=(~/.codex/sessions/**/rollout-*-$cid.jsonl(N))
   if [[ -n $cid ]] && (( $#s )); then
-    command codex resume "$cid" "$@"; return
+    local rid=$(_codex_rollout_root_id $s[1])
+    local -a roots=(~/.codex/sessions/**/rollout-*-$rid.jsonl(N))
+    if [[ -n $rid ]] && (( $#roots )); then
+      [[ $rid != $cid ]] && print -r -- $rid > $mapf
+      command codex resume "$rid" "$@"; return
+    fi
   fi
 
   local before=$(mktemp)
   command codex "$@"; local rc=$?
   local -a new=(~/.codex/sessions/**/rollout-*.jsonl(N.om))
   if (( $#new )) && [[ $new[1] -nt $before ]]; then
-    local uuid=${${new[1]:t:r}[-36,-1]}
-    [[ $uuid == ????????-????-????-????-???????????? ]] && { mkdir -p ${mapf:h}; print -r -- $uuid > $mapf; }
+    local uuid=$(_codex_rollout_root_id $new[1])
+    [[ -n $uuid ]] && { mkdir -p ${mapf:h}; print -r -- $uuid > $mapf; }
   fi
   command rm -f $before
   return $rc

--- a/cookbook/codex-session-resume/test_codex_resume.py
+++ b/cookbook/codex-session-resume/test_codex_resume.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT_ID = "01900000-0000-7000-8000-000000000001"
+CHILD_ID = "01900000-0001-7000-8000-000000000002"
+INTERMEDIATE_ID = "01900000-0002-7000-8000-000000000003"
+NESTED_ID = "01900000-0003-7000-8000-000000000004"
+LEGACY_ID = "01900000-0004-7000-8000-000000000005"
+TAB_ID = "01900000-0005-7000-8000-000000000006"
+RECIPE = Path(
+    os.environ.get("CODEX_RESUME_SCRIPT", Path(__file__).with_name("codex-resume.zsh"))
+).resolve()
+
+
+class CodexResumeTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.home = Path(self.temp_dir.name)
+        self.sessions = self.home / ".codex" / "sessions" / "2026" / "08" / "30"
+        self.map_file = self.home / ".codex" / "agterm" / TAB_ID
+        self.log = self.home / "codex-args.jsonl"
+        self.bin_dir = self.home / "bin"
+        self.bin_dir.mkdir()
+        fake_codex = self.bin_dir / "codex"
+        fake_codex.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env python3
+                import json
+                import os
+                import time
+                from pathlib import Path
+
+                with Path(os.environ["FAKE_CODEX_LOG"]).open("a") as log:
+                    print(json.dumps(__import__("sys").argv[1:]), file=log)
+
+                if target := os.environ.get("FAKE_CODEX_CREATE_CHILD"):
+                    sessions = Path(target)
+                    sessions.mkdir(parents=True, exist_ok=True)
+                    root = sessions / "rollout-2026-08-30T00-00-00-{ROOT_ID}.jsonl"
+                    child = sessions / "rollout-2026-08-30T00-00-01-{CHILD_ID}.jsonl"
+                    root.write_text(json.dumps({{
+                        "type": "session_meta",
+                        "payload": {{"id": "{ROOT_ID}", "session_id": "{ROOT_ID}"}},
+                    }}, separators=(",", ":")) + "\\n")
+                    child.write_text(json.dumps({{
+                        "type": "session_meta",
+                        "payload": {{
+                            "id": "{CHILD_ID}",
+                            "session_id": "{ROOT_ID}",
+                            "parent_thread_id": "{ROOT_ID}",
+                        }},
+                    }}, separators=(",", ":")) + "\\n")
+                    now = time.time()
+                    os.utime(root, (now + 1, now + 1))
+                    os.utime(child, (now + 2, now + 2))
+                """
+            )
+        )
+        fake_codex.chmod(0o755)
+
+    def write_rollout(self, rollout_id, session_id=None, parent_id=None):
+        self.sessions.mkdir(parents=True, exist_ok=True)
+        payload = {"id": rollout_id}
+        if session_id is not None:
+            payload["session_id"] = session_id
+        if parent_id is not None:
+            payload["parent_thread_id"] = parent_id
+        path = self.sessions / f"rollout-2026-08-30T00-00-00-{rollout_id}.jsonl"
+        path.write_text(
+            json.dumps(
+                {"type": "session_meta", "payload": payload}, separators=(",", ":")
+            )
+            + "\n"
+        )
+        return path
+
+    def run_codex(self, *args, create_child=False):
+        env = os.environ.copy()
+        env.update(
+            {
+                "AGTERM_SESSION_ID": TAB_ID,
+                "FAKE_CODEX_LOG": str(self.log),
+                "HOME": str(self.home),
+                "PATH": f"{self.bin_dir}{os.pathsep}{env['PATH']}",
+                "RECIPE": str(RECIPE),
+            }
+        )
+        if create_child:
+            env["FAKE_CODEX_CREATE_CHILD"] = str(self.sessions)
+        result = subprocess.run(
+            [
+                "zsh",
+                "-fc",
+                'source "$RECIPE"; codex "$@"',
+                "test-harness",
+                *args,
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        return [json.loads(line) for line in self.log.read_text().splitlines()]
+
+    def map_to(self, rollout_id):
+        self.map_file.parent.mkdir(parents=True, exist_ok=True)
+        self.map_file.write_text(f"{rollout_id}\n")
+
+    def test_mapped_child_resumes_and_repairs_root(self):
+        self.write_rollout(ROOT_ID, ROOT_ID)
+        self.write_rollout(CHILD_ID, ROOT_ID, ROOT_ID)
+        self.map_to(CHILD_ID)
+
+        calls = self.run_codex()
+
+        self.assertEqual([["resume", ROOT_ID]], calls)
+        self.assertEqual(ROOT_ID, self.map_file.read_text().strip())
+
+    def test_newest_child_records_root(self):
+        calls = self.run_codex(create_child=True)
+
+        self.assertEqual([[]], calls)
+        self.assertEqual(ROOT_ID, self.map_file.read_text().strip())
+
+    def test_nested_child_uses_root_session_id(self):
+        self.write_rollout(ROOT_ID, ROOT_ID)
+        self.write_rollout(INTERMEDIATE_ID, ROOT_ID, ROOT_ID)
+        self.write_rollout(NESTED_ID, ROOT_ID, INTERMEDIATE_ID)
+        self.map_to(NESTED_ID)
+
+        calls = self.run_codex()
+
+        self.assertEqual([["resume", ROOT_ID]], calls)
+        self.assertEqual(ROOT_ID, self.map_file.read_text().strip())
+
+    def test_mapped_root_forwards_yolo(self):
+        self.write_rollout(ROOT_ID, ROOT_ID)
+        self.map_to(ROOT_ID)
+
+        calls = self.run_codex("--yolo")
+
+        self.assertEqual([["resume", ROOT_ID, "--yolo"]], calls)
+        self.assertEqual(ROOT_ID, self.map_file.read_text().strip())
+
+    def test_child_without_root_falls_through_to_plain_run(self):
+        self.write_rollout(CHILD_ID, ROOT_ID, ROOT_ID)
+        self.map_to(CHILD_ID)
+
+        calls = self.run_codex()
+
+        self.assertEqual([[]], calls)
+        self.assertEqual(CHILD_ID, self.map_file.read_text().strip())
+
+    def test_explicit_resume_passes_through(self):
+        self.write_rollout(ROOT_ID, ROOT_ID)
+        self.map_to(ROOT_ID)
+
+        calls = self.run_codex("resume", LEGACY_ID, "--yolo")
+
+        self.assertEqual([["resume", LEGACY_ID, "--yolo"]], calls)
+        self.assertEqual(ROOT_ID, self.map_file.read_text().strip())
+
+    def test_legacy_rollout_falls_back_to_filename_id(self):
+        self.write_rollout(LEGACY_ID)
+        self.map_to(LEGACY_ID)
+
+        calls = self.run_codex()
+
+        self.assertEqual([["resume", LEGACY_ID]], calls)
+        self.assertEqual(LEGACY_ID, self.map_file.read_text().strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Codex CLI 0.151 creates a separate rollout file for each multi-agent v2 subagent. The existing per-tab resume recipe records the newest rollout's filename UUID, so a child rollout can replace the resumable root in `~/.codex/agterm/<tab-id>`.

The affected path is `cookbook/codex-session-resume/codex-resume.zsh`, in `codex()`. The previous capture and resume logic used the rollout filename directly:

```zsh
local uuid=${${new[1]:t:r}[-36,-1]}
command codex resume "$cid" "$@"
```

When the mapped UUID belongs to a multi-agent child, launching plain `codex` in that agterm tab calls `codex resume <child-id>` and fails with:

```text
cannot resume an unloaded multi-agent v2 sub-agent through its parent; resume the parent first
```

The rollout's first `session_meta` record carries the root conversation in `payload.session_id`. This patch resolves that field for both existing mappings and newly captured rollouts, verifies that the root rollout exists, repairs a child mapping before resuming, and retains the filename fallback for older metadata.

The regression suite uses synthetic UUIDs and covers mapped children, newly created children, nested children, legacy metadata, missing roots and explicit pass-through. It also fixes the launch-option contract in a test: `codex --yolo` becomes `codex resume <root-id> --yolo`, while a later plain `codex` resumes without elevated permissions.

Checks:

- `python3 cookbook/codex-session-resume/test_codex_resume.py` (7 tests)
- `python3 cookbook/two-agent-chat/test_peer_chat.py` (11 tests)
- mapped-child and newest-child tests fail against current master and pass with this patch
- `shellcheck` on every cookbook `.sh` file
- `zsh -n` on every cookbook `.zsh` file
- `ruff check --ignore EXE001` on every cookbook Python file
