### PR TITLE
Reveal a truncated sidebar row name on hover

### DIFF
--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -31,6 +31,21 @@ final class SidebarCellView: NSTableCellView {
         addButtonWidthConstraint.constant = visible ? Self.addButtonWidth : 0
     }
 
+    override func layout() {
+        super.layout()
+        updateNameTooltip()
+    }
+
+    /// Reveals the full name on hover, but only while the row is too narrow to show it: the label truncates by
+    /// tail and nothing else exposes what was cut. A tooltip repeating already-visible text would be noise, so
+    /// the width decides. Runs from `layout`, so dragging the sidebar divider re-evaluates it. Skipped mid-rename
+    /// — the field editor holds the text then, and `stringValue` is whatever has been typed so far.
+    private func updateNameTooltip() {
+        guard let field = textField, field.currentEditor() == nil else { return }
+        let available = field.cell?.titleRect(forBounds: field.bounds).width ?? field.bounds.width
+        field.toolTip = field.attributedStringValue.size().width > available ? field.stringValue : nil
+    }
+
     // hover tracking for the "+" reveal, workspace cells only (session cells have no button to show)
     override func updateTrackingAreas() {
         super.updateTrackingAreas()

--- a/agtermTests/SidebarRowViewsTests.swift
+++ b/agtermTests/SidebarRowViewsTests.swift
@@ -1,0 +1,141 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the sidebar row's name tooltip: it appears only while the label is too narrow to
+/// show the whole name, and clears again once the name fits.
+@MainActor
+final class SidebarRowViewsTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+    private var window: NSWindow!
+    private var scroll: NSScrollView!
+    private var outline: SidebarOutlineView!
+    private var coordinator: WorkspaceSidebar.Coordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-row-views-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            window?.orderOut(nil)
+            window = nil
+            scroll = nil
+            outline = nil
+            coordinator = nil
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testATruncatedNameGetsTheFullNameAsItsTooltip() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        let name = "PROJ-123 enforce the storage quota on the plan endpoint before the billing cutover"
+        store.renameSession(session.id, to: name)
+        coordinator.reconcile()
+
+        let field = try renderedNameField(forSession: session.id)
+        XCTAssertEqual(field.toolTip, name,
+                       "a name the row cannot show needs a hover reveal; the label truncates with no other way to read it")
+    }
+
+    func testANameThatFitsGetsNoTooltip() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        store.renameSession(session.id, to: "api")
+        coordinator.reconcile()
+
+        let field = try renderedNameField(forSession: session.id)
+        XCTAssertNil(field.toolTip, "a fully visible name needs no tooltip; repeating it on hover is noise")
+    }
+
+    func testWideningTheRowClearsAToolTipItNoLongerNeeds() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        store.renameSession(session.id, to: "PROJ-123 enforce the storage quota on the plan endpoint")
+        coordinator.reconcile()
+        let narrow = try renderedNameField(forSession: session.id)
+        XCTAssertNotNil(narrow.toolTip, "the narrow sidebar should truncate this name")
+        let narrowWidth = narrow.bounds.width
+
+        setSidebarWidth(CGFloat(AppStore.sidebarWidthMax))
+
+        let field = try renderedNameField(forSession: session.id)
+        XCTAssertGreaterThan(field.bounds.width, narrowWidth,
+                             "the row must widen here, or the tooltip assertion below proves nothing")
+        XCTAssertNil(field.toolTip, "dragging the divider wider must re-evaluate, or a stale tooltip lingers")
+    }
+
+    private func buildSidebar(for store: AppStore) {
+        outline = SidebarOutlineView()
+        coordinator = WorkspaceSidebar.Coordinator(store: store, actions: actions)
+        outline.dataSource = coordinator
+        outline.delegate = coordinator
+        outline.headerView = nil
+        outline.rowSizeStyle = .custom
+        outline.rowHeight = AppSettings.sidebarRowHeight(fontSize: GhosttyApp.shared.sidebarFontSize)
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        column.resizingMask = .autoresizingMask
+        outline.addTableColumn(column)
+        outline.outlineTableColumn = column
+
+        scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: Self.narrowSidebar, height: 400))
+        scroll.documentView = outline
+        window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: Self.narrowSidebar, height: 400),
+                          styleMask: [.titled], backing: .buffered, defer: false)
+        // over-releases a window the registry may still hold, crashing the host at autorelease-pool pop
+        window.isReleasedWhenClosed = false
+        window.contentView = scroll
+
+        coordinator.outlineView = outline
+        coordinator.renameController.outlineView = outline
+        coordinator.seedExpansionFromModel()
+        coordinator.reconcile()
+        setSidebarWidth(Self.narrowSidebar)
+    }
+
+    /// Both widths these tests use must stay inside the divider's own 160...560 range, or a truncation
+    /// threshold that no drag can actually clear would still pass here.
+    private static let narrowSidebar: CGFloat = 240
+
+    /// Drives the width the way a divider drag does: the column tracks the outline, and the row views retile
+    /// off that. Without it the column keeps its default width and every row measures the same regardless of
+    /// the window, which makes a truncation assertion pass for the wrong reason.
+    private func setSidebarWidth(_ width: CGFloat) {
+        window.setContentSize(NSSize(width: width, height: 400))
+        scroll.frame = NSRect(x: 0, y: 0, width: width, height: 400)
+        outline.frame = NSRect(x: 0, y: 0, width: width, height: outline.frame.height)
+        outline.sizeLastColumnToFit()
+        outline.layoutSubtreeIfNeeded()
+    }
+
+    private func renderedNameField(forSession id: UUID) throws -> NSTextField {
+        outline.layoutSubtreeIfNeeded()
+        let row = try XCTUnwrap((0..<outline.numberOfRows).first { index in
+            guard let node = outline.item(atRow: index) as? SidebarNode else { return false }
+            return node.kind == .session && node.id == id
+        }, "the session row should be visible in the outline")
+        let cell = try XCTUnwrap(outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? SidebarCellView)
+        cell.layoutSubtreeIfNeeded()
+        return try XCTUnwrap(cell.textField)
+    }
+}


### PR DESCRIPTION
a sidebar row label truncates by tail and nothing revealed what was cut, so a session or workspace name wider than the sidebar could only be read by renaming it or dragging the divider.

`SidebarCellView.layout` now sets the name field's `toolTip` to the full string while the text does not fit, and clears it once it does, so a widened sidebar stops repeating text already on screen. Skipped while a rename is in progress, where the field editor owns the text. Both row kinds get it, since they share the cell.

the measurement compares `attributedStringValue.size().width` against the cell's `titleRect`, which accounts for the cell's own insets and does not depend on `lineBreakMode`. Running it from `layout` rather than the cell-configure path is what makes a divider drag re-evaluate.

three hosted tests in `agtermTests/SidebarRowViewsTests.swift`: a truncated name gets the tooltip, a name that fits gets none, and widening clears one that is no longer needed. They size the table column by hand, which the existing sidebar test harness does not do, so without it every row measures the same width regardless of the window and a truncation assertion passes for the wrong reason. Both widths stay inside the divider's own 160 to 560 range.

tested with `swift test` (2794), `make test-app` (371) and `make lint`.

Related to #518
