### PR TITLE
Recover Claude tabs from bridge-only transcripts

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -51,9 +51,9 @@ paths:
   both directions; requires kebab-case directories, a `README.md` with all six exact
   (`grep -qxF`) headings, and shebangs for `.sh`/`.zsh`/`.py`; runs `shellcheck` on `.sh`; parses `.zsh`
   with `zsh -n`; runs `ruff check` on `.py`; and executes every `test_*.py` regression script directly.
-  `shellcheck` is preinstalled. Install absent `zsh` and `ruff` in separate steps immediately before
-  their own; shellcheck cannot lint zsh, and `ruff` needs `pipx` because the runner's python is externally
-  managed.
+  `shellcheck` is preinstalled. Install absent `zsh` and `fish` together before the shell gates (`fish`
+  runs the Claude resume regression), and install `ruff` through `pipx` because the runner's python is
+  externally managed.
 - Recipes are not shell-only. A language gains a gate by adding its extension to the shebang glob plus a
   lint or parse step; until then it merges unchecked, which is why `cookbook/CONTRIBUTING.md` tells a
   contributor to flag any other language in the pull request. Keep that file, `cookbook/README.md` and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,9 +250,9 @@ jobs:
         # without it a failed find would leave the step green having checked nothing
         shell: bash
         run: find cookbook -type f -name '*.sh' -print0 | xargs -0 -r shellcheck
-      - name: Install zsh
-        # not on the ubuntu-latest image, unlike shellcheck
-        run: sudo apt-get update && sudo apt-get install -y zsh
+      - name: Install recipe shells
+        # neither is on the ubuntu-latest image; fish runs a recipe regression test
+        run: sudo apt-get update && sudo apt-get install -y zsh fish
       - name: zsh syntax check
         # shellcheck cannot parse zsh, so a parse is the only gate .zsh recipes get.
         # -n1 because zsh -n reads one script and treats the rest as its arguments;

--- a/cookbook/claude-session-resume/README.md
+++ b/cookbook/claude-session-resume/README.md
@@ -9,8 +9,9 @@ Contributed by [@ssgreg](https://github.com/ssgreg), from [discussion #71](https
 Keep several Claude Code sessions open at once, and after the terminal restarts each tab resumes its own conversation instead of a shared "most recent" one.
 
 - Solves a concrete pain: multiple parallel Claude Code sessions survive a restart, each reopening exactly its own conversation.
-- Zero state: the conversation id **is** the tab's uuid (`AGTERM_SESSION_ID`). No mapping file to keep in sync or let go stale.
-- Idempotent: the first launch pins the conversation to the tab (`--session-id`); later launches continue it (`--resume`), and it flips automatically.
+- Zero mapping state: the first conversation id **is** the tab's uuid (`AGTERM_SESSION_ID`), and any recovery id is derived from it.
+- Idempotent: the first launch pins the conversation to the tab (`--session-id`); later launches continue it (`--resume`).
+- Non-destructive recovery: a metadata-only transcript is left in place and the tab advances to its next deterministic conversation id.
 - Stays out of the way: `claude mcp`, `-p`, an explicit `claude --resume <other-id>`, and any launch outside agterm pass through untouched.
 - Small, dependency-free, pure shell; options are function-local (zsh's `emulate -L`, fish's implicit function scoping), so nothing leaks into your interactive shell.
 
@@ -19,6 +20,7 @@ Keep several Claude Code sessions open at once, and after the terminal restarts 
 - agterm 0.3.1 or later, with **Restore running commands on restart** turned on under Settings ▸ General ▸ Sessions. Both `AGTERM_SESSION_ID` and that setting predate the repository's earliest tagged release, so 0.3.1 is the first version that can be named, not the version the behavior arrived in.
 - `zsh`, or `fish`
 - Claude Code, with its conversations in the default `~/.claude/projects/`
+- Python 3.8 or later, plus both `zsh` and `fish`, only to run the bundled `test_claude_resume.py`. Using the recipe needs no Python.
 
 ## Setup
 
@@ -68,15 +70,17 @@ To remove it, delete `~/.config/fish/functions/claude.fish`.
 
 Run `claude` the way you always do. The first launch in a tab starts a conversation pinned to that tab, and every later launch in the same tab continues it.
 
-To check it: open a tab, run `claude`, say a few words, then restart the terminal. The tab should come back to the same conversation, and `ps` shows `claude --resume <tab-id>`.
+To check it: open a tab, run `claude`, say a few words, then restart the terminal. The tab should come back to the same conversation, and `ps` shows `claude --resume <tab-owned-id>`.
 
 ## How it works
 
 agterm can remember the command running in a tab and re-run it on restart. The catch: it re-runs the command verbatim, and `claude` with no arguments is a *new* conversation, not a continuation.
 
-The trick rests on two facts. Every agterm tab has a stable identifier (`AGTERM_SESSION_ID`) that survives a restart. And Claude Code lets you supply a session id from the outside (`--session-id`). So you can use the tab's id as the conversation id, and the tab permanently "owns" one conversation.
+The trick rests on two facts. Every agterm tab has a stable identifier (`AGTERM_SESSION_ID`) that survives a restart. And Claude Code lets you supply a session id from the outside (`--session-id`). The tab id can therefore identify its conversation and any deterministic recovery ids.
 
-The function then wraps `claude`: on the first launch in a tab it pins the conversation to the tab id (`--session-id`); if that conversation's file already exists on disk it continues it (`--resume`). The whole decision is one check: is `<tab-id>.jsonl` present under `~/.claude/projects/`?
+The function then wraps `claude`: on the first launch in a tab it pins the conversation to the tab id (`--session-id`). Later launches find that id under Claude's project directories and continue it with `--resume`. Looking up the id directly means the wrapper does not need to reproduce Claude's private project-path encoding.
+
+Claude can leave a `bridge-session`-only file after switching conversations through `/resume`. Such a file is not resumable and also prevents reusing the id. The wrapper leaves the file untouched and derives another UUID by incrementing the final 32 bits of the tab id. It applies the same rule again if that id also has a metadata-only transcript. A conversation created by an older version of the recipe is still resumed because its id remains the tab id.
 
 On restart agterm replays the remembered command, the function recognizes "its own" id, sees the conversation already exists, and reopens exactly that one. Each tab, its own.
 
@@ -86,8 +90,10 @@ On the agterm side that replay is a foreground-process capture. At quit agterm r
 
 - **agterm-specific.** It needs a stable per-tab identifier and relies on agterm feeding the restored command back *through the login shell*, which is how the function intercepts it. It will not work as-is in another terminal; you would adapt it to that terminal's equivalent.
 - **Rests on restore behavior its author verified empirically rather than from documentation.** It could change between agterm versions.
-- **One conversation per tab.** Since conversation id equals tab id, two live `claude` processes in the same tab collide with `Session ID ... is already in use`. A split pane, a scratch pane and any overlay all run under the same `AGTERM_SESSION_ID` as the main pane, so a second `claude` in any of them hits this.
+- **One tab-owned conversation id at a time.** Simultaneous launches in the same tab can choose the same id and collide with Claude's transcript check. A process that has switched elsewhere through `/resume` can leave a metadata-only id, which the next launch skips.
 - **It shadows the `claude` command** with a shell function. Passthrough is handled, but the list of subcommands and flags that must not be touched has to be kept current if the CLI grows new ones.
-- **It knows Claude Code's on-disk layout** (`~/.claude/projects/*/<id>.jsonl`). If that storage location changes, the "does this conversation exist" check breaks: it would always create, then hit "already in use" on restart. A one-line fix, but worth knowing.
+- **It knows Claude Code's on-disk layout** (`~/.claude/projects/*/<id>.jsonl`). A Claude Code storage change can require a recipe update.
 - **zsh or fish only** (the zsh version uses `${:l}`, the `(N)` glob qualifier, and `emulate`; the fish version uses fish-only syntax throughout). Bash needs a rewrite.
-- **Existing conversations are not bound to tabs.** After you install this, the first launch in a tab starts a new conversation pinned to that tab; it does not adopt an arbitrary earlier one.
+- **Existing conversations are not bound to tabs.** After installation, the first launch starts a conversation pinned to that tab. Conversations created by an older copy of this recipe are adopted by their matching tab id, but arbitrary earlier conversations are not.
+- **Claude's `/resume` picker does not rebind the tab.** It switches the running process, but the next launch returns to the conversation owned by the tab id. To make agterm capture another conversation, exit and run `claude --resume <id>` from the shell.
+- **Metadata-only transcripts remain on disk.** They are small, remain available for inspection and are skipped on later launches.

--- a/cookbook/claude-session-resume/claude-resume.fish
+++ b/cookbook/claude-session-resume/claude-resume.fish
@@ -18,11 +18,16 @@ function claude --description 'Per-agterm-tab Claude Code session resume'
         command claude $argv                                    # not in an agterm tab -> passthrough
         return
     end
+    if not string match -qr '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' -- "$sid"
+        command claude $argv                                    # malformed tab id -> do not use it in a path
+        return
+    end
 
     set -l args $argv
+    set -l replay_prefix (string replace -r '[0-9a-f]{8}$' '' -- "$sid")
 
     if contains -- "$argv[1]" --session-id -r --resume
-        and test (string lower -- "$argv[2]") = "$sid"
+        and string match -qr "^"(string escape --style=regex "$replay_prefix")"[0-9a-f]{8}\$" -- (string lower -- "$argv[2]")
         set args $argv[3..-1]                                    # restore replayed our own flag -> re-decide below
     else
         for a in $argv                                           # user steering a session/subcommand/headless?
@@ -34,10 +39,52 @@ function claude --description 'Per-agterm-tab Claude Code session resume'
         end
     end
 
-    set -l existing ~/.claude/projects/*/$sid.jsonl               # does this tab's session already exist?
-    if test (count $existing) -gt 0
-        command claude --resume "$sid" $args                      # yes -> continue it
-    else
-        command claude --session-id "$sid" $args                  # no  -> create it with this fixed id
+    set -l config_dir "$CLAUDE_CONFIG_DIR"
+    test -n "$config_dir"; or set config_dir "$HOME/.claude"
+    set -l projects "$config_dir/projects"
+
+    set -l generation 0
+    set -l action
+    set -l candidate
+
+    while true
+        set candidate "$sid"
+        if test $generation -gt 0
+            set -l tail (math "(0x"(string sub -s -8 -- "$sid")" + $generation) % 4294967296")
+            set candidate (string replace -r '[0-9a-f]{8}$' (printf '%08x' "$tail") -- "$sid")
+        end
+
+        set -l transcripts "$projects"/*/"$candidate.jsonl"
+        if not test -f "$transcripts[1]"
+            set action --session-id
+            break
+        end
+
+        set -l found_conversation 0
+        for transcript in $transcripts
+            set -l found 0
+            set -l other 0
+            while read -l line
+                test -z "$line"; and continue
+                set found 1
+                if not string match -q '{"type":"bridge-session"*' -- "$line"
+                    or not string match -q '*"sessionId":"'"$candidate"'"*' -- "$line"
+                    or not string match -qr '"bridgeSessionId":"[^"]+"' -- "$line"
+                    or not string match -qr '"lastSequenceNum":[0-9]+' -- "$line"
+                    or not string match -q '*}' -- "$line"
+                    set other 1
+                    break
+                end
+            end < "$transcript"
+            if test $found -eq 0; or test $other -eq 1
+                set action --resume
+                set found_conversation 1
+                break
+            end
+        end
+        test $found_conversation -eq 1; and break
+        set generation (math $generation + 1)                   # metadata-only transcript -> leave it intact
     end
+
+    command claude "$action" "$candidate" $args
 end

--- a/cookbook/claude-session-resume/claude-resume.zsh
+++ b/cookbook/claude-session-resume/claude-resume.zsh
@@ -10,8 +10,15 @@ claude() {
   emulate -L zsh
   local sid=${AGTERM_SESSION_ID:l}
   [[ -z $sid ]] && { command claude "$@"; return; }             # not in an agterm tab -> passthrough
+  local compact=${sid//-/}
+  if [[ ${#sid} != 36 || $sid != ????????-????-????-????-???????????? ||
+    ${#compact} != 32 || $compact == *[^0-9a-f]* ]]; then
+    command claude "$@"; return                                 # malformed tab id -> do not use it in a path
+  fi
 
-  if [[ "$1" == (--session-id|-r|--resume) && "${2:l}" == $sid ]]; then
+  local replay=${2:l}
+  if [[ "$1" == (--session-id|-r|--resume) && ${#replay} == 36 &&
+    ${replay[1,-9]} == ${sid[1,-9]} && ${replay[-8,-1]} != *[^0-9a-f]* ]]; then
     shift 2                                                      # restore replayed our own flag -> re-decide below
   else
     local a
@@ -23,7 +30,42 @@ claude() {
     done
   fi
 
-  local -a f=(~/.claude/projects/*/$sid.jsonl(N))               # does this tab's session already exist?
-  if (( $#f )); then command claude --resume "$sid" "$@"        # yes -> continue it
-  else command claude --session-id "$sid" "$@"; fi              # no  -> create it with this fixed id
+  local projects=${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects
+  local candidate transcript tail action generation=0
+
+  while true; do
+    candidate=$sid
+    if (( generation )); then
+      builtin printf -v tail '%08x' $(( (16#${sid[-8,-1]} + generation) & 0xffffffff ))
+      candidate=${sid[1,-9]}$tail
+    fi
+
+    local transcripts=($projects/*/$candidate.jsonl(N))
+    if (( ! ${#transcripts} )); then
+      action=--session-id
+      break
+    fi
+
+    for transcript in $transcripts; do
+      local line found=0 other=0
+      while IFS= read -r line || [[ -n $line ]]; do
+        [[ -z $line ]] && continue
+        found=1
+        if [[ $line != '{"type":"bridge-session"'* ||
+          $line != *'"sessionId":"'"$candidate"'"'* || $line != *\} ]] ||
+          ! [[ $line =~ '"bridgeSessionId":"[^"]+"' ]] ||
+          ! [[ $line =~ '"lastSequenceNum":[0-9]+' ]]; then
+          other=1
+          break
+        fi
+      done < "$transcript"
+      if (( ! found || other )); then
+        action=--resume
+        break 2
+      fi
+    done
+    (( generation++ ))                                          # metadata-only transcript -> leave it intact
+  done
+
+  command claude "$action" "$candidate" "$@"
 }

--- a/cookbook/claude-session-resume/test_claude_resume.py
+++ b/cookbook/claude-session-resume/test_claude_resume.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+TAB_ID = "11111111-2222-4333-8444-555555555555"
+OTHER_ID = "66666666-7777-4888-8999-000000000000"
+HERE = Path(__file__).resolve().parent
+RECIPES = {
+    "zsh": Path(os.environ.get("CLAUDE_RESUME_ZSH_SCRIPT", HERE / "claude-resume.zsh")),
+    "fish": Path(
+        os.environ.get("CLAUDE_RESUME_FISH_SCRIPT", HERE / "claude-resume.fish")
+    ),
+}
+
+
+class ClaudeResumeTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.home = Path(self.temp_dir.name)
+        self.projects = self.home / ".claude" / "projects"
+        self.work = self.home / "work" / "project"
+        self.work.mkdir(parents=True)
+        self.current_project = self.projects / self.encode_project(self.work)
+        self.log = self.home / "claude-args.jsonl"
+        self.bin_dir = self.home / "bin"
+        self.bin_dir.mkdir()
+        fake_claude = self.bin_dir / "claude"
+        fake_claude.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                import sys
+                from pathlib import Path
+
+                def encode(path):
+                    return "".join(c if c.isascii() and (c.isalnum() or c == "-") else "-" for c in path)
+
+                args = sys.argv[1:]
+                if args[:1] == ["--session-id"]:
+                    transcript = Path.home() / ".claude" / "projects" / encode(os.getcwd()) / f"{args[1]}.jsonl"
+                    if transcript.exists():
+                        print(f"session file still exists: {transcript}", file=sys.stderr)
+                        raise SystemExit(73)
+
+                with Path(os.environ["FAKE_CLAUDE_LOG"]).open("a") as log:
+                    print(json.dumps(args), file=log)
+                """
+            )
+        )
+        fake_claude.chmod(0o755)
+
+        self.shell = os.environ.get("CLAUDE_RESUME_SHELLS", "zsh")
+        if self.shell not in RECIPES:
+            self.fail(f"unsupported shell in CLAUDE_RESUME_SHELLS: {self.shell}")
+        if not shutil.which(self.shell):
+            self.fail(f"required shell is not installed: {self.shell}")
+
+    @staticmethod
+    def encode_project(path):
+        return "".join(
+            char if char.isascii() and (char.isalnum() or char == "-") else "-"
+            for char in str(path.resolve())
+        )
+
+    @staticmethod
+    def message(message_type="user", sidechain=False, session_id=TAB_ID):
+        return {
+            "parentUuid": None,
+            "isSidechain": sidechain,
+            "type": message_type,
+            "message": {"role": message_type, "content": "probe"},
+            "uuid": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            "sessionId": session_id,
+        }
+
+    @staticmethod
+    def bridge(session_id=TAB_ID):
+        return {
+            "type": "bridge-session",
+            "sessionId": session_id,
+            "bridgeSessionId": "cse_probe",
+            "lastSequenceNum": 0,
+        }
+
+    @staticmethod
+    def generated_id(generation):
+        if generation == 0:
+            return TAB_ID
+        tail = (int(TAB_ID[-8:], 16) + generation) & 0xFFFFFFFF
+        return f"{TAB_ID[:-8]}{tail:08x}"
+
+    def write_transcript(self, *entries, project=None, session_id=TAB_ID):
+        directory = project or self.current_project
+        directory.mkdir(parents=True, exist_ok=True)
+        transcript = directory / f"{session_id}.jsonl"
+        transcript.write_text(
+            "".join(
+                json.dumps(entry, separators=(",", ":")) + "\n" for entry in entries
+            )
+        )
+        return transcript
+
+    def write_raw_transcript(self, text):
+        self.current_project.mkdir(parents=True, exist_ok=True)
+        transcript = self.current_project / f"{TAB_ID}.jsonl"
+        transcript.write_text(text)
+        return transcript
+
+    def invocation(self, *args, session_id=TAB_ID):
+        self.log.unlink(missing_ok=True)
+        env = os.environ.copy()
+        env.update(
+            {
+                "AGTERM_SESSION_ID": session_id.upper(),
+                "CLAUDE_CONFIG_DIR": str(self.home / ".claude"),
+                "FAKE_CLAUDE_LOG": str(self.log),
+                "HOME": str(self.home),
+                "PATH": f"{self.bin_dir}{os.pathsep}{env['PATH']}",
+                "RECIPE": str(RECIPES[self.shell]),
+                "TERM": "xterm-256color",
+            }
+        )
+        if self.shell == "zsh":
+            command = [
+                "zsh",
+                "-fic",
+                'source "$RECIPE"; claude "$@"',
+                "test-harness",
+                *args,
+            ]
+        else:
+            command = [
+                "fish",
+                "-i",
+                "-c",
+                'source "$RECIPE"; claude $argv',
+                "--",
+                *args,
+            ]
+        return command, env
+
+    def invoke_claude(self, *args, session_id=TAB_ID):
+        command, env = self.invocation(*args, session_id=session_id)
+        return subprocess.run(
+            command,
+            env=env,
+            cwd=self.work,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def run_claude(self, *args, session_id=TAB_ID):
+        result = self.invoke_claude(*args, session_id=session_id)
+        self.assertEqual(0, result.returncode, result.stderr)
+        return [json.loads(line) for line in self.log.read_text().splitlines()]
+
+    def assert_call(self, expected, *args, session_id=TAB_ID):
+        self.assertEqual(
+            [expected],
+            self.run_claude(*args, session_id=session_id),
+        )
+
+    def test_missing_transcript_starts_tab_session(self):
+        self.assert_call(["--session-id", TAB_ID])
+
+    def test_legacy_bridge_only_transcript_is_preserved(self):
+        transcript = self.write_transcript(self.bridge())
+
+        self.assert_call(["--session-id", self.generated_id(1)])
+        self.assertTrue(transcript.exists())
+
+    def test_legacy_user_or_assistant_message_resumes_tab_session(self):
+        for message_type in ("user", "assistant"):
+            with self.subTest(message_type=message_type):
+                self.write_transcript(
+                    self.bridge(),
+                    self.message(message_type),
+                )
+                self.assert_call(["--resume", TAB_ID])
+
+    def test_project_key_encoding_does_not_hide_legacy_conversation(self):
+        self.write_transcript(self.message(), project=self.projects / "unicode-hash-key")
+
+        self.assert_call(["--resume", TAB_ID])
+
+    def test_sidechain_only_transcript_is_not_moved(self):
+        transcript = self.write_transcript(self.message(sidechain=True))
+
+        self.assert_call(["--resume", TAB_ID])
+        self.assertTrue(transcript.exists())
+
+    def test_malformed_transcript_is_not_moved(self):
+        transcript = self.write_raw_transcript(
+            '{"type":"user","sessionId":"' + TAB_ID + '"\n'
+        )
+
+        self.assert_call(["--resume", TAB_ID])
+        self.assertTrue(transcript.exists())
+
+    def test_truncated_bridge_record_is_not_treated_as_recoverable(self):
+        transcript = self.write_raw_transcript(
+            '{"type":"bridge-session","sessionId":"'
+            + TAB_ID
+            + '","bridgeSessionId":"cse_probe","lastSequenceNum":0\n'
+        )
+
+        self.assert_call(["--resume", TAB_ID])
+        self.assertTrue(transcript.exists())
+
+    def test_bridge_only_generated_id_advances_without_moving_it(self):
+        transcript = self.write_transcript(
+            self.bridge(), project=self.projects / "encoded-project"
+        )
+
+        self.assert_call(["--session-id", self.generated_id(1)])
+        self.assertTrue(transcript.exists())
+
+    def test_second_generated_id_resumes(self):
+        self.write_transcript(
+            self.bridge(), project=self.projects / "encoded-project"
+        )
+        self.write_transcript(
+            self.message(session_id=self.generated_id(1)),
+            project=self.projects / "another-key",
+            session_id=self.generated_id(1),
+        )
+
+        self.assert_call(["--resume", self.generated_id(1)])
+
+    def test_restored_own_resume_is_recomputed(self):
+        self.write_transcript(self.bridge())
+
+        self.assert_call(
+            ["--session-id", self.generated_id(1), "--permission-mode", "plan"],
+            "--resume",
+            TAB_ID,
+            "--permission-mode",
+            "plan",
+        )
+
+    def test_restored_generated_resume_is_recomputed(self):
+        self.write_transcript(self.bridge())
+        generated = self.generated_id(1)
+        self.write_transcript(
+            self.message(session_id=generated),
+            project=self.projects / "new-key",
+            session_id=generated,
+        )
+
+        self.assert_call(["--resume", generated], "--resume", generated)
+
+    def test_explicit_other_resume_passes_through(self):
+        self.write_transcript(self.message())
+
+        self.assert_call(
+            ["--resume", OTHER_ID, "--permission-mode", "plan"],
+            "--resume",
+            OTHER_ID,
+            "--permission-mode",
+            "plan",
+        )
+
+    def test_malformed_same_prefix_resume_passes_through(self):
+        malformed = f"{TAB_ID[:-8]}gggggggg"
+
+        self.assert_call(["--resume", malformed], "--resume", malformed)
+
+    def test_parent_config_dir_does_not_escape_fixture(self):
+        self.write_transcript(self.bridge())
+        with patch.dict(
+            os.environ,
+            {"CLAUDE_CONFIG_DIR": str(self.home / "foreign-config")},
+        ):
+            self.assert_call(["--session-id", self.generated_id(1)])
+
+    def test_malformed_tab_id_passes_through_without_path_lookup(self):
+        for malformed in ("../../tmp/not-a-tab-id", "-" * 36):
+            with self.subTest(malformed=malformed):
+                self.assert_call(
+                    ["--permission-mode", "plan"],
+                    "--permission-mode",
+                    "plan",
+                    session_id=malformed,
+                )
+
+if __name__ == "__main__":
+    if "CLAUDE_RESUME_SHELLS" in os.environ:
+        unittest.main()
+    else:
+        status = 0
+        for selected_shell in RECIPES:
+            env = os.environ.copy()
+            env["CLAUDE_RESUME_SHELLS"] = selected_shell
+            result = subprocess.run([os.sys.executable, __file__], env=env, check=False)
+            status = max(status, result.returncode)
+        raise SystemExit(status)


### PR DESCRIPTION
Claude Code can leave a transcript containing only a `bridge-session` record after `/resume`. The existing recipe treated any matching JSONL file as resumable, so a restored tab selected `--resume`, received `No conversation found`, and could not reuse the occupied UUID.

This change leaves the metadata-only transcript intact and derives the tab's next UUID deterministically. It also validates `AGTERM_SESSION_ID`, finds transcripts without reproducing Claude's private project-path encoding, and defers malformed or unfamiliar records to Claude.

The bundled regression suite runs independently under zsh and fish in CI. Its 15 cases per shell cover the original collision, generated-ID replay, malformed input, configuration isolation, and project-key variation.

Verification:

- The complete cookbook gate passes in Ubuntu 22.04: shellcheck, zsh and fish parsing, ruff, and all Python recipe tests.
- The new suite fails against the previous wrapper at seven assertions per shell, including the bridge-only collision, generated-id replay and malformed tab-id handling.
- Weakening the bridge classifier makes the truncated-record regression fail at the expected assertion.
- Claude Code 2.1.251 starts the derived UUID and reaches its prompt while the original bridge-only file remains in place.
