### PR TITLE
Remote sessions: attach a session running on another Mac

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -156,7 +156,7 @@ renumbering. Do not reintroduce a count anywhere.
   `.fullscreen`, `.minimize`
 - `keymap.reload`, `keymap.list`, `config.reload`, `theme.set`, `theme.list`, `restore.capture`,
   `restore.clear`, `restore.mode`, `version`
-- `zmx.list`, `zmx.prune`, `zmx.kill`
+- `zmx.list`, `zmx.prune`, `zmx.kill`, `zmx.tree`, `zmx.attach`
 
 `debug.appearance` is a private `Command` case, absent from the list above, used only by `AppearanceFlipUITests`.
 It accepts light/dark, sets `NSApp.appearance`, posts `.agtermSystemAppearanceChanged`, echoes the effective
@@ -660,7 +660,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 
 - Session nodes include foreground/split foreground argv, idle shell basenames, background spec, overlay
   size, pane overlays, split axis, split ratio, split focus, status fields, flag, unseen, restore pins,
-  surfaces, `realized`, and `backedByZmx`.
+  surfaces, `realized`, `backedByZmx`, and `remoteHost`.
 - `foregroundShell`/`splitForegroundShell` name the RECOGNIZED shell HOLDING a pane's foreground, present
   exactly when that pane's `foreground` is absent because a shell holds it.
   For a pane that EXISTS, neither field means agterm could not determine the foreground state — a bare nil
@@ -677,6 +677,8 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   classifier behind both the tree read and the restore capture, so it would change what restore re-runs too.
   The basename comes from `stripLoginDash(argv)[0]`, in that order: `basename` splits on `/`, so it drops the
   login mark from `-/bin/zsh` but keeps it on the bare `-zsh`.
+- `remoteHost` names the machine a teleported session is attached to and is omitted for a local one. It is
+  live-only: a remote session is never persisted, so it cannot survive a relaunch.
 - `backedByZmx` on a session is true only when every existing primary/split pane is currently backed.
   Primary/split entries in `surfaces` report their own Boolean; scratch and overlays omit it. Older servers
   omit both levels. There is no sidebar indicator.
@@ -812,6 +814,140 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   already gone. The suppression is gated on `backedByZmx`: a requested-live launch that fell back keeps its
   claimed daemons while each pane runs a plain shell, so an ungated kill would close a pane that never
   attached to what it destroyed.
+
+## Remote sessions
+
+- `zmx.tree` lists another Mac's attachable sessions and `zmx.attach` opens one of them here. Each attach
+  imports one session, its split included; whole-workspace teleport is out of scope, and several remote
+  rows may sit side by side.
+- A row carries what a PICKER needs, not only what attach needs. Without that a caller has to run a second
+  ssh and join `agtermctl tree --json` by session id, paying another authentication for data the walk
+  already held and discarded. The exact fields are below.
+- A remote pane is an ORDINARY command surface whose command is ssh. There is no new surface kind, no new
+  lifecycle and no remote daemon ownership, so closing locally tears the surface down, ssh dies, and the
+  far-side daemon survives. No command asks the remote zmx to kill anything. `Session.remoteHost` is model
+  metadata, and persistence, ownership, icon and factory routing all read it.
+- `zmx list` carries the `endpoint` header — the zmx executable and its `ZMX_DIR` — because neither is
+  guessable from another machine. It is INJECTED from `ZmxClient` through the restored runtime, never
+  recomputed from the process environment, which would duplicate runtime selection and break hosted tests
+  that inject a client. Optional on the wire, so a remote reader tells an older server apart by absence and
+  refuses rather than half-attaching.
+- `zmx.tree`'s host is OPTIONAL, and that is the whole design. Bare, it builds this app's own attachable
+  sessions across every open window; with a host, it sshes once and runs the BARE form on the far side.
+  So the far-side operation is an ordinary public command a user can run and test on its own, there is no
+  second "internal export" noun, and one document comes back already joined. Nothing is composed across
+  two remote calls, which is what removed the framing marker, the two-sequential-calls race, and the
+  extra authentication.
+- The far side cannot know which name reached it, so `ControlRemoteTree.host` is stamped by the
+  REQUESTING app after decoding and is the validated ssh destination it was given, never a self-reported
+  hostname. It is absent from the bare local answer, which sshed nowhere.
+- Still read the exit status BEFORE the output. `agtermctl --json` prints a not-ok response to stdout and
+  exits nonzero, and an ssh that dies mid-write leaves output that may still parse, so an ok-looking
+  payload from a nonzero process is never accepted.
+- Scope is EVERY open window on the far side, keyed by a live store the way `openCounts` tests it. Rows
+  are flat and carry `windowID`/`windowName` and `workspaceID`/`workspaceName`: show the names, group by
+  the ids, because neither rename path nor `addWorkspace` enforces uniqueness, so two windows called
+  `main` and a `dev` workspace in each are ordinary and name-grouping silently merges them.
+- A session is offered only when the store reports `backedByZmx` AND every pane resolves to a `claimed`
+  daemon observed `running` under an agterm daemon name. A claimed daemon alone proves nothing: a
+  requested-live launch that fell back preserves its daemons while showing fresh shells. An incomplete
+  split is dropped whole, never offered half. These are ELIGIBILITY rules, not only a defence against a
+  race, so losing the two network reads does not retire them: the zmx observation is still a subprocess
+  snapshot taken beside the model walk. They now run on whichever side owns the sessions, which is the
+  far side for a remote call.
+- An empty candidate list is a SUCCESSFUL answer and deliberately does not distinguish "not running live"
+  from "live with nothing eligible". `zmx list` is the restore-mode diagnostic; no surface may claim the
+  empty list diagnoses the mode.
+- The attach argv appends a create-only guard command that exits nonzero. Stock `zmx attach` CREATES a
+  daemon whose name is absent, so a daemon that vanished since the tree was read would otherwise hand back
+  a fresh remote shell wearing the session's name. An existing daemon ignores the command; a vanished one
+  runs it and fails visibly.
+- The attach `env` sets the same FOUR variables the local pane sets in `ZmxSupport`: `ZMX_DIR` plus empty
+  `ZMX_SESSION` and `ZMX_SESSION_PREFIX` and `ZMX_NO_DETACH_KEY=1`. Empty rather than `env -u` because zmx
+  reads each as `getenv orelse ""` with a length check, so empty IS unset to it, and because one
+  convention across both panes beats two spellings of one intent. An inherited `ZMX_SESSION` is the
+  dangerous one: attach reads it first and SWITCHES session instead of attaching, never reaching the
+  create-only guard. An inherited `ZMX_SESSION_PREFIX` resolves a name agterm never created, since its
+  daemons are always unprefixed. The detach key is disabled for the same reason as locally — a detached
+  pane has no way back. The tree read needs none of this: it goes through the far side's own app.
+- Two ssh shapes. Tree uses `-T` plus an outer process deadline, `ConnectTimeout` bounding the handshake
+  only; attach uses `-tt`, because a remote command does not reliably get a pty and zmx reads termios and
+  window size, and carries no lifetime deadline. Both pass `BatchMode=yes`, so key-based non-interactive
+  auth is a precondition and a host-key or password prompt is a failure rather than a question a
+  dispatcher could answer. The host is refused rather than escaped; paths and the remote command are
+  argv-quoted.
+- Neither the host nor the session target is echoed into an error unless it PASSED validation. `invalid
+  host` is a constant, and `zmx.attach` refuses a session carrying EMBEDDED whitespace or a control
+  character through the same `RemoteSession.isPlain` the argv builders use — outer whitespace is trimmed
+  before the check — so the unresolved-session message can name the id it could not find. The later host
+  interpolations are safe because reaching them means `treeCommand` already accepted it. JSON encoding
+  escapes control bytes, so the protocol framing was never at risk; `agtermctl` decodes and prints to a
+  terminal, which is what this closes. Remote-supplied error detail is deliberately NOT sanitized beyond
+  an edge trim: an ssh failure is worth reading intact, and a chosen remote is the same trust model as
+  running ssh by hand.
+- The far side needs `agtermctl` on sshd's remote-command PATH — a machine merely running agterm has no
+  CLI an ssh command can find, and the read fails with exit 127. sshd's compiled-in default is
+  `/usr/bin:/bin:/usr/sbin:/sbin`, so the tree chain APPENDS `CommandPath.standardDirectories`:
+  `/usr/local/bin` where the Help action links, `/opt/homebrew/bin` where the cask does. Appending is what
+  leaves a PATH deliberately supplied to sshd, and a custom agtermctl already on it, ahead of those two.
+  State this precondition on every surface describing the setup, not only where it is demonstrated:
+  `site/docs.html`, `site/commands.html`, `reference.md`, `SKILL.md` and `examples.md`.
+- That chain travels as `/bin/sh -c '<chain>'` because sshd runs a remote command through the ACCOUNT's
+  shell, where a bare `VAR=value` assignment is a syntax error in fish and tcsh — the whole read then
+  fails before the first `agtermctl`, so it is not merely a PATH that failed to widen. `attachCommand`
+  already followed the same one-command rule, reaching it through `/usr/bin/env ZMX_DIR=...` rather than
+  an assignment. The account shell can also change under a running agterm: live-backed panes survive a
+  `chsh` that a later sshd command then honors.
+- The runner is async behind an injected seam. `ControlActions` is `@MainActor`, so a blocking wait would
+  freeze the UI for the whole network deadline, and the fake is what lets the end-to-end tests run without
+  a second Mac.
+- `zmx.tree` and `zmx.attach` are the ONLY commands `handleConnection` moves off the accept thread, and
+  that thread's own descriptor close moves with them. Everything else stays inline, because dispatch
+  refreshes the window cache in the same execution the fast path reads. Running an ssh inline instead
+  makes `zmx tree <this machine>` DEADLOCK: the far side's own `agtermctl` waits in the backlog this
+  connection is holding. Local `zmx.list` blocks that thread too, on a subprocess bounded at 3s, and
+  stays inline deliberately — contention is not deadlock. `ControlServerTests` pins the free accept
+  thread by probing `window.list`, which the cache answers with no main-actor hop, so only a held ACCEPT
+  thread can fail it.
+- `zmx.attach` re-runs the remote resolution itself before touching the model, since a picker's answer can
+  be minutes old. Discovery, endpoint validation, pane resolution and command construction are all
+  pre-model failures leaving no half-built row; ssh itself starts AFTER insertion, so a transport failure
+  is an ordinary pane exit on the held path. It matches the
+  session by ID ALONE — remote names are mutable and non-unique across workspaces — and panes by role,
+  never array position. The row lands in the frontmost window's current workspace and is selected.
+- The local cwd is this machine's home, not the remote one: libghostty chdirs the ssh process here and a
+  path that exists on the far side may not exist locally. The attached shell reports its real cwd through
+  the terminal stream.
+- Both panes set `commandWait`/`splitCommandWait`, so `shouldCloseOnChildExitAction` returns false, Ghostty
+  holds its own press-any-key prompt, and the wrapper's one sanitized line — host, session, pane, exit
+  status — can be read under the last remote screen. It says nothing about reconnecting: the picker is a
+  keymap custom command the user supplies. There is NO timer, notification or session-wide coalescing;
+  returning false dispatches no app callback, so app code does not learn ssh exited until the keypress, and
+  each pane holding and closing on its own is also right when one half of a split dies.
+- `Session.remoteHost` is immutable and set at construction, because `addSession` saves: a marker written
+  afterwards would let one snapshot reach disk carrying the ssh command. `isPersistable` gates every
+  producer — the launch snapshot, the Recent Closed session record, and a closed workspace's record, whose
+  `sessionCount` and `selectedSessionID` are recomputed after filtering. The in-memory pending-close record
+  keeps remote sessions, so the three-second undo still restores the row.
+- `Session.locallyManagedPaneIdentities` is the single local-ownership predicate, empty for a remote
+  session, read by `finalizePaneIdentities`, the direct `closeSplit` finalizer path, `liveClaims` and live
+  `finalizeWindowPanes`. Without it `liveClaims` invents an `agterm-<uuid>` claim for a pane whose daemon
+  is on another machine and the zmx commands resolve a session agterm does not manage. Structural
+  `paneIdentity` stays valid either way: swap, promotion and control addressing still need it.
+- `ZmxLaunch.wrapsLocally` is the one gate both surface factories read, so a remote pane is never wrapped
+  in a local daemon. Wrapping buys nothing for a session that never restores, and under live mode window
+  close would drop the local client while the daemon kept ssh connected with no UI showing it.
+- Accepted v1 limitations, documented rather than built around. Pinned zmx keeps one `leader_client_fd` and
+  our attach is a follower, so the snapshot arrives at the FAR side's geometry and does not resize until
+  the first classified keystroke calls `setLeader`:
+  - before that keystroke follower input is DROPPED, not merely non-claiming, so mouse, focus and Ctrl-L
+    never reach the remote and a mouse-first TUI looks dead;
+  - leadership is per DAEMON, so a typed primary can sit beside a split still at the far side's geometry;
+  - on detach each daemon we led keeps our geometry until it receives qualifying input or a resize report,
+    while panes we never claimed stay correct.
+
+  An opt-in upstream `zmx attach --take-leadership` with handback would remove all three and is not part of
+  this work.
 
 ## Session backgrounds
 

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -84,6 +84,10 @@ paths:
 - In tree mode, flagged rows swap to `terminal.fill` or `rectangle.split.2x1.fill`; flagged mode retains
   unfilled base icons because every row is flagged. This same-size symbol swap avoids layout shift.
   `RowContent.flagged` limits reload to the changed row.
+- A remote row (`Session.remoteHost != nil`) takes `arrow.up.forward.app` instead, and there the FILL means
+  split rather than flagged: a hidden split is state nothing else reveals, while the fill is tree-mode
+  decoration the flat flagged view already passes `flagged: false` for. The split axis is not
+  distinguished — no remote-looking symbol family carries both arrangements. See [[control-api]].
 
 ## Workspace focus
 

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -373,6 +373,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ForegroundProcess.command(for: view, shellBasename: shell, zmxSnapshot: snapshot)
         }
     ) -> Int {
+        // filtered here rather than at each caller, so quit and `restore.capture` get the same rule: a
+        // remote pane's foreground is an ssh client the save then drops, and reading it both inflates the
+        // reported count and spends the exit budget on a pane nothing will persist
+        let sessions = sessions.filter(\.isPersistable)
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: exitCaptureBudget)

--- a/agterm/Control/ControlServer+Zmx.swift
+++ b/agterm/Control/ControlServer+Zmx.swift
@@ -20,12 +20,141 @@ extension ControlServer {
         let walk = library.paneClaims()
         let result = ZmxInventory.join(observed: observed, claims: walk.claims,
                                        inventoryComplete: walk.complete)
-        let inventory = ControlZmxInventory(restore: restoreStatus(), result: result)
+        let inventory = ControlZmxInventory(restore: restoreStatus(), result: result,
+                                            endpoint: client.endpoint)
         return ControlResponse(ok: true, result: ControlResult(zmx: inventory))
     }
 }
 
 extension ControlServer {
+    /// Attachable sessions: this app's own when `host` is nil, another machine's when it is not.
+    ///
+    /// The remote form runs the BARE form over ssh, so the far side does the whole join in one walk of its
+    /// own windows and answers with a single document. Nothing is composed across two remote calls, so
+    /// there is no framing and no window where the far side's topology can move between reads.
+    func remoteTree(host: String?) async -> ControlResponse {
+        guard let host else { return localAttachableSessions() }
+        let argv: [String]
+        do {
+            argv = try RemoteSession.treeCommand(host: host)
+        } catch {
+            // the host is NOT echoed: reaching here means validation rejected it, and it is rejected for
+            // carrying control characters, which agtermctl would print to a terminal after JSON decoding
+            return ControlResponse(ok: false, error: "invalid host")
+        }
+        let result = await remoteRunner.run(argv, deadline: Self.remoteTreeDeadline)
+        guard result.status == 0 else {
+            // stdout first: the remote's agtermctl prints a not-ok response there and exits nonzero, so
+            // its own sentence never reaches stderr. ssh's own failures do. An ok-looking payload from a
+            // nonzero process is never accepted, which is why the status is read before the output.
+            let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let detail = RemoteTreeMerger.remoteError(stdout: result.stdout) ?? (stderr.isEmpty ? nil : stderr)
+            return ControlResponse(ok: false, error: detail ?? "the remote command failed on \(host)")
+        }
+        do {
+            let remote = try RemoteTreeMerger.decode(stdout: result.stdout)
+            // the far side cannot know which name reached it, so the destination we were given is stamped
+            // here rather than self-reported there
+            let stamped = ControlRemoteTree(host: host, endpoint: remote.endpoint, sessions: remote.sessions)
+            return ControlResponse(ok: true, result: ControlResult(remote: stamped))
+        } catch let error as RemoteTreeMerger.MergeError {
+            return ControlResponse(ok: false, error: error.message)
+        } catch {
+            return ControlResponse(ok: false, error: "the remote answer could not be read")
+        }
+    }
+
+    /// This app's own attachable sessions, across every OPEN window. An empty list is a successful answer
+    /// and does not distinguish "not running live" from "live with nothing eligible"; `zmx list` is the
+    /// restore-mode diagnostic.
+    private func localAttachableSessions() -> ControlResponse {
+        guard let client = zmxClient else {
+            return ControlResponse(ok: false, error: ControlZmxError.unavailable)
+        }
+        guard let observed = client.listSessions() else {
+            return ControlResponse(ok: false, error: "could not read the zmx session list")
+        }
+        let walk = library.paneClaims()
+        let inventory = ControlZmxInventory(restore: restoreStatus(),
+                                            result: ZmxInventory.join(observed: observed,
+                                                                      claims: walk.claims,
+                                                                      inventoryComplete: walk.complete),
+                                            endpoint: client.endpoint)
+        // a live store IS the open-window test, the same one `openCounts` uses: a closed window has no
+        // store, and its panes are not attachable from here anyway
+        let windows = library.windows.compactMap { entry in
+            library.store(for: entry.id).map {
+                RemoteWindowProjection(id: entry.id.uuidString, name: entry.name, tree: buildTree(in: $0))
+            }
+        }
+        do {
+            let tree = try RemoteTreeMerger.candidates(windows: windows, inventory: inventory)
+            return ControlResponse(ok: true, result: ControlResult(remote: tree))
+        } catch let error as RemoteTreeMerger.MergeError {
+            return ControlResponse(ok: false, error: error.message)
+        } catch {
+            return ControlResponse(ok: false, error: "the session list could not be built")
+        }
+    }
+
+    /// Create a local session attached to one of `host`'s.
+    ///
+    /// The remote is resolved again here rather than trusted from whatever the caller last saw: a picker's
+    /// answer can be minutes old, and a daemon that has gone since would otherwise be CREATED by the
+    /// attach, handing back a fresh shell wearing the session's name. Everything that can fail is checked
+    /// before the model is touched, so a refusal leaves no half-built row behind.
+    func attachRemoteSession(host: String, session: String) async -> ControlResponse {
+        let discovery = await remoteTree(host: host)
+        guard discovery.ok, let tree = discovery.result?.remote else { return discovery }
+        // by id only: remote session names are mutable and deliberately non-unique across workspaces, and
+        // `zmx tree` prints the id for exactly this hand-off
+        guard let remote = tree.sessions.first(where: { $0.id == session }) else {
+            return ControlResponse(ok: false, error: "no attachable session \(session) on \(host)")
+        }
+        guard let store = library.activeStore, let workspace = store.currentWorkspaceID else {
+            return ControlResponse(ok: false, error: "no window to attach into")
+        }
+        // by role, never by position: a payload with two lefts or no left must fail rather than quietly
+        // become one pane, or the wrong one
+        let byRole = Dictionary(remote.panes.map { (ZmxPaneRole(controlName: $0.pane), $0.daemon) },
+                                uniquingKeysWith: { first, _ in first })
+        guard byRole.count == remote.panes.count, let left = byRole[.left] else {
+            return ControlResponse(ok: false, error: "\(host) reported panes agterm cannot address")
+        }
+        let right = byRole[.right]
+        let primary: String
+        let split: String?
+        do {
+            primary = try paneCommand(host: host, tree: tree, daemon: left, name: remote.name, pane: .left)
+            split = try right.map {
+                try paneCommand(host: host, tree: tree, daemon: $0, name: remote.name, pane: .right)
+            }
+        } catch {
+            return ControlResponse(ok: false, error: "\(host) reported a session agterm cannot address")
+        }
+        // the LOCAL working directory, not the remote one: libghostty chdirs the ssh process here, and a
+        // path that exists on the far side may not exist on this Mac. The attached shell reports its real
+        // cwd through the terminal stream anyway.
+        guard let created = store.addSession(toWorkspace: workspace, cwd: NSHomeDirectory(),
+                                             command: primary, name: remote.name, wait: true,
+                                             remoteHost: host) else {
+            return ControlResponse(ok: false, error: "could not create the session")
+        }
+        if let split {
+            created.splitInitialCommand = split
+            created.splitCommandWait = true
+            store.setSplitVisibility(created.id, shown: true,
+                                     axis: remote.splitAxis.flatMap(SplitAxis.init(rawValue:)) ?? .leftRight)
+        }
+        return ControlResponse(ok: true, result: ControlResult(id: created.id.uuidString))
+    }
+
+    private func paneCommand(host: String, tree: ControlRemoteTree, daemon: String, name: String,
+                             pane: ZmxPaneRole) throws -> String {
+        try RemoteSession.attachPaneCommand(host: host, endpoint: tree.endpoint, daemon: daemon,
+                                            session: name, pane: pane)
+    }
+
     /// Kill the daemons the inventory shows as unclaimed and detached.
     ///
     /// The gate is checked and revalidated, never atomic: pinned zmx has no kill-if-detached, so this

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -137,10 +137,20 @@ final class ControlServer {
     /// backend is unavailable rather than pretending an empty listing.
     let zmxClient: ZmxClient?
 
+    /// Runs the ssh invocations behind the remote commands. Injectable so hosted tests drive them against
+    /// a fake instead of a second Mac.
+    let remoteRunner: any RemoteCommandRunner
+
+    /// How long a remote projection read may take before it is abandoned. `ConnectTimeout` bounds only the
+    /// handshake, so this is what covers a remote agterm that never answers.
+    static let remoteTreeDeadline: TimeInterval = 10
+
     init(library: WindowLibrary, actions: AppActions, settingsModel: SettingsModel, identity: AppIdentity,
          launchRestoreMode: RestoreMode = GhosttyApp.shared.launchRestoreMode,
          zmxForegroundResolver: ZmxForegroundResolver? = nil, zmxClient: ZmxClient? = nil,
+         remoteRunner: (any RemoteCommandRunner)? = nil,
          socketPath: String? = nil) {
+        self.remoteRunner = remoteRunner ?? RemoteCommandProcessRunner()
         self.library = library
         self.actions = actions
         self.settingsModel = settingsModel
@@ -340,7 +350,9 @@ final class ControlServer {
     /// Read one newline-delimited request from `conn`, decode it, dispatch it on `server` (main actor), write
     /// the response back, close. A decode failure replies with a structured error. Runs on the background queue.
     nonisolated private static func handleConnection(_ conn: Int32, server: ControlServer) {
-        defer { close(conn) }
+        // the remote commands hand the descriptor to a thread of their own, which then owns closing it
+        var handedOff = false
+        defer { if !handedOff { close(conn) } }
         // a write to a client that already hung up would raise the default-fatal SIGPIPE and take the whole
         // app down mid-request; SO_NOSIGPIPE turns it into a normal EPIPE write error.
         var noSigPipe: Int32 = 1
@@ -376,10 +388,29 @@ final class ControlServer {
             return
         }
 
+        // `zmx tree <this machine>` would otherwise deadlock against itself: the far side's own agtermctl
+        // waits in this server's backlog while this connection holds the only accept thread.
+        if Self.waitsOnNetwork(request.cmd) {
+            handedOff = true
+            let worker = Thread {
+                defer { close(conn) }
+                writeResponse(conn, runBlocking { await server.dispatch(request) })
+            }
+            worker.name = "com.umputun.agterm.control.remote"
+            worker.start()
+            return
+        }
+
         // hop to the main actor, blocking this background thread. dispatch refreshes the window cache in that
         // same execution, so the fast path sees this command's mutations without a second, stallable hop.
         let response = runBlocking { await server.dispatch(request) }
         writeResponse(conn, response)
+    }
+
+    /// Commands whose dispatch awaits an ssh round trip. `zmx.attach` re-resolves the remote first, so it
+    /// carries the same wait; local `zmx.list` blocks too, but bounded, and stays inline to keep cache order.
+    nonisolated private static func waitsOnNetwork(_ cmd: Command) -> Bool {
+        cmd == .zmxTree || cmd == .zmxAttach
     }
 
     /// Read bytes from `conn` up to (and excluding) the first newline. Returns nil on EOF-before-newline, a
@@ -471,7 +502,8 @@ final class ControlServer {
                 .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
                 .windowFullscreen, .windowMinimize,
-                .restoreClear, .restoreCapture, .restoreMode, .zmxList, .zmxPrune, .zmxKill, .dashboard, .version:
+                .restoreClear, .restoreCapture, .restoreMode, .zmxList, .zmxPrune, .zmxKill, .zmxTree,
+                .zmxAttach, .dashboard, .version:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)

--- a/agterm/Control/RemoteCommandProcessRunner.swift
+++ b/agterm/Control/RemoteCommandProcessRunner.swift
@@ -1,0 +1,82 @@
+import Foundation
+import agtermCore
+
+/// Runs an ssh invocation off the main actor so the UI is free while the network is slow.
+///
+/// The deadline is the caller's, not ssh's: `ConnectTimeout` ends at the handshake and cannot bound a
+/// remote command that never returns.
+struct RemoteCommandProcessRunner: RemoteCommandRunner {
+    /// Grace between SIGTERM and SIGKILL, matching `ZmxClient.terminationGrace`.
+    private static let terminationGrace: TimeInterval = 0.25
+
+    func run(_ argv: [String], deadline: TimeInterval) async -> RemoteCommandResult {
+        await withCheckedContinuation { continuation in
+            Thread.detachNewThread {
+                continuation.resume(returning: Self.execute(argv, deadline: deadline))
+            }
+        }
+    }
+
+    private static func execute(_ argv: [String], deadline: TimeInterval) -> RemoteCommandResult {
+        guard let executable = argv.first else {
+            return RemoteCommandResult(status: -1, stdout: "", stderr: "no command to run")
+        }
+        let process = Process()
+        // env resolves `ssh` through PATH, so a user who put their own ahead of /usr/bin keeps it
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = argv
+        let output = Pipe()
+        let errors = Pipe()
+        process.standardOutput = output
+        process.standardError = errors
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+        do {
+            try process.run()
+        } catch {
+            return RemoteCommandResult(status: -1, stdout: "",
+                                       stderr: "could not run \(executable): \(error.localizedDescription)")
+        }
+
+        // both pipes drain on their own threads while this one holds the deadline. Reading here instead
+        // would make the deadline unreachable — `readDataToEndOfFile` returns only once the child closes
+        // the pipe — and reading them in sequence deadlocks the moment the child fills the other one.
+        let stdoutSink = Sink(output.fileHandleForReading)
+        let stderrSink = Sink(errors.fileHandleForReading)
+        let timedOut = finished.wait(timeout: .now() + deadline) == .timedOut
+        if timedOut {
+            process.terminate()
+            if finished.wait(timeout: .now() + terminationGrace) == .timedOut {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                process.waitUntilExit()
+            }
+        }
+        // joined after the process is gone, so its pipes are closed and the sinks have seen EOF: returning
+        // on the semaphore alone can beat the tail of the output out of the pipe.
+        let stdout = stdoutSink.wait()
+        let stderr = stderrSink.wait()
+        guard !timedOut else {
+            return RemoteCommandResult(status: -1, stdout: "", stderr: "the remote did not answer in time")
+        }
+        return RemoteCommandResult(status: process.terminationStatus, stdout: stdout, stderr: stderr)
+    }
+
+    /// One pipe drained to EOF on its own thread. Each sink owns its storage outright, so the two never
+    /// share state and the only synchronisation is the join.
+    private final class Sink: @unchecked Sendable {
+        private var data = Data()
+        private let done = DispatchSemaphore(value: 0)
+
+        init(_ handle: FileHandle) {
+            Thread.detachNewThread { [self] in
+                data = handle.readDataToEndOfFile()
+                done.signal()
+            }
+        }
+
+        func wait() -> String {
+            done.wait()
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+}

--- a/agterm/Ghostty/ZmxClient.swift
+++ b/agterm/Ghostty/ZmxClient.swift
@@ -47,6 +47,13 @@ final class ZmxClient {
         let killedAll: Bool
     }
 
+    /// What a caller on another machine needs to reach these daemons. Read from the injected client so a
+    /// hosted test answers for the client it built, not for whatever the process environment happens to
+    /// select.
+    var endpoint: ControlZmxEndpoint {
+        ControlZmxEndpoint(executable: executablePath, socketDirectory: socketDirectory)
+    }
+
     @discardableResult
     func reap(knownPaneIdentities: Set<UUID>?, launchDecision: RestoreLaunchDecision) -> ReapOutcome {
         let requestedMode = launchDecision.requested

--- a/agterm/Ghostty/ZmxLaunch.swift
+++ b/agterm/Ghostty/ZmxLaunch.swift
@@ -18,6 +18,14 @@ enum ZmxLaunch {
         let allowDebugOverride: Bool
     }
 
+    /// Whether this pane may be wrapped in a LOCAL zmx daemon; both surface factories gate on it. A remote
+    /// session never is — a wrapper would keep its ssh alive inside a surviving daemon after a window
+    /// close, with no UI showing it.
+    @MainActor
+    static func wrapsLocally(mode: RestoreMode, session: Session) -> Bool {
+        mode == .live && session.remoteHost == nil
+    }
+
     static let uiTestOptInKey = "AGTERM_UITEST_ENABLE_ZMX"
     static let uiTestBypassReason = "Live sessions are disabled for default UI tests."
     private static let logger = Logger(subsystem: "com.umputun.agterm", category: "ZmxLaunch")

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -73,7 +73,7 @@ extension WorkspaceSidebar.Coordinator {
             let showSplitIcon = session?.hasSplit == true
             let flagged = store.sidebarMode == .tree && session?.flagged == true
             cell.imageView?.image = iconForSession(split: showSplitIcon, axis: session?.splitAxis ?? .leftRight,
-                                                   flagged: flagged)
+                                                   flagged: flagged, remote: session?.remoteHost != nil)
             cell.imageView?.setAccessibilityIdentifier("session-icon")
         }
         // text/icon colors track the terminal theme; a selected row uses the selection foreground.
@@ -95,7 +95,13 @@ extension WorkspaceSidebar.Coordinator {
 
     /// The leading session-row icon: split-rectangle when split, else plain terminal, each swapped to its
     /// filled variant when `flagged` — tree mode only, the flat flagged view passes `flagged: false`.
-    private func iconForSession(split: Bool, axis: SplitAxis, flagged: Bool) -> NSImage? {
+    ///
+    /// A remote row takes its own glyph and keeps the split bit, not the flagged fill: a HIDDEN split is
+    /// state nothing else reveals, while the fill is tree-mode decoration the flat flagged view already
+    /// passes `flagged: false` for. So on a remote row the fill means split, not flagged. The axis is not
+    /// distinguished — no remote-looking symbol family carries both arrangements.
+    private func iconForSession(split: Bool, axis: SplitAxis, flagged: Bool, remote: Bool) -> NSImage? {
+        if remote { return split ? remoteSplitSessionIcon : remoteSessionIcon }
         switch (split, axis, flagged) {
         case (true, .topBottom, true): return flaggedHorizontalSplitSessionIcon
         case (true, .topBottom, false): return horizontalSplitSessionIcon

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -749,6 +749,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         lazy var flaggedSessionIcon = Self.rowIcon("terminal.fill")
         lazy var flaggedSplitSessionIcon = Self.rowIcon("rectangle.split.2x1.fill")
         lazy var flaggedHorizontalSplitSessionIcon = Self.rowIcon("rectangle.split.1x2.fill")
+        lazy var remoteSessionIcon = Self.rowIcon("arrow.up.forward.app")
+        lazy var remoteSplitSessionIcon = Self.rowIcon("arrow.up.forward.app.fill")
 
         private static func rowIcon(_ symbolName: String, weight: NSFont.Weight = .regular) -> NSImage? {
             let config = NSImage.SymbolConfiguration(pointSize: 13, weight: weight)

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -351,7 +351,7 @@ struct agtermApp: App {
         // foreground pid, so it is never captured and restores via the exec `command` path, keeping close-on-exit.
         // `LaunchSeedProvider` owns the precedence between them and resolves it at spawn time, not here, so
         // the pending slots stay on the session until the pane really spawns.
-        let zmx = ghostty.launchRestoreMode == .live
+        let zmx = ZmxLaunch.wrapsLocally(mode: ghostty.launchRestoreMode, session: session)
             ? ZmxLaunch.configuration(paneIdentity: session.paneIdentity, pane: "primary", environment: env)
             : nil
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,
@@ -514,7 +514,7 @@ struct agtermApp: App {
         // effectiveCwd. Font size matches the primary; env inherits the parent's window/workspace/session ids.
         // Creation, capture and override precedence matches the primary.
         let ghostty = GhosttyApp.shared
-        let zmx = ghostty.launchRestoreMode == .live
+        let zmx = ZmxLaunch.wrapsLocally(mode: ghostty.launchRestoreMode, session: session)
             ? ZmxLaunch.configuration(paneIdentity: session.splitPaneIdentity, pane: "split", environment: env)
             : nil
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -174,7 +174,10 @@ extension AppStore {
     /// resets `splitFocused`, else it points the collapsed view at the gone pane.
     public func closeSplit(_ sessionID: UUID, alreadyFinalized: UUID? = nil) {
         guard let session = session(withID: sessionID) else { return }
-        if let splitPaneIdentity = session.splitPaneIdentity, splitPaneIdentity != alreadyFinalized {
+        // through the ownership projection, not the raw identity: a remote split's daemon is on another
+        // machine and this finalizer only ever kills local ones
+        if let splitPaneIdentity = session.splitPaneIdentity, splitPaneIdentity != alreadyFinalized,
+           session.locallyManagedPaneIdentities.contains(splitPaneIdentity) {
             paneFinalizer?([splitPaneIdentity])
         }
         if let split = session.splitPaneIdentity { launchPaneDrop?([split]) }

--- a/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
@@ -150,7 +150,7 @@ extension AppStore {
                                    workspaceIndex: Int,
                                    sessionIndex: Int,
                                    id: UUID = UUID()) -> UUID? {
-        guard let recentClosedStore else { return nil }
+        guard let recentClosedStore, session.isPersistable else { return nil }
         recentClosedStore.record(RecentClosedItem(
             id: id,
             kind: .session,
@@ -172,14 +172,18 @@ extension AppStore {
                                      focusMember: Bool,
                                      id: UUID = UUID()) -> UUID? {
         guard let recentClosedStore else { return nil }
-        let sessionCount = workspace.sessions.count
+        // count and selection describe what Reopen will restore, so both follow the filtered snapshot:
+        // remote sessions are not in it, and a selection pointing at one would restore nothing
+        let snapshot = workspaceSnapshot(workspace)
+        let sessionCount = snapshot.sessions.count
+        let restorable = selectedSessionID.flatMap { id in snapshot.sessions.contains { $0.id == id } ? id : nil }
         recentClosedStore.record(RecentClosedItem(
             id: id,
             kind: .workspace,
             title: workspace.name,
             subtitle: "\(sessionCount) session\(sessionCount == 1 ? "" : "s")",
-            workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot(workspace),
-                                             selectedSessionID: selectedSessionID,
+            workspace: RecentClosedWorkspace(snapshot: snapshot,
+                                             selectedSessionID: restorable,
                                              focusMember: focusMember)
         ))
         recentClosedDidChange?()

--- a/agtermCore/Sources/agtermCore/AppStore+Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Snapshot.swift
@@ -11,20 +11,27 @@ extension AppStore {
     /// Builds a `Snapshot` of the current tree; each session captures its live `currentCwd` (or `initialCwd`
     /// if no PWD report arrived). Runs on `@MainActor`; the result is `Sendable`, safe to hand to a writer.
     public func snapshot() -> Snapshot {
-        let workspaceSnapshots = workspaces.map { workspace in
-            let sessions = workspace.sessions.map(sessionSnapshot)
-            // only a collapsed workspace writes the flag, so an all-expanded tree matches a legacy snapshot.
-            return WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: sessions,
-                                     collapsed: workspace.isExpanded ? nil : true)
-        }
+        let workspaceSnapshots = workspaces.map(workspaceSnapshot)
         // TREE order keeps the on-disk list deterministic (not the Set's hash order); an unmarked store omits
         // both focus keys, matching a file written before the set existed. `focusedWorkspaceID` stays unused.
         let focusIDs = workspaces.map(\.id).filter(focusedWorkspaceIDs.contains)
-        return Snapshot(selectedSessionID: selectedSessionID, workspaces: workspaceSnapshots,
+        let persistable = Set(workspaceSnapshots.flatMap(\.sessions).map(\.id))
+        let recency = sessionRecency.items.filter(persistable.contains)
+        return Snapshot(selectedSessionID: persistedSelection(among: persistable, recency: recency),
+                        workspaces: workspaceSnapshots,
                         sidebarWidth: sidebarWidth, sidebarVisible: sidebarVisible, sidebarMode: sidebarMode,
                         focusedWorkspaceIDs: focusIDs.isEmpty ? nil : focusIDs,
                         focusEnabled: focusEnabled ? true : nil,
-                        sessionRecency: sessionRecency.items)
+                        sessionRecency: recency)
+    }
+
+    /// The selection to write. A remote session is not in the snapshot, so naming it would restore an empty
+    /// window while local rows sit there; fall back to the most recent surviving session, then the first,
+    /// matching the MRU repair `reselectIfSelectionHidden` already does for a narrowed tree.
+    private func persistedSelection(among persistable: Set<UUID>, recency: [UUID]) -> UUID? {
+        if let selectedSessionID, persistable.contains(selectedSessionID) { return selectedSessionID }
+        guard selectedSessionID != nil else { return nil }
+        return recency.first ?? workspaces.flatMap(\.sessions).first { persistable.contains($0.id) }?.id
     }
 
     func sessionSnapshot(_ session: Session) -> SessionSnapshot {
@@ -47,8 +54,12 @@ extension AppStore {
                         context: session.context)
     }
 
+    /// The single workspace-to-disk producer, used by the launch snapshot and by a closed workspace's
+    /// Recent Closed record. Only a collapsed workspace writes the flag, so an all-expanded tree matches a
+    /// legacy snapshot.
     func workspaceSnapshot(_ workspace: Workspace) -> WorkspaceSnapshot {
-        WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: workspace.sessions.map(sessionSnapshot),
+        WorkspaceSnapshot(id: workspace.id, name: workspace.name,
+                          sessions: workspace.sessions.filter(\.isPersistable).map(sessionSnapshot),
                           collapsed: workspace.isExpanded ? nil : true)
     }
 

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -329,7 +329,7 @@ public final class AppStore {
                                           // no app-side closure like the font sizes above. An empty slot is
                                           // false, not omitted — "no terminal" either way to a caller.
                                           realized: session.surface?.isRealized ?? false,
-                                          context: session.context)
+                                          context: session.context, remoteHost: session.remoteHost)
             }
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID,
@@ -412,12 +412,15 @@ public final class AppStore {
     /// workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
-                           name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true) -> Session? {
+                           name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true,
+                           remoteHost: String? = nil) -> Session? {
         guard let wsIndex = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return nil }
         // both reach a custom command's expansion — cwd through initialCwd, name through customName — so
         // both are sanitized here. See TerminalText.
+        // `remoteHost` arrives here rather than being assigned after, because this call saves.
         let session = Session(initialCwd: TerminalText.sanitized(cwd),
-                              customName: name.map(TerminalText.sanitized)?.trimmedOrNil)
+                              customName: name.map(TerminalText.sanitized)?.trimmedOrNil,
+                              remoteHost: remoteHost)
         session.initialCommand = command
         session.commandWait = wait
         if let index {

--- a/agtermCore/Sources/agtermCore/CommandPath.swift
+++ b/agtermCore/Sources/agtermCore/CommandPath.swift
@@ -5,10 +5,10 @@
 /// `path_helper`. Without widening, a bare `agtermctl`, `jq` or `lazygit` in a keymap line exits 127 with
 /// the shell's own diagnostic discarded (#393).
 public enum CommandPath {
-    /// Appended when absent: the CLI install target, which reaches `PATH` only through `path_helper` and so
-    /// only in a login shell, and Homebrew's Apple Silicon prefix. Both are fixed macOS locations, not a
-    /// guess at the user's shell config, which the app cannot see.
-    private static let standardDirectories = [CLIInstall.installDirectory, "/opt/homebrew/bin"]
+    /// Appended when absent: the Help installer's target, which reaches `PATH` only through `path_helper`
+    /// and so only in a login shell, and the cask's — the route the README documents. `RemoteSession`
+    /// widens a REMOTE shell with the same list, so the two cannot disagree about where the CLI lives.
+    static let standardDirectories = [CLIInstall.installDirectory, "/opt/homebrew/bin"]
 
     /// The PATH a launchd-started app inherits, used when the environment carries none at all.
     static let launchdDefault = "/usr/bin:/bin:/usr/sbin:/sbin"

--- a/agtermCore/Sources/agtermCore/ControlActionsDefaults.swift
+++ b/agtermCore/Sources/agtermCore/ControlActionsDefaults.swift
@@ -26,6 +26,14 @@ public extension ControlActions {
         ControlResponse(ok: false, error: ControlActionsUnsupported.message("zmx.kill"))
     }
 
+    func remoteTree(host _: String?) async -> ControlResponse {
+        ControlResponse(ok: false, error: ControlActionsUnsupported.message("zmx.tree"))
+    }
+
+    func attachRemoteSession(host _: String, session _: String) async -> ControlResponse {
+        ControlResponse(ok: false, error: ControlActionsUnsupported.message("zmx.attach"))
+    }
+
     func splitSession(_ target: String?, window: String?, mode: String?, axis _: SplitAxis?) -> ControlResponse {
         splitSession(target, window: window, mode: mode)
     }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Zmx.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Zmx.swift
@@ -3,7 +3,33 @@ import Foundation
 extension ControlDispatcher {
     /// `restore.mode` and the `zmx` group. Split out of `ControlDispatcher.swift` so that file stays inside
     /// the 1000-line limit, following `+Hud` and `+Pick`.
-    func dispatchZmxCommand(_ request: ControlRequest) -> ControlResponse {
+    func dispatchZmxCommand(_ request: ControlRequest) async -> ControlResponse {
+        switch request.cmd {
+        case .zmxTree:
+            // no host is this app's own attachable sessions, which is also exactly what a `zmx tree HOST`
+            // runs on the far side
+            return await actions.remoteTree(host: request.args?.host?.trimmedOrNil)
+        case .zmxAttach:
+            guard let host = request.args?.host?.trimmedOrNil else {
+                return ControlResponse(ok: false, error: "zmx.attach requires a host")
+            }
+            // no `active` default: the target names a session on ANOTHER machine, which nothing local
+            // could resolve for the caller
+            guard let session = request.target?.trimmedOrNil else {
+                return ControlResponse(ok: false, error: "zmx.attach requires a remote session")
+            }
+            // the unresolved case names the id it could not find, so a control character here would reach
+            // a terminal through that message
+            guard RemoteSession.isPlain(session) else {
+                return ControlResponse(ok: false, error: "invalid remote session")
+            }
+            return await actions.attachRemoteSession(host: host, session: session)
+        default:
+            return dispatchLocalZmxCommand(request)
+        }
+    }
+
+    private func dispatchLocalZmxCommand(_ request: ControlRequest) -> ControlResponse {
         switch request.cmd {
         case .restoreMode:
             guard let raw = request.args?.mode else { return actions.readRestoreMode() }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -142,6 +142,12 @@ public protocol ControlActions {
     /// Destroy ONE pane's daemon. The host resolves the owner against the inventory rather than the open
     /// stores, since this reaches closed and unindexed claims the target resolver cannot see.
     func killZmxDaemon(target: String, window: String?, pane: ZmxPaneRole) -> ControlResponse
+    /// Another machine's attachable sessions. Async because it runs ssh: a blocking wait here would hold
+    /// the main actor for the whole network deadline.
+    func remoteTree(host: String?) async -> ControlResponse
+    /// Create a local session attached to `session` on `host`. Resolves the remote itself before inserting
+    /// anything, so a session that has gone since the tree was read creates nothing.
+    func attachRemoteSession(host: String, session: String) async -> ControlResponse
 }
 
 /// Routes control commands through a host-provided action seam. The dispatcher owns command parsing and
@@ -176,8 +182,10 @@ public struct ControlDispatcher {
             return dispatchWorkspaceCommand(request)
         case .quick, .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList,
                 .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
-                .sidebarCollapse, .sidebarWidth, .restoreClear, .restoreCapture, .restoreMode, .zmxList, .zmxPrune, .zmxKill, .version:
+                .sidebarCollapse, .sidebarWidth, .restoreClear, .restoreCapture, .version:
             return dispatchAppCommand(request)
+        case .restoreMode, .zmxList, .zmxPrune, .zmxKill, .zmxTree, .zmxAttach:
+            return await dispatchZmxCommand(request)
         case .quickType, .quickText:
             return await dispatchQuickCommand(request)
         case .windowNew, .windowList, .windowSelect, .windowClose, .windowRename,
@@ -728,8 +736,6 @@ public struct ControlDispatcher {
             return actions.clearRestoreCommands()
         case .restoreCapture:
             return actions.captureRestoreCommands()
-        case .restoreMode, .zmxList, .zmxPrune, .zmxKill:
-            return dispatchZmxCommand(request)
         default:
             preconditionFailure("unexpected app command: \(request.cmd.rawValue)")
         }

--- a/agtermCore/Sources/agtermCore/ControlPayloads.swift
+++ b/agtermCore/Sources/agtermCore/ControlPayloads.swift
@@ -79,17 +79,103 @@ public struct ControlZmxEntry: Codable, Sendable, Equatable {
     }
 }
 
+/// What a caller on another machine needs to reach these daemons over ssh. Neither is guessable from the
+/// far side, so a remote attach cannot be built without asking.
+public struct ControlZmxEndpoint: Codable, Sendable, Equatable {
+    /// Absolute path to the zmx this instance invokes: inside the app bundle, or a debug override.
+    public let executable: String
+    /// The `ZMX_DIR` its daemons live under, hashed from this instance's state directory.
+    public let socketDirectory: String
+
+    public init(executable: String, socketDirectory: String) {
+        self.executable = executable
+        self.socketDirectory = socketDirectory
+    }
+}
+
+/// One pane of a remote session and the daemon behind it.
+public struct ControlRemotePane: Codable, Sendable, Equatable {
+    /// `left` or `right`, matching the local pane vocabulary.
+    public let pane: String
+    public let daemon: String
+    /// Argv of what the far side reports running in this pane, so a caller can say what it is about to
+    /// attach to. Omitted when the remote reports none, which a plain idle shell does.
+    public let foreground: [String]?
+
+    public init(pane: String, daemon: String, foreground: [String]? = nil) {
+        self.pane = pane
+        self.daemon = daemon
+        self.foreground = foreground
+    }
+}
+
+/// A session on another machine, with every pane resolved to a live daemon. A session whose panes did not
+/// all resolve is absent rather than partial — see `RemoteTreeMerger`.
+public struct ControlRemoteSession: Codable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+    /// Where this session lives on the far side: show the names, group by the ids. Neither rename path
+    /// nor `addWorkspace` enforces uniqueness, so grouping by name merges two windows called `main`, and
+    /// the window id alone still merges two `dev` workspaces inside one of them.
+    public let windowID: String
+    public let windowName: String
+    public let workspaceID: String
+    public let workspaceName: String
+    /// The far side's own note of what the session is FOR, when its owner set one.
+    public let context: String?
+    public let cwd: String
+    /// Divider direction, present only for a session that has a split.
+    public let splitAxis: String?
+    public let panes: [ControlRemotePane]
+
+    public init(id: String, name: String, windowID: String, windowName: String, workspaceID: String,
+                workspaceName: String, context: String? = nil, cwd: String, splitAxis: String?,
+                panes: [ControlRemotePane]) {
+        self.id = id
+        self.name = name
+        self.windowID = windowID
+        self.windowName = windowName
+        self.workspaceID = workspaceID
+        self.workspaceName = workspaceName
+        self.context = context
+        self.cwd = cwd
+        self.splitAxis = splitAxis
+        self.panes = panes
+    }
+}
+
+/// `zmx tree [HOST]`'s payload: every open window's attachable sessions, and the one endpoint they all
+/// attach through.
+public struct ControlRemoteTree: Codable, Sendable, Equatable {
+    /// The ssh destination the REQUESTING app was given, stamped on by it after decoding; never the far
+    /// side's own idea of its hostname. Absent from the bare local projection, which nothing sshed to.
+    public let host: String?
+    public let endpoint: ControlZmxEndpoint
+    public let sessions: [ControlRemoteSession]
+
+    public init(host: String?, endpoint: ControlZmxEndpoint, sessions: [ControlRemoteSession]) {
+        self.host = host
+        self.endpoint = endpoint
+        self.sessions = sessions
+    }
+}
+
 /// `zmx list`'s payload. Carries the restore status as a header so a reader can tell whether the rows
 /// describe a live-mode instance without a second call, and `inventoryComplete` because a false one is
 /// what makes every unmatched row `unknown` rather than an orphan.
 public struct ControlZmxInventory: Codable, Sendable, Equatable {
     public let restore: ControlRestoreStatus
     public let inventoryComplete: Bool
+    /// Header rather than per row: one instance has one zmx and one socket directory. Optional so a
+    /// remote reader can tell an older server apart from one that reports nothing to attach to.
+    public let endpoint: ControlZmxEndpoint?
     public let entries: [ControlZmxEntry]
 
-    public init(restore: ControlRestoreStatus, result: ZmxInventoryResult) {
+    public init(restore: ControlRestoreStatus, result: ZmxInventoryResult,
+                endpoint: ControlZmxEndpoint? = nil) {
         self.restore = restore
         inventoryComplete = result.inventoryComplete
+        self.endpoint = endpoint
         entries = result.rows.map(ControlZmxEntry.init(row:))
     }
 }

--- a/agtermCore/Sources/agtermCore/ControlProjection.swift
+++ b/agtermCore/Sources/agtermCore/ControlProjection.swift
@@ -216,6 +216,10 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// each omitted when its pane is unrealized.
     public let realized: Bool?
 
+    /// The host a teleported session is attached to; nil/omitted for a local one. Live-only — a remote
+    /// session is never persisted, so this never survives a relaunch.
+    public let remoteHost: String?
+
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
                 hasSplit: Bool? = nil, backedByZmx: Bool?, splitAxis: String? = nil,
                 splitRatio: Double? = nil, splitFocused: Bool? = nil,
@@ -230,7 +234,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
                 background: BackgroundWatermark? = nil, unseen: Int? = nil,
                 fontSize: Double? = nil, splitFontSize: Double? = nil, scratchFontSize: Double? = nil,
                 surfaces: [ControlSurfaceNode]? = nil, realized: Bool? = nil,
-                context: String? = nil) {
+                context: String? = nil, remoteHost: String? = nil) {
         self.id = id
         self.name = name
         self.cwd = cwd
@@ -270,6 +274,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.scratchFontSize = scratchFontSize
         self.surfaces = surfaces
         self.realized = realized
+        self.remoteHost = remoteHost
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -89,6 +89,8 @@ public enum Command: String, Codable, Sendable {
     case zmxList = "zmx.list"
     case zmxPrune = "zmx.prune"
     case zmxKill = "zmx.kill"
+    case zmxTree = "zmx.tree"
+    case zmxAttach = "zmx.attach"
     /// UI-TEST-ONLY: forces the app-level appearance (`light`|`dark` via `args.name`) so an XCUITest can
     /// simulate a macOS light/dark flip; with NO name it READS the side the last config feed applied, so a
     /// test can assert the flip drove the reload. Refused outside an XCUITest launch, and EXEMPT from the
@@ -129,6 +131,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// `zmx kill`'s explicit confirmation. The command destroys a backend process that can reach detached
     /// claims and every client attached to it, so it has no useful default for who is affected.
     public var force: Bool?
+    /// The machine `zmx tree` reaches, spelled as ssh would take it.
+    public var host: String?
     /// For `session.new`: create in the background without selecting or focusing (the CLI's `--no-select`);
     /// omitted/`false` keeps select-and-focus. Read back via the `tree` `active` flag — the new node is not it.
     public var noSelect: Bool?
@@ -323,7 +327,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public init(name: String? = nil, cwd: String? = nil, targets: [String]? = nil,
                 workspace: String? = nil, workspaceName: String? = nil,
                 createWorkspace: Bool? = nil, collapsed: Bool? = nil, minimized: Bool? = nil,
-                force: Bool? = nil,
+                force: Bool? = nil, host: String? = nil,
                 noSelect: Bool? = nil,
                 text: String? = nil, select: Bool? = nil, mode: String? = nil, axis: String? = nil,
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
@@ -351,6 +355,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.collapsed = collapsed
         self.minimized = minimized
         self.force = force
+        self.host = host
         self.noSelect = noSelect
         self.text = text
         self.select = select
@@ -486,6 +491,8 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var restore: ControlRestoreStatus?
     /// The daemon inventory for `zmx list`.
     public var zmx: ControlZmxInventory?
+    /// Another machine's attachable sessions, for `zmx tree`.
+    public var remote: ControlRemoteTree?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
@@ -496,9 +503,10 @@ public struct ControlResult: Codable, Sendable, Equatable {
                 events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil,
                 pick: ControlPickResult? = nil, cursor: ControlCursor? = nil,
                 app: AppIdentity? = nil, restore: ControlRestoreStatus? = nil,
-                zmx: ControlZmxInventory? = nil) {
+                zmx: ControlZmxInventory? = nil, remote: ControlRemoteTree? = nil) {
         self.restore = restore
         self.zmx = zmx
+        self.remote = remote
         self.id = id
         self.tree = tree
         self.text = text

--- a/agtermCore/Sources/agtermCore/RemoteSession.swift
+++ b/agtermCore/Sources/agtermCore/RemoteSession.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// The ssh command lines that reach another agterm's zmx daemons. Pure and host-free: callers run what
+/// these return, and the app target owns process execution.
+public enum RemoteSession {
+    public enum InvocationError: Error, Equatable {
+        case emptyHost
+        case invalidHost
+        case invalidSession
+        case invalidEndpoint
+    }
+
+    /// One ssh invocation running the far side's own `zmx tree`, which returns its attachable sessions
+    /// across every open window as a single document.
+    ///
+    /// `-T` because no pty is wanted, `BatchMode=yes` because a host-key or password prompt would hang a
+    /// dispatcher with no way to answer it. `ConnectTimeout` bounds the handshake only — the caller still
+    /// needs its own deadline for a remote command that never returns.
+    public static func treeCommand(host: String, connectTimeout: Int = 5) throws -> [String] {
+        try validate(host: host)
+        // the far side runs the BARE form of the same command, which does the whole join in one
+        // main-actor walk of its own windows and answers with one document
+        let chain = cliPathPrefix + " && agtermctl zmx tree --json"
+        // sshd runs the remote command through the ACCOUNT's shell, where a bare `VAR=value` assignment is
+        // a syntax error in fish and tcsh; wrapped, every login shell sees one ordinary command, as
+        // `attachCommand` already sends.
+        let remote = CommandRestore.shellQuotedLine(["/bin/sh", "-c", chain])
+        return sshArguments(host: host, connectTimeout: connectTimeout, interactive: false) + [remote]
+    }
+
+    /// sshd runs a remote command with `/usr/bin:/bin:/usr/sbin:/sbin` and a non-interactive shell reads no
+    /// profile, so an installed CLI is otherwise not found and every command exits 127. `CommandPath` owns
+    /// where it can live; APPENDED, so a user's own `agtermctl` earlier on PATH still wins.
+    static var cliPathPrefix: String {
+        "PATH=\"$PATH:" + CommandPath.standardDirectories.joined(separator: ":") + "\""
+    }
+
+    /// One ssh invocation attaching to `daemon` on `host`, for the lifetime of the pane.
+    ///
+    /// `-tt` forces a pty: a remote command does not reliably get one, and zmx reads termios and the
+    /// window size. There is no lifetime deadline — this is meant to stay connected.
+    ///
+    /// The trailing `/bin/sh -c` is a create-only guard, not a command we expect to run. Stock
+    /// `zmx attach` CREATES the daemon when the name is absent, so a daemon that vanished since the tree
+    /// was read would otherwise hand the user a fresh remote shell wearing the old session's name. An
+    /// existing daemon ignores the command; a vanished one runs this and fails, saying so.
+    ///
+    /// `env` and `sh` are spelled absolutely because they are implementation primitives. The remote
+    /// `agtermctl` in `treeCommand` is deliberately PATH-resolved instead — that one IS the user's
+    /// installed CLI.
+    public static func attachCommand(host: String, endpoint: ControlZmxEndpoint, daemon: String,
+                                     connectTimeout: Int = 5) throws -> [String] {
+        try validate(host: host)
+        guard ZmxSupport.isDaemonName(daemon) else { throw InvocationError.invalidSession }
+        guard isPath(endpoint.executable), isPath(endpoint.socketDirectory) else {
+            throw InvocationError.invalidEndpoint
+        }
+        let guardScript = "printf '%s\\n' 'agterm: remote session is gone'; exit 1"
+        let remote = CommandRestore.shellQuotedLine([
+            // the four the LOCAL pane sets in `ZmxSupport`, empty being unset to zmx: an inherited
+            // `ZMX_SESSION` makes attach SWITCH session instead, never reaching the create-only guard,
+            // and an inherited prefix resolves a name agterm never created.
+            "/usr/bin/env", "ZMX_SESSION=", "ZMX_SESSION_PREFIX=", "ZMX_NO_DETACH_KEY=1",
+            "ZMX_DIR=" + endpoint.socketDirectory, endpoint.executable,
+            "attach", daemon, "/bin/sh", "-c", guardScript,
+        ])
+        return sshArguments(host: host, connectTimeout: connectTimeout, interactive: true) + [remote]
+    }
+
+    /// The pane's command: the attach, then one line saying what died. `commandWait` holds the pane on
+    /// Ghostty's own press-any-key prompt, so this sits under the last remote screen until it is read.
+    ///
+    /// It names the host, the session and the exit status and stops there. How to get back is not
+    /// agterm's to say: the picker is a keymap custom command the user supplies.
+    public static func attachPaneCommand(host: String, endpoint: ControlZmxEndpoint, daemon: String,
+                                         session: String, pane: ZmxPaneRole,
+                                         connectTimeout: Int = 5) throws -> String {
+        let attach = CommandRestore.shellQuotedLine(
+            try attachCommand(host: host, endpoint: endpoint, daemon: daemon, connectTimeout: connectTimeout))
+        let label = CommandRestore.shellQuotedLine(
+            ["agterm: \(session) (\(pane.rawValue)) on \(host) disconnected, exit"])
+        // the pane must exit with SSH's status, not printf's zero, or a failed connection reads as a
+        // clean one to anything that looks at the exit code
+        return "\(attach); status=$?; printf '%s %s\\n' \(label) \"$status\"; exit \"$status\""
+    }
+
+    private static func sshArguments(host: String, connectTimeout: Int, interactive: Bool) -> [String] {
+        ["ssh", interactive ? "-tt" : "-T",
+         "-o", "BatchMode=yes",
+         "-o", "ConnectTimeout=\(connectTimeout)",
+         host]
+    }
+
+    /// Refused rather than escaped, and a leading `-` with it: ssh would read that as an option.
+    private static func validate(host: String) throws {
+        guard !host.isEmpty else { throw InvocationError.emptyHost }
+        guard isPlain(host), !host.hasPrefix("-") else { throw InvocationError.invalidHost }
+    }
+
+    /// A host or remote-session token: no whitespace, no control characters. Shared with the dispatcher,
+    /// so one predicate decides what may reach both an argv and an error message.
+    static func isPlain(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return !value.unicodeScalars.contains { $0.properties.isWhitespace || $0.value < 0x20 || $0.value == 0x7f }
+    }
+
+    /// A filesystem path, which may legitimately contain spaces — `/Users/me/My Apps/agterm.app/…` is an
+    /// ordinary install. `shellQuotedLine` keeps it one argument through the remote shell, so only
+    /// control characters and NUL are refused, neither of which survives a path anyway.
+    private static func isPath(_ value: String) -> Bool {
+        guard !value.isEmpty else { return false }
+        return !value.unicodeScalars.contains { $0.value < 0x20 || $0.value == 0x7f }
+    }
+}

--- a/agtermCore/Sources/agtermCore/RemoteTree.swift
+++ b/agtermCore/Sources/agtermCore/RemoteTree.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// What running a remote command produced. `status` is ssh's exit code, which carries the far side's own
+/// exit status once the connection itself succeeded.
+public struct RemoteCommandResult: Sendable, Equatable {
+    public let status: Int32
+    public let stdout: String
+    public let stderr: String
+
+    public init(status: Int32, stdout: String, stderr: String) {
+        self.status = status
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+}
+
+/// Runs an ssh invocation somewhere that is not the main actor. The app supplies a `Process`-backed
+/// implementation; tests supply a fake, which is what lets the end-to-end coverage run without a second
+/// Mac.
+public protocol RemoteCommandRunner: Sendable {
+    func run(_ argv: [String], deadline: TimeInterval) async -> RemoteCommandResult
+}
+
+/// One open window's projection, paired with the identity the tree payload does not carry.
+public struct RemoteWindowProjection: Sendable {
+    public let id: String
+    public let name: String
+    public let tree: ControlTree
+
+    public init(id: String, name: String, tree: ControlTree) {
+        self.id = id
+        self.name = name
+        self.tree = tree
+    }
+}
+
+/// Turns an agterm's own windows into the per-pane endpoints an attach needs, and reads that answer back
+/// when it arrives over ssh.
+public enum RemoteTreeMerger {
+    public enum MergeError: Error, Equatable {
+        /// The remote answered, but not with a readable `zmx tree` document — an older CLI, or a
+        /// truncated read.
+        case malformedProjection
+        /// The remote is too old to report where its zmx and its daemons live, so nothing can be attached.
+        case missingEndpoint
+        /// The remote command itself failed; carries whatever it said.
+        case remoteFailed(String)
+
+        public var message: String {
+            switch self {
+            case .malformedProjection:
+                return "the remote did not return a readable session list"
+            case .missingEndpoint:
+                return "the remote agterm is too old to report its zmx endpoint"
+            case let .remoteFailed(reason):
+                return reason
+            }
+        }
+    }
+
+    /// The remote's own explanation for a nonzero exit, or nil when it gave none.
+    ///
+    /// `agtermctl --json` prints a not-ok response to STDOUT and then exits nonzero, so stderr is empty on
+    /// exactly the failures worth reporting. An ok-looking payload from a nonzero process is never
+    /// accepted: the caller checks the status first and only comes here for the reason.
+    public static func remoteError(stdout: String) -> String? {
+        let response = try? JSONDecoder().decode(ControlResponse.self, from: Data(stdout.utf8))
+        guard let response, !response.ok else { return nil }
+        return response.error?.trimmedOrNil
+    }
+
+    /// Every attachable session across the windows given, flat, each row naming where it lives.
+    ///
+    /// Only a session whose every pane resolves to a daemon that is both claimed and running is returned.
+    /// A daemon that vanished, one zmx could not read, and a split whose second pane has no row are all
+    /// dropped rather than offered: `zmx attach` CREATES a missing daemon, handing back a fresh shell
+    /// wearing the name of the session that was asked for. The zmx observation is a subprocess snapshot
+    /// taken beside the model walk rather than inside it, so these guards are eligibility rules and not
+    /// only a defence against that gap.
+    ///
+    /// An empty result is a successful answer. It cannot be told apart from a store that is simply not
+    /// running in `live` mode, and does not try to be: `zmx list` is the restore-mode diagnostic.
+    public static func candidates(windows: [RemoteWindowProjection],
+                                  inventory: ControlZmxInventory) throws -> ControlRemoteTree {
+        guard let endpoint = inventory.endpoint else { throw MergeError.missingEndpoint }
+
+        var daemons: [String: [String: String]] = [:]
+        for entry in inventory.entries where entry.state == "claimed" && entry.observation == "running" {
+            guard let sessionID = entry.sessionID, let pane = entry.pane else { continue }
+            // this command promises every row it returns is attachable, so a name `zmx attach` would
+            // deterministically refuse must not reach the caller
+            guard ZmxSupport.isDaemonName(entry.daemon) else { continue }
+            daemons[sessionID, default: [:]][pane] = entry.daemon
+        }
+
+        let sessions = windows.flatMap { window in
+            window.tree.workspaces.flatMap { workspace in
+                workspace.sessions.compactMap { node in
+                    remoteSession(node, window: window, workspace: workspace,
+                                  daemons: daemons[node.id] ?? [:])
+                }
+            }
+        }
+        return ControlRemoteTree(host: nil, endpoint: endpoint, sessions: sessions)
+    }
+
+    /// Reads back what the far side's own `zmx tree` printed. The caller must reject a nonzero exit BEFORE
+    /// calling this, and stamps the ssh destination it was given onto the result: the far side has no idea
+    /// what name reached it.
+    public static func decode(stdout: String) throws -> ControlRemoteTree {
+        guard let response = try? JSONDecoder().decode(ControlResponse.self, from: Data(stdout.utf8)) else {
+            throw MergeError.malformedProjection
+        }
+        guard response.ok else {
+            throw MergeError.remoteFailed(response.error ?? "the remote session list could not be read")
+        }
+        // an older far side answers ok to `zmx tree` with no `remote` result at all
+        guard let remote = response.result?.remote else { throw MergeError.malformedProjection }
+        return remote
+    }
+
+    private static func remoteSession(_ node: ControlSessionNode, window: RemoteWindowProjection,
+                                      workspace: ControlWorkspaceNode,
+                                      daemons: [String: String]) -> ControlRemoteSession? {
+        // a claimed, running daemon is not proof the owner is looking at it: a launch that asked for live
+        // and fell back preserves its daemons while showing fresh ordinary shells, and so does a mode
+        // switch. `backedByZmx` is the store's own answer to "is every pane actually attached".
+        guard node.backedByZmx == true else { return nil }
+        guard let left = daemons["left"] else { return nil }
+        var panes = [ControlRemotePane(pane: "left", daemon: left, foreground: node.foreground)]
+        if node.hasSplit == true {
+            guard let right = daemons["right"] else { return nil }
+            panes.append(ControlRemotePane(pane: "right", daemon: right, foreground: node.splitForeground))
+        }
+        return ControlRemoteSession(id: node.id, name: node.name, windowID: window.id,
+                                    windowName: window.name, workspaceID: workspace.id,
+                                    workspaceName: workspace.name, context: node.context, cwd: node.cwd,
+                                    splitAxis: node.hasSplit == true ? node.splitAxis : nil, panes: panes)
+    }
+}

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -120,6 +120,26 @@ public final class Session: Identifiable {
     /// transition, not `statusChangedAt`, so a hook re-asserting `blocked` over `blocked` stays muted.
     @ObservationIgnored public var autoFollowConsumed = false
 
+    /// The host this session is teleported from, nil for a local one. NOT persisted, and excluded from
+    /// every snapshot: a persisted ssh command would reconnect on a `rerun` launch or come back as a
+    /// plain shell under a marker that lies.
+    ///
+    /// Immutable and set at construction, because the first save happens inside `addSession`: a marker
+    /// written afterwards would let one snapshot go to disk carrying the ssh command.
+    public let remoteHost: String?
+
+    /// Whether this session may be written to disk at all. Every persistence producer gates on it: the
+    /// launch snapshot, the Recent Closed session record, and a closed workspace's record.
+    public var isPersistable: Bool { remoteHost == nil }
+
+    /// The pane identities this instance's zmx owns — none for a remote session, whose panes run ssh.
+    /// Every reader of local daemon ownership goes through this, or a remote pane reports as a claimed
+    /// local daemon that does not exist. Structural `paneIdentity` stays valid either way.
+    public var locallyManagedPaneIdentities: [UUID] {
+        guard remoteHost == nil else { return [] }
+        return [paneIdentity] + [splitPaneIdentity].compactMap { $0 }
+    }
+
     /// User-set flagged working-set membership: surfaces the session in the sidebar's flat cross-workspace
     /// flagged view with a filled row icon. Persisted, surviving a relaunch and a workspace move.
     public var flagged: Bool = false
@@ -403,12 +423,14 @@ public final class Session: Identifiable {
     @ObservationIgnored public weak var searchSurface: (any TerminalSurface)?
 
     public init(id: UUID = UUID(), initialCwd: String, customName: String? = nil,
-                paneIdentity: UUID = UUID(), splitPaneIdentity: UUID? = nil) {
+                paneIdentity: UUID = UUID(), splitPaneIdentity: UUID? = nil,
+                remoteHost: String? = nil) {
         self.id = id
         self.paneIdentity = paneIdentity
         self.splitPaneIdentity = splitPaneIdentity
         self.initialCwd = initialCwd
         self.customName = customName
+        self.remoteHost = remoteHost
     }
 
     /// The sidebar label: a non-blank `customName` (a manual rename) wins; else the focused pane's non-blank

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -898,9 +898,14 @@ public final class WindowLibrary {
         var claims: [ZmxPaneClaim] = []
         var complete = true
         for (site, session) in pairs {
-            claims.append(site.claim(.left, identity: session.paneIdentity))
+            // through the ownership projection, so this stays one predicate: an empty list is a session
+            // whose daemons are not ours to claim, and inventing rows for it would name daemons that do
+            // not exist here
+            var owned = session.locallyManagedPaneIdentities.makeIterator()
+            guard let primary = owned.next() else { continue }
+            claims.append(site.claim(.left, identity: primary))
             guard session.hasSplit else { continue }
-            guard let split = session.splitPaneIdentity else {
+            guard let split = owned.next() else {
                 complete = false
                 continue
             }

--- a/agtermCore/Sources/agtermCore/ZmxLifecycle.swift
+++ b/agtermCore/Sources/agtermCore/ZmxLifecycle.swift
@@ -143,8 +143,6 @@ public enum PaneIdentityInventory {
     }
 
     @MainActor public static func identities(in sessions: [Session]) -> [UUID] {
-        sessions.flatMap { session in
-            [session.paneIdentity] + [session.splitPaneIdentity].compactMap { $0 }
-        }
+        sessions.flatMap(\.locallyManagedPaneIdentities)
     }
 }

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -193,6 +193,9 @@ struct SocketClient {
         if let keymap = response.result?.keymap {
             return formatKeymap(keymap)
         }
+        if let remote = response.result?.remote {
+            return formatRemoteTree(remote)
+        }
         if let zmx = response.result?.zmx {
             return formatZmx(zmx)
         }
@@ -247,6 +250,24 @@ struct SocketClient {
         if status.restartRequired { lines.append("restart agterm to apply the configured mode") }
         if let reason = status.unavailableReason { lines.append("live unavailable: \(reason)") }
         return lines.joined(separator: "\n")
+    }
+
+    /// A remote host's attachable sessions, one per line, carrying the session id `zmx attach` takes. An
+    /// empty answer says so rather than printing nothing, which a caller cannot tell from a failed read.
+    static func formatRemoteTree(_ tree: ControlRemoteTree) -> String {
+        let place = tree.host.map { " on \($0)" } ?? ""
+        guard !tree.sessions.isEmpty else { return "no attachable sessions\(place)" }
+        return tree.sessions.map { session in
+            let split = session.panes.count > 1 ? " (split\(session.splitAxis.map { " \($0)" } ?? ""))" : ""
+            // what the row is for, then where it is: the running command answers "attach to which one"
+            // more often than the path does, and the context line is the far side's own answer to it
+            let running = session.panes.compactMap { $0.foreground?.first.map { CommandRestore.basename($0) } }
+            let detail = [session.context, running.isEmpty ? nil : running.joined(separator: " | ")]
+                .compactMap { $0 }.joined(separator: "  ")
+            let tail = detail.isEmpty ? "" : "  \(detail)"
+            let at = "\(session.windowName)/\(session.workspaceName)/\(session.name)"
+            return "  \(at)\(split)  [\(session.id)]  \(session.cwd)\(tail)"
+        }.joined(separator: "\n")
     }
 
     /// The daemon inventory under the restore header. Owner window state is its own column rather than

--- a/agtermCore/Sources/agtermctlKit/ZmxCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/ZmxCommands.swift
@@ -15,8 +15,64 @@ struct Zmx: ParsableCommand {
         Every one needs a running agterm: only the app can join its live windows, its pending closes and \
         its persisted snapshots against what zmx reports. With agterm stopped there is nothing to ask.
         """,
-        subcommands: [List.self, Prune.self, Kill.self]
+        subcommands: [List.self, Prune.self, Kill.self, Tree.self, Attach.self]
     )
+
+    struct Attach: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Attach to a session on another Mac, as a session here.",
+            discussion: """
+            Takes a host and the id of one of the sessions `zmx tree` listed, and opens it in this window \
+            marked as remote. A remote session with a split arrives with the same split.
+
+            The remote is resolved again before anything is created, so a session that has gone since the \
+            list was taken fails rather than handing back a fresh shell wearing its name.
+
+            Closing it here ends only this side's connection: the far-side processes keep running, and \
+            nothing this command does can kill them. The session is not restored after a relaunch.
+            """)
+        @Argument(help: "The host, as ssh would take it.")
+        var host: String
+        @Argument(help: "The remote session's id, as `zmx tree` prints it.")
+        var session: String
+        @OptionGroup var options: BasicOptions
+
+        /// It creates a local session, so it echoes that session's id like every other create command.
+        var echoesResultID: Bool { true }
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .zmxAttach, target: session, args: ControlArgs(host: host))
+        }
+    }
+
+    struct Tree: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "List the sessions that can be attached to, here or on another Mac.",
+            discussion: """
+            With a HOST, runs over ssh against a machine that is also running agterm and reports what it \
+            offers, across every one of its open windows. Feed the result to a picker and hand what the \
+            user chooses to `zmx attach`.
+
+            With no HOST, reports this app's own attachable sessions in the same shape — which is exactly \
+            the form the remote call runs on the far side, so it is also how to see what another machine \
+            would answer without sshing anywhere.
+
+            Only a session whose every pane has a live daemon is listed. One whose daemon has gone is \
+            omitted rather than offered, because attaching to a name that no longer exists would create a \
+            fresh shell wearing it. An empty list is a successful answer: it does not distinguish a store \
+            that is not running in live mode, which `zmx list` reports.
+
+            The connection is non-interactive: ssh runs with BatchMode, so key-based auth must already \
+            work for this host and a password or host-key prompt is a failure rather than a question.
+            """)
+        @Argument(help: "The host, as ssh would take it. Omit for this app's own sessions.")
+        var host: String?
+        @OptionGroup var options: BasicOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .zmxTree, args: ControlArgs(host: host))
+        }
+    }
 
     struct List: RequestCommand {
         static let configuration = CommandConfiguration(

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherZmxTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherZmxTests.swift
@@ -176,6 +176,113 @@ struct ControlDispatcherZmxTests {
         #expect(foreign.sessionID == nil)
     }
 
+    @Test func zmxTreeReachesTheHostItWasGiven() async {
+        let actions = MockControlActions()
+        let request = ControlRequest(cmd: .zmxTree, args: ControlArgs(host: "buildbox"))
+
+        _ = await ControlDispatcher(actions: actions).dispatch(request)
+
+        #expect(actions.calls == [.zmxTree(host: "buildbox")])
+    }
+
+    // a blank host is not a host, and must reach the action as the LOCAL form rather than as an ssh
+    // destination made of whitespace
+    @Test(arguments: [nil, "", "   "])
+    func zmxTreeWithNoUsableHostAsksAboutThisApp(_ host: String?) async {
+        let actions = MockControlActions()
+        let request = ControlRequest(cmd: .zmxTree, args: ControlArgs(host: host))
+
+        let response = await ControlDispatcher(actions: actions).dispatch(request)
+
+        #expect(response?.ok == true)
+        #expect(actions.calls == [.zmxTree(host: nil)])
+    }
+
+    @Test func zmxAttachCarriesBothTheHostAndTheRemoteSession() async {
+        let actions = MockControlActions()
+        let request = ControlRequest(cmd: .zmxAttach, target: "s1", args: ControlArgs(host: "buildbox"))
+
+        _ = await ControlDispatcher(actions: actions).dispatch(request)
+
+        #expect(actions.calls == [.zmxAttach(host: "buildbox", session: "s1")])
+    }
+
+    @Test func zmxAttachRefusesWithoutAHostOrASessionBeforeTheHostIsCalled() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let noHost = await dispatcher.dispatch(ControlRequest(cmd: .zmxAttach, target: "s1"))
+        #expect(noHost?.error == "zmx.attach requires a host")
+
+        let noSession = await dispatcher.dispatch(ControlRequest(cmd: .zmxAttach,
+                                                                 args: ControlArgs(host: "buildbox")))
+        #expect(noSession?.error == "zmx.attach requires a remote session")
+        #expect(actions.calls.isEmpty)
+    }
+
+    // the unresolved-session message names the id, so a control character reaching it would be printed
+    // to a terminal by agtermctl after JSON decoding
+    @Test(arguments: ["s1\nrm -rf /", "s1\u{1B}[31m", "s1\u{7F}", "s 1"])
+    func zmxAttachRefusesASessionCarryingControlCharactersOrEmbeddedWhitespace(_ session: String) async {
+        let actions = MockControlActions()
+
+        let response = await ControlDispatcher(actions: actions).dispatch(
+            ControlRequest(cmd: .zmxAttach, target: session, args: ControlArgs(host: "buildbox")))
+
+        #expect(response?.error == "invalid remote session")
+        #expect(actions.calls.isEmpty, "it must refuse before the host is reached")
+    }
+
+    @Test func theRemoteTreeSurvivesTheWire() throws {
+        let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/zmx",
+                                          socketDirectory: "/tmp/agterm-zmx-abc")
+        let session = ControlRemoteSession(
+            id: "s1", name: "build", windowID: "w-1", windowName: "main", workspaceID: "ws-1",
+            workspaceName: "umputun.dev", context: "release prep", cwd: "/repo", splitAxis: "vertical",
+            panes: [ControlRemotePane(pane: "left", daemon: "agterm-1", foreground: ["/bin/zsh"]),
+                    ControlRemotePane(pane: "right", daemon: "agterm-2", foreground: nil)])
+        let payload = ControlRemoteTree(host: "buildbox", endpoint: endpoint, sessions: [session])
+
+        let encoded = try JSONEncoder().encode(ControlResponse(ok: true, result: ControlResult(remote: payload)))
+        let decoded = try #require(try JSONDecoder().decode(ControlResponse.self, from: encoded).result?.remote)
+
+        #expect(decoded == payload)
+    }
+
+    @Test func zmxInventoryCarriesTheEndpointARemoteAttachNeeds() throws {
+        let status = ControlRestoreStatus(configured: .live, requestedAtLaunch: .live, active: .live,
+                                          unavailableReason: nil)
+        let result = ZmxInventory.join(observed: [], claims: [], inventoryComplete: true)
+        let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/Contents/Resources/zmx/zmx",
+                                          socketDirectory: "/tmp/agterm-zmx-abc123")
+
+        let payload = ControlZmxInventory(restore: status, result: result, endpoint: endpoint)
+        let response = ControlResponse(ok: true, result: ControlResult(zmx: payload))
+        let encoded = try JSONEncoder().encode(response)
+        let decoded = try #require(try JSONDecoder().decode(ControlResponse.self, from: encoded).result?.zmx)
+
+        #expect(decoded.endpoint == endpoint)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let zmx = try #require((json["result"] as? [String: Any])?["zmx"] as? [String: Any])
+        let wire = try #require(zmx["endpoint"] as? [String: Any])
+        #expect(wire["socketDirectory"] as? String == "/tmp/agterm-zmx-abc123")
+    }
+
+    @Test func zmxInventoryOmitsTheEndpointRatherThanNullingIt() throws {
+        let status = ControlRestoreStatus(configured: .none, requestedAtLaunch: .none, active: .none,
+                                          unavailableReason: nil)
+        let result = ZmxInventory.join(observed: [], claims: [], inventoryComplete: true)
+
+        let payload = ControlZmxInventory(restore: status, result: result)
+        let encoded = try JSONEncoder().encode(ControlResponse(ok: true, result: ControlResult(zmx: payload)))
+        let decoded = try #require(try JSONDecoder().decode(ControlResponse.self, from: encoded).result?.zmx)
+
+        #expect(decoded.endpoint == nil)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let zmx = try #require((json["result"] as? [String: Any])?["zmx"] as? [String: Any])
+        #expect(zmx["endpoint"] == nil, "a remote reader tells an older server apart by absence")
+    }
+
     @Test func restoreStatusHidesAProbedReasonUnlessLiveActuallyFellBack() {
         let asked = ControlRestoreStatus(configured: .live, requestedAtLaunch: .live, active: .none,
                                          unavailableReason: "the password-database login shell is not zsh")

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -1060,6 +1060,19 @@ struct ControlProtocolTests {
         #expect(decoded.backedByZmx == nil)
     }
 
+    @Test func treeSessionNodeReportsAndOmitsTheRemoteHost() throws {
+        let remote = ControlSessionNode(id: "s1", name: "build", cwd: "/tmp", active: true, split: false,
+                                        backedByZmx: nil, remoteHost: "buildbox")
+        let encoded = try JSONEncoder().encode(remote)
+        #expect(try JSONDecoder().decode(ControlSessionNode.self, from: encoded).remoteHost == "buildbox")
+
+        let local = ControlSessionNode(id: "s2", name: "shell", cwd: "/tmp", active: false, split: false,
+                                       backedByZmx: nil)
+        let localJSON = try #require(try JSONSerialization
+            .jsonObject(with: try JSONEncoder().encode(local)) as? [String: Any])
+        #expect(localJSON["remoteHost"] == nil, "a local session omits the key, never nulls it")
+    }
+
     @Test func treeSessionNodeToleratesMissingSurfaces() throws {
         // a pre-`surface.zoom` server omits the key entirely, so it must decode as nil.
         let raw = #"{"id":"s1","name":"shell","cwd":"/tmp","active":true,"split":false,"# +

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -57,6 +57,8 @@ final class MockControlActions: ControlActions {
         case zmxList
         case zmxPrune
         case zmxKill(target: String, window: String?, pane: ZmxPaneRole)
+        case zmxTree(host: String?)
+        case zmxAttach(host: String, session: String)
         case sidebarVisibility(ControlToggleMode)
         case sidebarViewMode(ControlSidebarViewMode)
         case expand(window: String?)
@@ -132,6 +134,8 @@ final class MockControlActions: ControlActions {
     var nextZmxListResponse = ControlResponse(ok: true)
     var nextZmxPruneResponse = ControlResponse(ok: true)
     var nextZmxKillResponse = ControlResponse(ok: true)
+    var nextRemoteTreeResponse = ControlResponse(ok: true)
+    var nextRemoteAttachResponse = ControlResponse(ok: true)
     var nextQuickResponse = ControlResponse(ok: true)
     var nextQuickTypeResponse = ControlResponse(ok: true)
     var nextQuickTextResponse = ControlResponse(ok: true)
@@ -429,6 +433,16 @@ final class MockControlActions: ControlActions {
     func killZmxDaemon(target: String, window: String?, pane: ZmxPaneRole) -> ControlResponse {
         calls.append(.zmxKill(target: target, window: window, pane: pane))
         return nextZmxKillResponse
+    }
+
+    func remoteTree(host: String?) async -> ControlResponse {
+        calls.append(.zmxTree(host: host))
+        return nextRemoteTreeResponse
+    }
+
+    func attachRemoteSession(host: String, session: String) async -> ControlResponse {
+        calls.append(.zmxAttach(host: host, session: session))
+        return nextRemoteAttachResponse
     }
 
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
@@ -16,6 +16,50 @@ final class RecentClosedTests {
 
     private var fileURL: URL { directory.appendingPathComponent("recent-closed.json") }
 
+    // MARK: - remote sessions are never written to disk
+
+    @MainActor
+    @Test func closingARemoteSessionRecordsNothingToReopen() {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        let ws = store.addWorkspace(name: "work")
+        let remote = store.addSession(toWorkspace: ws.id, cwd: "/a", remoteHost: "buildbox")!
+
+        store.closeSession(remote.id)
+
+        #expect(recentClosed.load().isEmpty)
+    }
+
+    @MainActor
+    @Test func closingAWorkspaceRecordsOnlyItsLocalSessionsAndCountsThem() {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        store.addWorkspace(name: "keep")
+        let ws = store.addWorkspace(name: "mixed")
+        let local = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        _ = store.addSession(toWorkspace: ws.id, cwd: "/b", remoteHost: "buildbox")
+
+        store.removeWorkspace(ws.id)
+
+        let item = try? #require(recentClosed.load().first { $0.kind == .workspace })
+        #expect(item?.workspace?.snapshot.sessions.map(\.id) == [local.id])
+        #expect(item?.subtitle == "1 session", "the count describes what Reopen will restore")
+    }
+
+    @MainActor
+    @Test func aWorkspaceSelectionPointingAtARemoteSessionIsNotRestored() {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        store.addWorkspace(name: "keep")
+        let ws = store.addWorkspace(name: "mixed")
+        store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let remote = store.addSession(toWorkspace: ws.id, cwd: "/b", remoteHost: "buildbox")!
+        store.selectSession(remote.id)
+
+        store.removeWorkspace(ws.id)
+
+        let item = try? #require(recentClosed.load().first { $0.kind == .workspace })
+        #expect(item?.workspace?.selectedSessionID == nil,
+                "restoring a selection the snapshot no longer contains selects nothing")
+    }
+
     @Test func diskRoundTripPreservesNewestFirstItems() {
         let store = RecentClosedStore(directory: directory)
         let first = sessionItem(title: "first")

--- a/agtermCore/Tests/agtermCoreTests/RemoteSessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RemoteSessionTests.swift
@@ -1,0 +1,337 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct RemoteSessionTests {
+    private let daemon = ZmxSupport.daemonName(for: UUID())
+    private let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/Contents/Resources/zmx/zmx",
+                                              socketDirectory: "/tmp/agterm-zmx-abc123")
+
+    // MARK: - ssh options
+
+    @Test func treeIsNonInteractiveAndBounded() throws {
+        let argv = try RemoteSession.treeCommand(host: "buildbox", connectTimeout: 12)
+        #expect(argv.prefix(7) == ["ssh", "-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=12", "buildbox"])
+        #expect(argv.count == 8)
+    }
+
+    @Test func attachForcesAPtyAndNeverBoundsItsLifetime() throws {
+        let argv = try RemoteSession.attachCommand(host: "buildbox", endpoint: endpoint, daemon: daemon)
+        #expect(argv.prefix(7) == ["ssh", "-tt", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", "buildbox"])
+        #expect(!argv.contains { $0.hasPrefix("ServerAlive") })
+    }
+
+    // MARK: - what the remote shell actually runs
+
+    @Test func treeRunsTheFarSidesOwnBareForm() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        try fake.installAgtermctl(exitCodes: [0])
+
+        let run = try fake.runRemote(RemoteSession.treeCommand(host: "buildbox"))
+
+        #expect(run.status == 0)
+        #expect(try fake.calls() == [["zmx", "tree", "--json"]],
+                "one command: the far side does the whole join and answers with one document")
+    }
+
+    @Test func treeWidensPathWithEveryDocumentedInstallDirectory() throws {
+        let remote = try #require(RemoteSession.treeCommand(host: "buildbox").last)
+
+        // sshd runs a remote command with /usr/bin:/bin:/usr/sbin:/sbin and a non-interactive shell reads
+        // no profile, so a CLI installed through the Help action or the cask is otherwise not found. One
+        // list, shared with the local widening, or the two drift and an install route stops working.
+        #expect(remote.contains(RemoteSession.cliPathPrefix))
+        for directory in CommandPath.standardDirectories {
+            #expect(remote.contains(directory))
+        }
+    }
+
+    @Test func theRemoteCommandIsOneOrdinaryCommandEvenUnderANonPosixLoginShell() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        try fake.installAgtermctl(exitCodes: [0])
+
+        // sshd runs it through the ACCOUNT's shell, and a bare VAR=value assignment is a syntax error in
+        // tcsh; unwrapped, the whole read fails before the first agtermctl
+        let run = try fake.runRemote(RemoteSession.treeCommand(host: "buildbox"), shell: "/bin/tcsh")
+
+        #expect(run.status == 0)
+        #expect(try fake.calls() == [["zmx", "tree", "--json"]])
+    }
+
+    @Test func thePathPrefixAppendsSoAUsersOwnCliStillWins() {
+        #expect(RemoteSession.cliPathPrefix.hasPrefix("PATH=\"$PATH:"))
+        #expect(!RemoteSession.cliPathPrefix.contains(":$PATH\""))
+    }
+
+    // the far side prints a not-ok JSON response to stdout and exits nonzero, so the caller must read the
+    // status before the output rather than trusting a well-formed-looking document
+    @Test func theFarSidesFailureReachesTheCallerAsANonzeroExit() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        try fake.installAgtermctl(exitCodes: [3])
+
+        let run = try fake.runRemote(RemoteSession.treeCommand(host: "buildbox"))
+
+        #expect(run.status != 0)
+        #expect(try fake.calls() == [["zmx", "tree", "--json"]])
+    }
+
+    @Test func attachPassesTheEndpointAndGuardAsExactArguments() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        let zmx = try fake.installZmx()
+        let endpoint = ControlZmxEndpoint(executable: zmx, socketDirectory: "/tmp/zmx dir")
+
+        let run = try fake.runRemote(RemoteSession.attachCommand(host: "buildbox", endpoint: endpoint,
+                                                                daemon: daemon))
+
+        #expect(run.status == 0)
+        #expect(try fake.recordedZmxDir() == "/tmp/zmx dir")
+        let argv = try #require(try fake.calls().first)
+        #expect(argv == ["attach", daemon, "/bin/sh", "-c",
+                         "printf '%s\\n' 'agterm: remote session is gone'; exit 1"])
+    }
+
+    // an inherited ZMX_SESSION made attach switch session instead of attaching, past the create-only guard
+    @Test func attachClearsTheAccountsOwnZmxSessionVariables() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        let zmx = try fake.installZmx()
+        let endpoint = ControlZmxEndpoint(executable: zmx, socketDirectory: "/tmp/z")
+
+        let run = try fake.runRemote(
+            RemoteSession.attachCommand(host: "buildbox", endpoint: endpoint, daemon: daemon),
+            exporting: ["ZMX_SESSION_PREFIX": "work-", "ZMX_SESSION": "someone-elses"])
+
+        #expect(run.status == 0)
+        #expect(try fake.recordedZmxSessionEnv() == "session=[] prefix=[] nodetach=[1]")
+        #expect(try fake.recordedZmxDir() == "/tmp/z", "clearing them must not lose ZMX_DIR")
+    }
+
+    @Test func attachSurvivesABundlePathWithASpace() throws {
+        let fake = try FakeRemote(directoryName: "fake remote \(UUID().uuidString)")
+        defer { fake.cleanUp() }
+        let zmx = try fake.installZmx()
+        #expect(zmx.contains(" "), "the fixture must actually exercise the quoting")
+        let endpoint = ControlZmxEndpoint(executable: zmx, socketDirectory: "/tmp/agterm-zmx-abc")
+
+        let run = try fake.runRemote(RemoteSession.attachCommand(host: "buildbox", endpoint: endpoint,
+                                                                daemon: daemon))
+
+        #expect(run.status == 0)
+        #expect(try fake.calls().first?.first == "attach")
+    }
+
+    // MARK: - the pane command
+
+    @Test func thePaneCommandPrintsWhatDiedAfterTheAttachExits() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        try fake.installSSH()
+        let zmx = try fake.installZmx()
+        let endpoint = ControlZmxEndpoint(executable: zmx, socketDirectory: "/tmp/z")
+
+        let command = try RemoteSession.attachPaneCommand(host: "buildbox", endpoint: endpoint,
+                                                          daemon: daemon, session: "build", pane: .right)
+        let run = try fake.runShell(command)
+
+        #expect(run.stdout.contains("agterm: build (right) on buildbox disconnected, exit"))
+        #expect(try fake.calls().first?.first == "attach", "the diagnostic runs AFTER the attach")
+    }
+
+    @Test func thePaneCommandKeepsTheSshExitStatusRatherThanPrintfsZero() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        try fake.installSSH(exitCode: 23)
+        let endpoint = ControlZmxEndpoint(executable: "/bin/true", socketDirectory: "/tmp/z")
+
+        let command = try RemoteSession.attachPaneCommand(host: "buildbox", endpoint: endpoint,
+                                                          daemon: daemon, session: "build", pane: .left)
+        let run = try fake.runShell(command)
+
+        #expect(run.stdout.hasSuffix("exit 23\n"), "the line must name the real status")
+        #expect(run.status == 23, "a failed connection must not read as a clean exit")
+    }
+
+    @Test func aHostileSessionNameCannotEscapeTheDiagnosticLine() throws {
+        let fake = try FakeRemote()
+        defer { fake.cleanUp() }
+        try fake.installSSH()
+        let zmx = try fake.installZmx()
+        let endpoint = ControlZmxEndpoint(executable: zmx, socketDirectory: "/tmp/z")
+        let marker = fake.root.appendingPathComponent("pwned").path
+
+        let command = try RemoteSession.attachPaneCommand(
+            host: "buildbox", endpoint: endpoint, daemon: daemon,
+            session: "build'; touch \(marker); echo '", pane: .left)
+        _ = try fake.runShell(command)
+
+        #expect(!FileManager.default.fileExists(atPath: marker), "the name is data, never shell syntax")
+    }
+
+    // MARK: - validation
+
+    @Test func emptyHostIsRefused() {
+        #expect(throws: RemoteSession.InvocationError.emptyHost) {
+            try RemoteSession.treeCommand(host: "")
+        }
+    }
+
+    @Test(arguments: ["build box", "box\nrm -rf /", "box\u{0}", "-oProxyCommand=touch /tmp/pwned"])
+    func hostileHostIsRefused(_ host: String) {
+        #expect(throws: RemoteSession.InvocationError.self) {
+            try RemoteSession.treeCommand(host: host)
+        }
+    }
+
+    @Test(arguments: ["agterm 42", "agterm\n42", "", "notes", "agterm-nothex"])
+    func anythingButAnAgtermDaemonNameIsRefused(_ name: String) {
+        #expect(throws: RemoteSession.InvocationError.invalidSession) {
+            try RemoteSession.attachCommand(host: "buildbox", endpoint: endpoint, daemon: name)
+        }
+    }
+
+    @Test func anEndpointPathMaySpaceButNotCarryControlCharacters() throws {
+        let spaced = ControlZmxEndpoint(executable: "/Users/me/My Apps/agterm.app/zmx",
+                                        socketDirectory: "/tmp/x")
+        #expect(throws: Never.self) {
+            try RemoteSession.attachCommand(host: "buildbox", endpoint: spaced, daemon: daemon)
+        }
+        let broken = ControlZmxEndpoint(executable: "/tmp/zmx\n", socketDirectory: "/tmp/x")
+        #expect(throws: RemoteSession.InvocationError.invalidEndpoint) {
+            try RemoteSession.attachCommand(host: "buildbox", endpoint: broken, daemon: daemon)
+        }
+    }
+}
+
+/// Runs the remote half of an invocation through `/bin/sh` against recording stand-ins, so a quoting or
+/// ordering regression fails rather than passing a substring check.
+private struct FakeRemote {
+    let root: URL
+    private let log: URL
+    private let zmxDirLog: URL
+    private let zmxEnvLog: URL
+
+    init(directoryName: String = "fake-remote-\(UUID().uuidString)") throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        log = root.appendingPathComponent("calls.log")
+        zmxDirLog = root.appendingPathComponent("zmxdir.log")
+        zmxEnvLog = root.appendingPathComponent("zmxenv.log")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        // the command under test appends the REAL install directories to PATH, so a test that forgets
+        // `installAgtermctl` would otherwise resolve the machine's own CLI and drive the live terminal.
+        // this sentinel makes that fail here instead of reaching outside the fixture.
+        try write(name: "agtermctl", script: """
+        printf '%s\\n' 'fake-remote: no agtermctl installed for this test' >&2
+        exit 99
+        """)
+    }
+
+    func cleanUp() { try? FileManager.default.removeItem(at: root) }
+
+    /// Exits with `exitCodes[n]` on its nth call, so a chain can be failed at a chosen stage.
+    func installAgtermctl(exitCodes: [Int32]) throws {
+        let cases = exitCodes.enumerated()
+            .map { "  \($0.offset)) exit \($0.element) ;;" }
+            .joined(separator: "\n")
+        try write(name: "agtermctl", script: """
+        \(recordArguments)
+        n=$(grep -c '^\(Self.callSeparator)$' '\(log.path)')
+        case $((n - 1)) in
+        \(cases)
+        esac
+        exit 0
+        """)
+    }
+
+    /// Stands in for ssh by running its LAST argument through a shell, which is what the real one does
+    /// with the remote command.
+    func installSSH(exitCode: Int32? = nil) throws {
+        let body = exitCode.map { "exit \($0)" } ?? #"/bin/sh -c "$last""#
+        try write(name: "ssh", script: """
+        for a in "$@"; do last=$a; done
+        \(body)
+        """)
+    }
+
+    func installZmx() throws -> String {
+        try write(name: "zmx", script: """
+        \(recordArguments)
+        printf '%s\\n' "$ZMX_DIR" >> '\(zmxDirLog.path)'
+        printf 'session=[%s] prefix=[%s] nodetach=[%s]\\n' \\
+          "${ZMX_SESSION-MISSING}" "${ZMX_SESSION_PREFIX-MISSING}" "${ZMX_NO_DETACH_KEY-MISSING}" \\
+          >> '\(zmxEnvLog.path)'
+        """)
+        return root.appendingPathComponent("zmx").path
+    }
+
+    /// One line per argument, so an argument containing spaces stays one argument. `"$*"` would flatten
+    /// the guard script into words and let a broken argv pass.
+    private var recordArguments: String {
+        """
+        for a in "$@"; do printf '%s\\n' "$a" >> '\(log.path)'; done
+        printf '%s\\n' '\(Self.callSeparator)' >> '\(log.path)'
+        """
+    }
+
+    private static let callSeparator = "<<<agterm-call>>>"
+
+    /// `shell` stands in for the far side's login shell, which is what sshd actually runs the remote
+    /// command through — not necessarily a POSIX one.
+    func runRemote(_ argv: [String], shell: String = "/bin/sh",
+                   exporting extra: [String: String] = [:]) throws -> (status: Int32, stdout: String) {
+        try runShell(try #require(argv.last), shell: shell, exporting: extra)
+    }
+
+    /// The fake's directory goes FIRST, ahead of the real install locations the command under test
+    /// appends, so these never resolve the machine's own agtermctl and drive the live terminal.
+    func runShell(_ remote: String, shell: String = "/bin/sh",
+                  exporting extra: [String: String] = [:]) throws -> (status: Int32, stdout: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-c", remote]
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = root.path + ":" + (environment["PATH"] ?? "/usr/bin:/bin")
+        environment.merge(extra) { _, new in new }
+        process.environment = environment
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+
+    func calls() throws -> [[String]] {
+        guard let text = try? String(contentsOf: log, encoding: .utf8) else { return [] }
+        var calls: [[String]] = []
+        var current: [String] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false).dropLast() {
+            if line == Self.callSeparator {
+                calls.append(current)
+                current = []
+                continue
+            }
+            current.append(String(line))
+        }
+        return calls
+    }
+
+    func recordedZmxDir() throws -> String {
+        try String(contentsOf: zmxDirLog, encoding: .utf8).trimmingCharacters(in: .newlines)
+    }
+
+    /// The zmx session variables as the invoked zmx saw them; `MISSING` marks one the argv never set.
+    func recordedZmxSessionEnv() throws -> String {
+        try String(contentsOf: zmxEnvLog, encoding: .utf8).trimmingCharacters(in: .newlines)
+    }
+
+    private func write(name: String, script: String) throws {
+        let url = root.appendingPathComponent(name)
+        try ("#!/bin/sh\n" + script + "\n").write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/RemoteTreeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RemoteTreeTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct RemoteTreeTests {
+    private static let left = ZmxSupport.daemonName(for: UUID())
+    private static let right = ZmxSupport.daemonName(for: UUID())
+    private static let other = ZmxSupport.daemonName(for: UUID())
+
+    private let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/zmx",
+                                              socketDirectory: "/tmp/agterm-zmx-abc")
+
+    // MARK: - building the candidate list
+
+    @Test func aPlainSessionResolvesToOneLeftDaemon() throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo")])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                   ]))
+
+        #expect(tree.host == nil, "the local form sshed nowhere, so it names no destination")
+        #expect(tree.endpoint == endpoint)
+        #expect(tree.sessions.count == 1)
+        #expect(tree.sessions[0].panes == [ControlRemotePane(pane: "left", daemon: Self.left)])
+        #expect(tree.sessions[0].splitAxis == nil)
+        #expect(tree.sessions[0].windowName == "main")
+        #expect(tree.sessions[0].workspaceName == "work")
+    }
+
+    @Test func everyOpenWindowIsOffered() throws {
+        let windows = [window(id: "w-1", name: "main", workspace: "umputun.dev",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo")]),
+                       window(id: "w-2", name: "second", workspace: "ops",
+                              sessions: [node(id: "s2", name: "logs", cwd: "/var")])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                       entry(session: "s2", pane: "left", daemon: Self.right),
+                                                   ]))
+
+        #expect(tree.sessions.map(\.id) == ["s1", "s2"])
+        #expect(tree.sessions.map(\.windowID) == ["w-1", "w-2"])
+        #expect(tree.sessions.map(\.windowName) == ["main", "second"])
+    }
+
+    // neither rename path enforces uniqueness, so a caller grouping by name would merge these two
+    @Test func sameNamedWindowsAndWorkspacesStayApartByID() throws {
+        let windows = [window(id: "w-1", name: "main", workspaceID: "ws-1", workspace: "dev",
+                              sessions: [node(id: "s1", name: "build", cwd: "/a")]),
+                       window(id: "w-2", name: "main", workspaceID: "ws-2", workspace: "dev",
+                              sessions: [node(id: "s2", name: "build", cwd: "/b")])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                       entry(session: "s2", pane: "left", daemon: Self.right),
+                                                   ]))
+
+        #expect(Set(tree.sessions.map(\.windowName)) == ["main"])
+        #expect(tree.sessions.map(\.windowID) == ["w-1", "w-2"])
+        #expect(tree.sessions.map(\.workspaceID) == ["ws-1", "ws-2"])
+    }
+
+    @Test func eachSessionCarriesItsOwnWorkspaceRatherThanTheFirstOne() throws {
+        let left = ControlWorkspaceNode(id: "ws-1", name: "umputun.dev", active: true,
+                                        sessions: [node(id: "s1", name: "build", cwd: "/repo")])
+        let right = ControlWorkspaceNode(id: "ws-2", name: "ops", active: false,
+                                         sessions: [node(id: "s2", name: "logs", cwd: "/var")])
+        let windows = [RemoteWindowProjection(id: "w-1", name: "main",
+                                              tree: ControlTree(workspaces: [left, right]))]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                       entry(session: "s2", pane: "left", daemon: Self.right),
+                                                   ]))
+
+        #expect(tree.sessions.map(\.workspaceName) == ["umputun.dev", "ops"])
+    }
+
+    @Test func aPaneCarriesWhatIsRunningInItAndTheSessionItsContext() throws {
+        let running = ControlSessionNode(id: "s1", name: "build", cwd: "/repo", active: false, split: false,
+                                         backedByZmx: true, foreground: ["/usr/bin/tail", "-f"],
+                                         context: "release prep")
+        let windows = [window(name: "main", workspace: "work", sessions: [running])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                   ]))
+
+        #expect(tree.sessions[0].context == "release prep")
+        #expect(tree.sessions[0].panes[0].foreground == ["/usr/bin/tail", "-f"])
+    }
+
+    @Test func aSplitSessionCarriesBothDaemonsAndItsAxis() throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo", hasSplit: true)])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                       entry(session: "s1", pane: "right", daemon: Self.right),
+                                                   ]))
+
+        #expect(tree.sessions[0].panes.map(\.pane) == ["left", "right"])
+        #expect(tree.sessions[0].panes.map(\.daemon) == [Self.left, Self.right])
+        #expect(tree.sessions[0].splitAxis == "vertical")
+    }
+
+    @Test func aSplitMissingItsSecondDaemonIsDroppedRatherThanOfferedHalfWay() throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo", hasSplit: true)])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                   ]))
+
+        #expect(tree.sessions.isEmpty)
+    }
+
+    @Test(arguments: [("orphan", "running"), ("claimed", "absent"), ("claimed", "unreadable")])
+    func onlyAClaimedAndRunningDaemonIsOffered(_ pair: (state: String, observation: String)) throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo")])]
+
+        let tree = try RemoteTreeMerger.candidates(
+            windows: windows,
+            inventory: inventory(entries: [entry(session: "s1", pane: "left", daemon: Self.left,
+                                                 state: pair.state, observation: pair.observation)]))
+
+        #expect(tree.sessions.isEmpty)
+    }
+
+    // a launch that asked for live and fell back keeps its daemons while showing plain shells
+    @Test func aSessionThatIsNotBackedByZmxIsNotOffered() throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo", backedByZmx: false)])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                   ]))
+
+        #expect(tree.sessions.isEmpty)
+    }
+
+    @Test func aDaemonNamedOutsideAgtermsSchemeIsNotOffered() throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo")])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: "notes"),
+                                                   ]))
+
+        #expect(tree.sessions.isEmpty)
+    }
+
+    @Test func rowsNamingNoListedSessionAreIgnored() throws {
+        let windows = [window(name: "main", workspace: "work",
+                              sessions: [node(id: "s1", name: "build", cwd: "/repo")])]
+
+        let tree = try RemoteTreeMerger.candidates(windows: windows,
+                                                   inventory: inventory(entries: [
+                                                       entry(session: "s1", pane: "left", daemon: Self.left),
+                                                       entry(session: "gone", pane: "left", daemon: Self.other),
+                                                   ]))
+
+        #expect(tree.sessions.map(\.id) == ["s1"])
+    }
+
+    @Test func anInventoryWithNoEndpointIsRefusedByName() {
+        #expect(throws: RemoteTreeMerger.MergeError.missingEndpoint) {
+            try RemoteTreeMerger.candidates(windows: [], inventory: inventory(entries: [],
+                                                                              includeEndpoint: false))
+        }
+    }
+
+    @Test func noWindowsIsAnEmptyAnswerRatherThanAFailure() throws {
+        let tree = try RemoteTreeMerger.candidates(windows: [], inventory: inventory(entries: []))
+
+        #expect(tree.sessions.isEmpty)
+        #expect(tree.endpoint == endpoint)
+    }
+
+    // MARK: - reading the far side's answer back
+
+    @Test func theFarSidesAnswerIsDecodedWhole() throws {
+        let session = ControlRemoteSession(id: "s1", name: "build", windowID: "w-1", windowName: "main",
+                                           workspaceID: "ws-1", workspaceName: "work", cwd: "/repo",
+                                           splitAxis: nil,
+                                           panes: [ControlRemotePane(pane: "left", daemon: Self.left)])
+        let payload = ControlRemoteTree(host: nil, endpoint: endpoint, sessions: [session])
+        let stdout = String(decoding: try JSONEncoder().encode(
+            ControlResponse(ok: true, result: ControlResult(remote: payload))), as: UTF8.self)
+
+        #expect(try RemoteTreeMerger.decode(stdout: stdout) == payload)
+    }
+
+    @Test func theRemotesOwnRefusalIsReadFromStdoutWhereAgtermctlPutsIt() {
+        let stdout = #"{"ok":false,"error":"could not read the zmx session list"}"#
+
+        #expect(RemoteTreeMerger.remoteError(stdout: stdout) == "could not read the zmx session list")
+    }
+
+    @Test func anOkAnswerCarriesNoRemoteErrorToReport() {
+        let stdout = #"{"ok":true,"result":{"remote":{"endpoint":{"executable":"/z","socketDirectory":"/t"},"sessions":[]}}}"#
+
+        #expect(RemoteTreeMerger.remoteError(stdout: stdout) == nil)
+    }
+
+    @Test func unreadableOutputIsMalformedRatherThanEmpty() {
+        #expect(throws: RemoteTreeMerger.MergeError.malformedProjection) {
+            try RemoteTreeMerger.decode(stdout: "command not found: agtermctl")
+        }
+    }
+
+    // an older far side knows `zmx tree` but answers ok with nothing in it
+    @Test func anOkAnswerWithNoRemoteResultIsMalformed() {
+        #expect(throws: RemoteTreeMerger.MergeError.malformedProjection) {
+            try RemoteTreeMerger.decode(stdout: #"{"ok":true}"#)
+        }
+    }
+
+    @Test func aFailedRemoteReadCarriesItsOwnReason() {
+        #expect(throws: RemoteTreeMerger.MergeError.remoteFailed("zmx is not available")) {
+            try RemoteTreeMerger.decode(stdout: #"{"ok":false,"error":"zmx is not available"}"#)
+        }
+    }
+
+    // MARK: - fixtures
+
+    private func node(id: String, name: String, cwd: String, hasSplit: Bool = false,
+                      axis: String = "vertical", backedByZmx: Bool? = true) -> ControlSessionNode {
+        ControlSessionNode(id: id, name: name, cwd: cwd, active: false, split: hasSplit,
+                           hasSplit: hasSplit ? true : nil, backedByZmx: backedByZmx,
+                           splitAxis: hasSplit ? axis : nil)
+    }
+
+    private func window(id: String = "w-1", name: String, workspaceID: String = "ws-1", workspace: String,
+                        sessions: [ControlSessionNode]) -> RemoteWindowProjection {
+        let node = ControlWorkspaceNode(id: workspaceID, name: workspace, active: true, sessions: sessions)
+        return RemoteWindowProjection(id: id, name: name, tree: ControlTree(workspaces: [node]))
+    }
+
+    private func entry(session: String, pane: String, daemon: String,
+                       state: String = "claimed", observation: String = "running") -> [String: Any] {
+        ["daemon": daemon, "state": state, "observation": observation, "sessionID": session, "pane": pane]
+    }
+
+    /// Built as raw JSON and decoded, so the fixture pins the wire shape rather than whatever the current
+    /// encoder happens to emit. `ControlZmxEntry` has no memberwise init of its own.
+    private func inventory(entries: [[String: Any]], includeEndpoint: Bool = true) -> ControlZmxInventory {
+        var payload: [String: Any] = [
+            "restore": ["configured": "live", "requestedAtLaunch": "live", "active": "live",
+                        "restartRequired": false],
+            "inventoryComplete": true,
+            "entries": entries,
+        ]
+        if includeEndpoint {
+            payload["endpoint"] = ["executable": endpoint.executable,
+                                   "socketDirectory": endpoint.socketDirectory]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: payload)
+        return try! JSONDecoder().decode(ControlZmxInventory.self, from: data)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
@@ -6,6 +6,66 @@ import Testing
 // restore-time clamping.
 @MainActor
 struct SnapshotRoundTripTests {
+    @Test func remoteSessionIsAbsentFromTheSnapshot() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let local = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let remote = store.addSession(toWorkspace: ws.id, cwd: "/b", remoteHost: "buildbox")!
+
+        let snapshot = store.snapshot()
+
+        let ids = snapshot.workspaces.flatMap(\.sessions).map(\.id)
+        #expect(ids == [local.id])
+    }
+
+    @Test func aWorkspaceOfOnlyRemoteSessionsSnapshotsEmptyRatherThanVanishing() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "remote only")
+        _ = store.addSession(toWorkspace: ws.id, cwd: "/a", remoteHost: "buildbox")
+
+        let snapshot = store.snapshot()
+
+        let workspace = snapshot.workspaces.first { $0.id == ws.id }
+        #expect(workspace != nil, "the workspace itself is local and must survive")
+        #expect(workspace?.sessions.isEmpty == true)
+    }
+
+    @Test func aRestoredStoreCarriesNoRemoteMarker() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        _ = store.addSession(toWorkspace: ws.id, cwd: "/a", remoteHost: "buildbox")
+        let restored = makeStore()
+
+        restored.restore(from: store.snapshot())
+
+        #expect(restored.workspaces.flatMap(\.sessions).allSatisfy { $0.remoteHost == nil })
+    }
+
+    @Test func quittingOnARemoteSessionRestoresTheMostRecentLocalOne() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let first = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let second = store.addSession(toWorkspace: ws.id, cwd: "/b")!
+        let remote = store.addSession(toWorkspace: ws.id, cwd: "/c", remoteHost: "buildbox")!
+        store.selectSession(first.id)
+        store.selectSession(second.id)
+        store.selectSession(remote.id)
+
+        let snapshot = store.snapshot()
+
+        #expect(snapshot.selectedSessionID == second.id, "an empty window beside live local rows is a poor restore")
+        #expect(snapshot.sessionRecency?.contains(remote.id) != true, "a remote id must not survive to disk")
+    }
+
+    @Test func aStoreOfOnlyRemoteSessionsPersistsNoSelection() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let remote = store.addSession(toWorkspace: ws.id, cwd: "/a", remoteHost: "buildbox")!
+        store.selectSession(remote.id)
+
+        #expect(store.snapshot().selectedSessionID == nil)
+    }
+
     @Test func paneIdentitiesRoundTrip() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryClaimsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryClaimsTests.swift
@@ -92,6 +92,22 @@ final class WindowLibraryClaimsTests {
         #expect(walk.claims.first?.sessionID == live.id)
     }
 
+    @Test func remoteSessionClaimsNoLocalDaemon() throws {
+        let library = WindowLibrary(directory: directory)
+        let windowID = try #require(library.windows.first?.id)
+        let store = try #require(library.store(for: windowID))
+        let live = try #require(store.workspaces.first?.sessions.first)
+        let remote = try #require(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/a",
+                                                   remoteHost: "buildbox"))
+        store.toggleSplit(remote.id)
+
+        let walk = library.paneClaims()
+
+        #expect(walk.complete, "a remote session is not a missing identity")
+        #expect(walk.claims.map(\.paneIdentity) == [live.paneIdentity],
+                "its panes run ssh; claiming them invents a local daemon nothing answers to")
+    }
+
     @Test func windowFileMissingFromTheIndexIsClaimedAsUnindexed() throws {
         let indexed = UUID()
         let stray = UUID()

--- a/agtermCore/Tests/agtermCoreTests/ZmxLifecycleTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ZmxLifecycleTests.swift
@@ -126,6 +126,58 @@ struct ZmxLifecycleTests {
         #expect(leaders == [ours: 41])
     }
 
+    @Test func remoteSessionCloseFinalizesNothingWhileALocalOneStillDoes() throws {
+        var finalized: [[UUID]] = []
+        let store = AppStore(persistence: temporaryPersistence(),
+                             paneFinalizer: { finalized.append($0) })
+        let workspace = store.addWorkspace(name: "work")
+        let local = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/local"))
+        let remote = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/remote",
+                                                   remoteHost: "buildbox"))
+        remote.hasSplit = true
+        remote.splitPaneIdentity = UUID()
+
+        store.closeSession(remote.id)
+        #expect(finalized.isEmpty, "its daemons live on buildbox; this finalizer only kills local ones")
+
+        store.closeSession(local.id)
+        #expect(finalized.flatMap { $0 } == [local.paneIdentity])
+    }
+
+    @Test func remoteSplitCloseFinalizesNothingWhileALocalSplitStillDoes() throws {
+        var finalized: [[UUID]] = []
+        let store = AppStore(persistence: temporaryPersistence(),
+                             paneFinalizer: { finalized.append($0) })
+        let workspace = store.addWorkspace(name: "work")
+        let remote = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/remote",
+                                                   remoteHost: "buildbox"))
+        remote.hasSplit = true
+        remote.splitPaneIdentity = UUID()
+        let local = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/local"))
+        let localSplit = UUID()
+        local.hasSplit = true
+        local.splitPaneIdentity = localSplit
+
+        store.closeSplit(remote.id)
+        #expect(finalized.isEmpty)
+
+        store.closeSplit(local.id)
+        #expect(finalized.flatMap { $0 } == [localSplit])
+    }
+
+    @Test func theInventoryProjectionSkipsARemoteSessionEntirely() throws {
+        let store = AppStore(persistence: temporaryPersistence())
+        let workspace = store.addWorkspace(name: "work")
+        let local = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/local"))
+        let remote = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/remote",
+                                                   remoteHost: "buildbox"))
+        remote.hasSplit = true
+        remote.splitPaneIdentity = UUID()
+
+        #expect(remote.locallyManagedPaneIdentities.isEmpty)
+        #expect(PaneIdentityInventory.identities(in: [local, remote]) == [local.paneIdentity])
+    }
+
     @Test func immediateSessionAndWorkspaceCloseFinalizeEveryOwnedPane() throws {
         var finalized: [[UUID]] = []
         let store = AppStore(persistence: temporaryPersistence(),

--- a/agtermCore/Tests/agtermctlKitTests/ZmxCommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/ZmxCommandsTests.swift
@@ -8,6 +8,77 @@ import Testing
 /// the point is that the CLI cannot send a kill the server would have to refuse, and that a reader can
 /// tell a closed window's resting state from a leak.
 struct ZmxCommandsTests {
+    @Test func treeCarriesItsHostAsAnArgumentNotATarget() throws {
+        let tree = try Zmx.Tree.parse(["buildbox"])
+
+        #expect(try tree.makeRequest().cmd == .zmxTree)
+        #expect(try tree.makeRequest().args?.host == "buildbox")
+        #expect(try tree.makeRequest().target == nil, "a remote host is not a local addressing target")
+    }
+
+    // no host is this app's own attachable sessions, which is the form the remote call runs on the far side
+    @Test func treeWithoutAHostAsksAboutThisApp() throws {
+        let tree = try Zmx.Tree.parse([])
+
+        #expect(try tree.makeRequest().cmd == .zmxTree)
+        #expect(try tree.makeRequest().args?.host == nil)
+    }
+
+    @Test func attachSendsTheHostAsAnArgumentAndTheSessionAsTheTarget() throws {
+        let attach = try Zmx.Attach.parse(["buildbox", "s1"])
+
+        #expect(try attach.makeRequest().cmd == .zmxAttach)
+        #expect(try attach.makeRequest().args?.host == "buildbox")
+        #expect(try attach.makeRequest().target == "s1")
+    }
+
+    @Test(arguments: [[], ["buildbox"]])
+    func attachNeedsBothAHostAndASession(_ arguments: [String]) {
+        #expect(throws: (any Error).self) { try Zmx.Attach.parse(arguments) }
+    }
+
+    @Test func attachEchoesTheLocalSessionItCreated() throws {
+        // it creates a session, so a script can pipe its id onward without --json
+        #expect(try Zmx.Attach.parse(["buildbox", "s1"]).echoesResultID)
+        #expect(try !Zmx.Tree.parse(["buildbox"]).echoesResultID, "a listing creates nothing to echo")
+    }
+
+    @Test func remoteTreeRendersOneRowPerAttachableSession() {
+        let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/zmx", socketDirectory: "/tmp/z")
+        let plain = ControlRemoteSession(
+            id: "s1", name: "build", windowID: "w-1", windowName: "main", workspaceID: "ws-1",
+            workspaceName: "umputun.dev", cwd: "/repo", splitAxis: nil,
+            panes: [ControlRemotePane(pane: "left", daemon: "agterm-1")])
+        let split = ControlRemoteSession(
+            id: "s2", name: "logs", windowID: "w-2", windowName: "second", workspaceID: "ws-2",
+            workspaceName: "ops", context: "tailing prod", cwd: "/var", splitAxis: "horizontal",
+            panes: [ControlRemotePane(pane: "left", daemon: "agterm-2", foreground: ["/usr/bin/tail", "-f"]),
+                    ControlRemotePane(pane: "right", daemon: "agterm-3", foreground: ["/bin/zsh"])])
+        let tree = ControlRemoteTree(host: "buildbox", endpoint: endpoint, sessions: [plain, split])
+
+        let lines = SocketClient.formatRemoteTree(tree).split(separator: "\n").map(String.init)
+
+        #expect(lines.count == 2)
+        #expect(lines[0] == "  main/umputun.dev/build  [s1]  /repo", "no context and no command adds no tail")
+        #expect(lines[1] == "  second/ops/logs (split horizontal)  [s2]  /var  tailing prod  tail | zsh")
+    }
+
+    // the bare form answers about this app, where no ssh destination exists to name
+    @Test func aLocalEmptyListNamesNoHost() {
+        let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/zmx", socketDirectory: "/tmp/z")
+
+        #expect(SocketClient.formatRemoteTree(ControlRemoteTree(host: nil, endpoint: endpoint, sessions: []))
+                == "no attachable sessions")
+    }
+
+    @Test func anEmptyRemoteTreeSaysSoRatherThanPrintingNothing() {
+        let endpoint = ControlZmxEndpoint(executable: "/Applications/agterm.app/zmx", socketDirectory: "/tmp/z")
+        let tree = ControlRemoteTree(host: "buildbox", endpoint: endpoint, sessions: [])
+
+        #expect(SocketClient.formatRemoteTree(tree) == "no attachable sessions on buildbox",
+                "silence reads the same as a failed read")
+    }
+
     @Test func listAndPruneSendTheirCommandWithNothingToResolve() throws {
         let list = try Zmx.List.parse([])
         #expect(try list.makeRequest().cmd == .zmxList)

--- a/agtermTests/AppDelegateCaptureTests.swift
+++ b/agtermTests/AppDelegateCaptureTests.swift
@@ -6,6 +6,28 @@ import agtermCore
 
 @MainActor
 final class AppDelegateCaptureTests: XCTestCase {
+    func testARemoteSessionIsNeitherReadNorCounted() {
+        let local = Session(initialCwd: "/tmp")
+        local.surface = GhosttySurfaceView(workingDirectory: "/tmp")
+        let remote = Session(initialCwd: "/tmp", remoteHost: "buildbox")
+        remote.surface = GhosttySurfaceView(workingDirectory: "/tmp")
+        var read: [Session] = []
+
+        let count = AppDelegate.captureForegroundCommands(
+            sessions: [local, remote],
+            commandReader: { view, _, _ in
+                read.append(view === local.surface ? local : remote)
+                return ["worker"]
+            })
+
+        // its foreground is an ssh client the save drops, so reading it inflates the count and spends the
+        // exit budget on a pane nothing will persist
+        XCTAssertEqual(count, 1)
+        XCTAssertTrue(read.allSatisfy { $0 === local })
+        XCTAssertNil(remote.foregroundCommand)
+        XCTAssertEqual(local.foregroundCommand, ["worker"])
+    }
+
     func testLivePrimaryAndHiddenSplitUseOneFreshSnapshot() throws {
         let primaryID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
         let splitID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!

--- a/agtermTests/ControlServerTests.swift
+++ b/agtermTests/ControlServerTests.swift
@@ -150,7 +150,7 @@ final class ControlServerTests: XCTestCase {
         var clients: [Int32] = []
         defer { for fd in clients { close(fd) } }
         for _ in 0..<24 {
-            let fd = connectFD(to: socketPath)
+            let fd = Self.connectFD(to: socketPath)
             if fd < 0 { break }
             clients.append(fd)
         }
@@ -195,20 +195,53 @@ final class ControlServerTests: XCTestCase {
                       "the error should name the rejected cmd, got: \(response ?? "nil")")
     }
 
-    private func makeServer() -> ControlServer {
+    private func makeServer(remoteRunner: RemoteCommandRunner? = nil) -> ControlServer {
         let library = WindowLibrary(directory: stateDir)
         let server = ControlServer(
             library: library,
             actions: AppActions(library: library),
             settingsModel: SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir)),
             identity: AppIdentity(version: "9.9.9"),
+            remoteRunner: remoteRunner,
             socketPath: socketPath
         )
         servers.append(server)
         return server
     }
 
-    private func address(for path: String) -> sockaddr_un {
+    // zmx tree ran its ssh inline on the one accept thread, so `zmx tree <this machine>` deadlocked
+    func testARemoteCallDoesNotHoldTheAcceptLoop() {
+        let runner = BlockingRemoteRunner()
+        let path = socketPath!
+        let server = makeServer(remoteRunner: runner)
+        server.start()
+        XCTAssertNotNil(server.boundSocketPath)
+
+        let sshInFlight = expectation(description: "the ssh has started")
+        runner.onEntered = { sshInFlight.fulfill() }
+        let remoteFinished = expectation(description: "the remote call returns once released")
+        Thread {
+            _ = Self.roundTrip(#"{"cmd":"zmx.tree","args":{"host":"buildbox"}}"#, at: path)
+            remoteFinished.fulfill()
+        }.start()
+
+        wait(for: [sshInFlight], timeout: 5)
+
+        let probeAnswered = expectation(description: "a second client is served during the ssh")
+        var probe: String?
+        Thread {
+            probe = Self.roundTrip(#"{"cmd":"window.list"}"#, at: path)
+            probeAnswered.fulfill()
+        }.start()
+
+        wait(for: [probeAnswered], timeout: 5)
+        XCTAssertNotNil(probe, "a second connection must be answered while the remote call is still waiting")
+
+        runner.release.signal()
+        wait(for: [remoteFinished], timeout: 10)
+    }
+
+    nonisolated private static func address(for path: String) -> sockaddr_un {
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let bytes = path.utf8CString
@@ -221,17 +254,17 @@ final class ControlServerTests: XCTestCase {
     }
 
     private func connects(to path: String) -> Bool {
-        let fd = connectFD(to: path)
+        let fd = Self.connectFD(to: path)
         guard fd >= 0 else { return false }
         close(fd)
         return true
     }
 
     /// A connected fd the caller keeps open, or -1. Holding them is what saturates the listen backlog.
-    private func connectFD(to path: String) -> Int32 {
+    nonisolated private static func connectFD(to path: String) -> Int32 {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return -1 }
-        var addr = address(for: path)
+        var addr = Self.address(for: path)
         let ok = withUnsafePointer(to: &addr) { ptr in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
                 connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size)) == 0
@@ -243,8 +276,10 @@ final class ControlServerTests: XCTestCase {
 
     /// One request line in, one response line out. Safe to block this main-actor test on the read: a decode
     /// failure is answered from `acceptQueue` before `handleConnection` hops to the main actor at all.
-    private func roundTrip(_ line: String) -> String? {
-        let fd = connectFD(to: socketPath)
+    private func roundTrip(_ line: String) -> String? { Self.roundTrip(line, at: socketPath) }
+
+    nonisolated private static func roundTrip(_ line: String, at path: String) -> String? {
+        let fd = connectFD(to: path)
         guard fd >= 0 else { return nil }
         defer { close(fd) }
         let payload = Array((line + "\n").utf8)
@@ -257,12 +292,31 @@ final class ControlServerTests: XCTestCase {
     }
 
     private func bindListener(_ fd: Int32, at path: String) -> Bool {
-        var addr = address(for: path)
+        var addr = Self.address(for: path)
         let bound = withUnsafePointer(to: &addr) { ptr in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
                 Darwin.bind(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
             }
         }
         return bound == 0 && listen(fd, 1) == 0
+    }
+}
+
+/// Stands in for ssh: signals when the call starts, then blocks until the test releases it, so a test can
+/// observe the server WHILE a remote command is still outstanding.
+private final class BlockingRemoteRunner: RemoteCommandRunner, @unchecked Sendable {
+    let release = DispatchSemaphore(value: 0)
+    var onEntered: (@Sendable () -> Void)?
+
+    func run(_: [String], deadline _: TimeInterval) async -> RemoteCommandResult {
+        stall()
+        return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+    }
+
+    /// Not inline in `run`: a semaphore wait is unavailable directly inside an async body, and blocking is
+    /// the whole point here — the real runner blocks on a `Process` the same way.
+    private func stall() {
+        onEntered?()
+        release.wait()
     }
 }

--- a/agtermTests/ControlServerZmxTests.swift
+++ b/agtermTests/ControlServerZmxTests.swift
@@ -30,6 +30,199 @@ final class ControlServerZmxTests: XCTestCase {
         try await super.tearDown()
     }
 
+    func testRemoteTreeReadsTheFarSidesAnswerInOneInvocation() async throws {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: Self.projection, stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: "buildbox")
+
+        let remote = try XCTUnwrap(response.result?.remote)
+        XCTAssertEqual(remote.host, "buildbox", "the far side names no host; the caller stamps it")
+        XCTAssertEqual(remote.sessions.map(\.id), ["s1"])
+        XCTAssertEqual(remote.sessions.map(\.windowName), ["main"])
+        XCTAssertEqual(remote.endpoint.socketDirectory, "/tmp/agterm-zmx-abc")
+        XCTAssertEqual(runner.invocations.count, 1, "the far side does the whole join in one call")
+        XCTAssertEqual(runner.invocations.first?.first, "ssh")
+    }
+
+    func testTheBareFormAnswersAboutThisAppWithoutSshingAnywhere() async throws {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: "", stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: nil)
+
+        let remote = try XCTUnwrap(response.result?.remote)
+        XCTAssertTrue(response.ok)
+        XCTAssertNil(remote.host, "nothing was sshed to, so there is no destination to name")
+        XCTAssertTrue(runner.invocations.isEmpty, "the local form must never reach ssh")
+        // no pane in this fixture is zmx-backed, and an empty list is a successful answer rather than
+        // a refusal: it does not claim to tell "not live" apart from "live with nothing eligible"
+        XCTAssertTrue(remote.sessions.isEmpty)
+    }
+
+    func testRemoteTreeRefusesANonzeroExitBeforeParsing() async {
+        // an ssh that dies mid-write leaves output that may still parse; only the exit status separates a
+        // real answer from a truncated one, which is why it is read first
+        let truncated = String(Self.projection.dropLast(40))
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 255, stdout: truncated,
+                                                                 stderr: "Permission denied (publickey)."))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: "buildbox")
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.error, "Permission denied (publickey).")
+    }
+
+    func testAFailedRemoteReportsItsOwnReasonRatherThanAGenericOne() async {
+        // the remote's agtermctl prints its refusal to stdout and exits nonzero, leaving stderr empty
+        let refusal = #"{"ok":false,"error":"could not read the zmx session list"}"#
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 1, stdout: refusal, stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: "buildbox")
+
+        XCTAssertEqual(response.error, "could not read the zmx session list")
+    }
+
+    func testAnSshFailureStillFallsBackToStderr() async {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 255, stdout: "",
+                                                                  stderr: "ssh: Could not resolve hostname"))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: "buildbox")
+
+        XCTAssertEqual(response.error, "ssh: Could not resolve hostname")
+    }
+
+    func testRemoteTreeRejectsAHostileHostWithoutRunningAnything() async {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: "", stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: "-oProxyCommand=touch /tmp/pwned")
+
+        XCTAssertFalse(response.ok)
+        XCTAssertTrue(runner.invocations.isEmpty, "a refused host must never reach a process")
+    }
+
+    // a rejected host is rejected for carrying control characters, so echoing it back would print them
+    // to a terminal once agtermctl decodes the response
+    func testRefusedHostIsNotEchoedIntoTheResponse() async {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: "", stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        let response = await server.remoteTree(host: "buildbox\nrm -rf /\u{1B}[31mRED")
+
+        XCTAssertEqual(response.error, "invalid host")
+        XCTAssertFalse(response.error?.contains("\n") ?? true)
+        XCTAssertFalse(response.error?.contains("\u{1B}") ?? true)
+        XCTAssertFalse(response.error?.contains("rm -rf") ?? true)
+    }
+
+    func testAttachCreatesARemoteSessionWithAHoldingSshPane() async throws {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: Self.projection, stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+        let store = try XCTUnwrap(library.activeStore)
+
+        let response = await server.attachRemoteSession(host: "buildbox", session: "s1")
+
+        XCTAssertTrue(response.ok)
+        let created = try XCTUnwrap(store.workspaces.flatMap(\.sessions).first { $0.remoteHost != nil })
+        XCTAssertEqual(created.remoteHost, "buildbox")
+        XCTAssertEqual(created.customName, "build")
+        XCTAssertTrue(created.commandWait, "the pane must hold so the disconnect line can be read")
+        let command = try XCTUnwrap(created.initialCommand)
+        XCTAssertTrue(command.contains("ssh"))
+        XCTAssertTrue(command.contains("agterm-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"))
+        XCTAssertFalse(created.hasSplit)
+    }
+
+    func testAttachResolvesTheRemoteAgainRatherThanTrustingTheCaller() async {
+        // the daemon has gone since the picker listed it, so the far side's own eligibility walk no longer
+        // offers the session at all; attaching would CREATE the daemon and hand back a fresh shell
+        // wearing the session's name
+        let vanished = """
+        {"ok":true,"result":{"remote":{\
+        "endpoint":{"executable":"/Applications/agterm.app/zmx","socketDirectory":"/tmp/agterm-zmx-abc"},\
+        "sessions":[]}}}
+        """
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: vanished, stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+        let store = library.activeStore
+
+        let response = await server.attachRemoteSession(host: "buildbox", session: "s1")
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.error, "no attachable session s1 on buildbox")
+        XCTAssertEqual(runner.invocations.count, 1, "it re-reads before touching the model")
+        XCTAssertNil(store?.workspaces.flatMap(\.sessions).first { $0.remoteHost != nil },
+                     "a refused attach must leave no half-built row")
+    }
+
+    func testAFailedDiscoveryCreatesNothingAndKeepsItsReason() async {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 255, stdout: "",
+                                                                  stderr: "Permission denied (publickey)."))
+        let server = makeServer(list: "", remoteRunner: runner)
+        let store = library.activeStore
+
+        let response = await server.attachRemoteSession(host: "buildbox", session: "s1")
+
+        XCTAssertEqual(response.error, "Permission denied (publickey).")
+        XCTAssertNil(store?.workspaces.flatMap(\.sessions).first { $0.remoteHost != nil })
+    }
+
+    func testAttachTakesTheSessionIdOnlyNotItsName() async {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: Self.projection, stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+
+        // remote names are mutable and non-unique across workspaces, so only the id can address one
+        let response = await server.attachRemoteSession(host: "buildbox", session: "build")
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.error, "no attachable session build on buildbox")
+    }
+
+    func testAttachUsesALocalWorkingDirectoryNotTheRemoteOne() async throws {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: Self.projection, stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+        let store = try XCTUnwrap(library.activeStore)
+
+        _ = await server.attachRemoteSession(host: "buildbox", session: "s1")
+
+        let created = try XCTUnwrap(store.workspaces.flatMap(\.sessions).first { $0.remoteHost != nil })
+        // libghostty chdirs the local ssh process here; /repo exists on buildbox, not necessarily here
+        XCTAssertNotEqual(created.initialCwd, "/repo")
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: created.initialCwd, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testAttachBringsBothPanesOfARemoteSplit() async throws {
+        let runner = FakeRemoteRunner(result: RemoteCommandResult(status: 0, stdout: Self.splitProjection,
+                                                                  stderr: ""))
+        let server = makeServer(list: "", remoteRunner: runner)
+        let store = try XCTUnwrap(library.activeStore)
+
+        let response = await server.attachRemoteSession(host: "buildbox", session: "s1")
+
+        XCTAssertTrue(response.ok)
+        let created = try XCTUnwrap(store.workspaces.flatMap(\.sessions).first { $0.remoteHost != nil })
+        XCTAssertTrue(created.hasSplit)
+        XCTAssertEqual(created.splitAxis, .topBottom, "the split arrives arranged as it is over there")
+        XCTAssertTrue(created.splitCommandWait)
+        XCTAssertTrue(try XCTUnwrap(created.splitInitialCommand).contains("agterm-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"))
+    }
+
+    func testListReportsTheEndpointOfTheInjectedClient() throws {
+        let server = makeServer(list: "")
+
+        let inventory = try XCTUnwrap(server.listZmxDaemons().result?.zmx)
+
+        let endpoint = try XCTUnwrap(inventory.endpoint)
+        XCTAssertEqual(endpoint.executable, "/tmp/zmx")
+        XCTAssertEqual(endpoint.socketDirectory, "/tmp/zmx-dir")
+    }
+
     func testListJoinsObservedDaemonsAgainstTheLivePanes() throws {
         let live = try XCTUnwrap(library.allOpenSessions().first)
         let orphan = "agterm-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -526,18 +719,60 @@ final class ControlServerZmxTests: XCTestCase {
     }
 
     /// A client whose runner returns `list` output, or throws when it is nil.
-    private func makeServer(list output: String?) -> ControlServer {
+    private func makeServer(list output: String?,
+                            remoteRunner: (any RemoteCommandRunner)? = nil) -> ControlServer {
         makeServer(runner: { _ in
             guard let output else { throw ZmxClient.CommandError.timedOut }
             return output
-        })
+        }, remoteRunner: remoteRunner)
     }
 
-    private func makeServer(runner: @escaping ZmxClient.Runner) -> ControlServer {
+    private func makeServer(runner: @escaping ZmxClient.Runner,
+                            remoteRunner: (any RemoteCommandRunner)? = nil) -> ControlServer {
         ControlServer(
             library: library, actions: AppActions(library: library), settingsModel: settingsModel,
             identity: AppIdentity(version: "9.9.9", commit: "testsha"),
             zmxClient: ZmxClient(executablePath: "/tmp/zmx", socketDirectory: "/tmp/zmx-dir", runner: runner),
+            remoteRunner: remoteRunner,
             socketPath: stateDir.appendingPathComponent("control-\(UUID().uuidString).sock").path)
+    }
+
+    /// What the far side's own `zmx tree` prints: one document, one attachable session, and no `host` —
+    /// it cannot know which name reached it, so the requesting app stamps that on afterwards.
+    private static let projection = """
+    {"ok":true,"result":{"remote":{\
+    "endpoint":{"executable":"/Applications/agterm.app/zmx","socketDirectory":"/tmp/agterm-zmx-abc"},\
+    "sessions":[{"id":"s1","name":"build","windowID":"w1","windowName":"main","workspaceID":"ws1",\
+    "workspaceName":"work","cwd":"/repo",\
+    "panes":[{"pane":"left","daemon":"agterm-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"}]}]}}}
+    """
+
+    /// The same remote, whose session has a top/bottom split with both daemons live.
+    private static let splitProjection = """
+    {"ok":true,"result":{"remote":{\
+    "endpoint":{"executable":"/Applications/agterm.app/zmx","socketDirectory":"/tmp/agterm-zmx-abc"},\
+    "sessions":[{"id":"s1","name":"build","windowID":"w1","windowName":"main","workspaceID":"ws1",\
+    "workspaceName":"work","cwd":"/repo","splitAxis":"horizontal",\
+    "panes":[{"pane":"left","daemon":"agterm-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"},\
+    {"pane":"right","daemon":"agterm-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"}]}]}}}
+    """
+}
+
+/// Records what it was asked to run and answers with a canned result, so the remote commands are covered
+/// without a second Mac.
+private final class FakeRemoteRunner: RemoteCommandRunner, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [[String]] = []
+    private let result: RemoteCommandResult
+
+    var invocations: [[String]] { lock.withLock { recorded } }
+
+    init(result: RemoteCommandResult) {
+        self.result = result
+    }
+
+    func run(_ argv: [String], deadline _: TimeInterval) async -> RemoteCommandResult {
+        lock.withLock { recorded.append(argv) }
+        return result
     }
 }

--- a/agtermTests/RemoteCommandProcessRunnerTests.swift
+++ b/agtermTests/RemoteCommandProcessRunnerTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// The real process runner, which every other remote test replaces with a fake. Covers the two ways it
+/// can hang: a child that never exits, and one that fills a pipe while nobody drains it.
+final class RemoteCommandProcessRunnerTests: XCTestCase {
+    private let runner = RemoteCommandProcessRunner()
+
+    func testACommandThatOutlivesTheDeadlineIsKilledAndReported() async {
+        let started = Date()
+
+        let result = await runner.run(["sh", "-c", "sleep 30"], deadline: 0.4)
+
+        XCTAssertEqual(result.status, -1)
+        XCTAssertEqual(result.stderr, "the remote did not answer in time")
+        XCTAssertLessThan(Date().timeIntervalSince(started), 5,
+                          "the deadline must bound a child that keeps its pipes open")
+    }
+
+    func testOutputLargerThanAPipeBufferOnBothStreamsStillCompletes() async {
+        // 512 KiB each way, well past the 64 KiB pipe buffer: draining one stream at a time deadlocks here
+        let script = "yes abcdefgh | head -c 524288; yes abcdefgh | head -c 524288 >&2"
+
+        let result = await runner.run(["sh", "-c", script], deadline: 20)
+
+        XCTAssertEqual(result.status, 0)
+        XCTAssertEqual(result.stdout.utf8.count, 524_288)
+        XCTAssertEqual(result.stderr.utf8.count, 524_288)
+    }
+
+    func testANonzeroExitKeepsBothStreams() async {
+        let result = await runner.run(["sh", "-c", "printf out; printf err >&2; exit 7"], deadline: 10)
+
+        XCTAssertEqual(result.status, 7)
+        XCTAssertEqual(result.stdout, "out")
+        XCTAssertEqual(result.stderr, "err")
+    }
+
+    func testAMissingExecutableIsAnErrorRatherThanAHang() async {
+        let result = await runner.run(["agterm-no-such-command-\(UUID().uuidString)"], deadline: 10)
+
+        XCTAssertNotEqual(result.status, 0)
+    }
+}

--- a/agtermTests/SidebarRowViewsTests.swift
+++ b/agtermTests/SidebarRowViewsTests.swift
@@ -85,6 +85,40 @@ final class SidebarRowViewsTests: XCTestCase {
         XCTAssertNil(field.toolTip, "dragging the divider wider must re-evaluate, or a stale tooltip lingers")
     }
 
+    func testARemoteSessionRowGetsItsOwnIcon() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let local = try XCTUnwrap(store.activeSession)
+        let remote = try XCTUnwrap(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/a", remoteHost: "buildbox"))
+        buildSidebar(for: store)
+
+        let remoteIcon = try renderedIcon(forSession: remote.id)
+        let localIcon = try renderedIcon(forSession: local.id)
+
+        XCTAssertEqual(remoteIcon, coordinator.remoteSessionIcon)
+        XCTAssertNotEqual(remoteIcon, localIcon, "a teleported row must be tellable from a local one at a glance")
+    }
+
+    func testARemoteRowStillShowsAHiddenSplit() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let remote = try XCTUnwrap(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/a", remoteHost: "buildbox"))
+        store.toggleSplit(remote.id)
+        store.toggleSplit(remote.id)
+        buildSidebar(for: store)
+
+        XCTAssertTrue(remote.hasSplit, "the pane is alive but hidden; the row is the only place this shows")
+        XCTAssertEqual(try renderedIcon(forSession: remote.id), coordinator.remoteSplitSessionIcon)
+    }
+
+    func testAFlaggedRemoteRowKeepsTheUnsplitGlyph() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let remote = try XCTUnwrap(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/a", remoteHost: "buildbox"))
+        remote.flagged = true
+        buildSidebar(for: store)
+
+        XCTAssertEqual(try renderedIcon(forSession: remote.id), coordinator.remoteSessionIcon,
+                       "on a remote row the fill carries split, so flagging must not claim it")
+    }
+
     private func buildSidebar(for store: AppStore) {
         outline = SidebarOutlineView()
         coordinator = WorkspaceSidebar.Coordinator(store: store, actions: actions)
@@ -137,5 +171,15 @@ final class SidebarRowViewsTests: XCTestCase {
         let cell = try XCTUnwrap(outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? SidebarCellView)
         cell.layoutSubtreeIfNeeded()
         return try XCTUnwrap(cell.textField)
+    }
+
+    private func renderedIcon(forSession id: UUID) throws -> NSImage? {
+        outline.layoutSubtreeIfNeeded()
+        let row = try XCTUnwrap((0..<outline.numberOfRows).first { index in
+            guard let node = outline.item(atRow: index) as? SidebarNode else { return false }
+            return node.kind == .session && node.id == id
+        }, "the session row should be visible in the outline")
+        let cell = try XCTUnwrap(outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? SidebarCellView)
+        return cell.imageView?.image
     }
 }

--- a/agtermTests/ZmxLaunchTests.swift
+++ b/agtermTests/ZmxLaunchTests.swift
@@ -4,6 +4,23 @@ import agtermCore
 
 @MainActor
 final class ZmxLaunchTests: XCTestCase {
+
+    func testALiveLaunchWrapsALocalSessionButNeverARemoteOne() {
+        let local = Session(initialCwd: "/tmp")
+        let remote = Session(initialCwd: "/tmp", remoteHost: "buildbox")
+
+        XCTAssertTrue(ZmxLaunch.wrapsLocally(mode: .live, session: local))
+        // a wrapper would keep the ssh alive inside a surviving daemon after a window close
+        XCTAssertFalse(ZmxLaunch.wrapsLocally(mode: .live, session: remote))
+    }
+
+    func testNoSessionIsWrappedOutsideLiveMode() {
+        let local = Session(initialCwd: "/tmp")
+
+        XCTAssertFalse(ZmxLaunch.wrapsLocally(mode: .none, session: local))
+        XCTAssertFalse(ZmxLaunch.wrapsLocally(mode: .rerun, session: local))
+    }
+
     func testLaunchDispositionKeepsFallbackStateUnconsumed() {
         let configuration = ZmxSupport.Configuration(
             command: "zmx attach session", environment: [:], daemonName: "session",

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -55,6 +55,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [fzf-path-picker](fzf-path-picker/) | pick a path with fzf and type it into the shell | 0.8.0, fzf, fd, zsh |
 | [native-dir-picker](native-dir-picker/) | pick a directory in the native picker and type it into the shell | 0.19.0, fd, jq |
 | [overlay-and-split](overlay-and-split/) | keymap lines: a stateful split toggle and TUI overlays | 0.10.0, jq |
+| [remote-session-picker](remote-session-picker/) | pick a session running on another Mac and attach it here | 0.26.0, jq |
 | [same-dir](same-dir/) | sync working directory to target split pane | 0.10.0, jq, zsh |
 | [sqlite-browser](sqlite-browser/) | pick one of the repo's SQLite databases and browse it in an overlay | 0.22.0, python3, tabiew |
 

--- a/cookbook/remote-session-picker/README.md
+++ b/cookbook/remote-session-picker/README.md
@@ -1,0 +1,115 @@
+# Remote session picker
+
+Pick a session running on another Mac and attach it here, marked remote in the sidebar.
+
+## What it does
+
+Lists what another Mac has to offer, shows it in agterm's native picker, and attaches whatever you
+choose. The row is the session's name; underneath it sits the far side's window and workspace, the
+session's own note of what it is for when its owner set one, its working directory, and what its panes
+are running.
+
+A picked session appears in your current workspace as an ordinary session with a remote marker. Its
+split comes with it. Closing it here ends only your side's connection: the far-side processes keep
+running, and nothing this recipe does can kill them.
+
+## Requirements
+
+agterm 0.26.0 or later, which added `zmx tree` and `zmx attach`, plus `jq`.
+
+The far side needs more than the near side does:
+
+- it is running agterm 0.26.0 or later too, since the discovery call runs `zmx tree` over there and an
+  older build does not have it;
+- its restore mode is **Live sessions**, which is what puts a daemon behind each pane. Without it there
+  is nothing to attach to. The empty list does not say so, though: it reads the same as a machine that is
+  in Live sessions mode with nothing eligible. Run `agtermctl zmx list` on that machine to tell them apart;
+- it has `agtermctl` installed, from the cask or Help ▸ Install, because a machine merely running agterm
+  has no CLI an ssh command can find;
+- ssh key auth to it already works from this Mac. The connection is non-interactive, so a password or
+  host-key prompt is a failure rather than a question.
+
+Check that last one before binding the chord, using the same non-interactive form agterm uses:
+
+```sh
+ssh -o BatchMode=yes <remote-host> true
+```
+
+Exiting silently means agterm can reach the host. A password or host-key prompt means it cannot, and
+agterm will fail the same way.
+
+One difference the check cannot show: agterm runs ssh from the app, which inherits the launch environment
+rather than your shell's. An agent exported in `.zshrc` passes the check above and still fails here, so
+put `IdentityAgent` and key settings in `~/.ssh/config`, which both paths read.
+
+## Setup
+
+Copy `attach-remote.sh` somewhere on your PATH and make it executable:
+
+```sh
+mkdir -p ~/bin
+install -m 755 attach-remote.sh ~/bin/attach-remote
+```
+
+Then bind it in `~/.config/agterm/keymap.conf`, one line per machine you want to reach. Replace
+`<remote-host>` with the machine as ssh would take it:
+
+```
+command "Attach Remote" cmd+shift+r ~/bin/attach-remote <remote-host>
+```
+
+The host can come from the environment instead, which suits a single machine:
+
+```
+command "Attach Remote" cmd+shift+r AGT_REMOTE_HOST=<remote-host> ~/bin/attach-remote
+```
+
+## Usage
+
+Press the chord. The picker opens with one row per attachable session; type to filter, Return to attach,
+Esc to cancel. Cancelling does nothing at all.
+
+Run it from a shell to see the same list without the picker's filtering:
+
+```sh
+agtermctl zmx tree <remote-host>
+```
+
+## How it works
+
+`zmx tree HOST` is the discovery half. The local agterm runs one ssh to the far side, which runs its own
+bare `zmx tree` there and answers with a single document: every open window's sessions, filtered to the
+ones whose every pane still has a live daemon. A session with a missing daemon is omitted rather than
+offered, because attaching to a name that no longer exists would create a fresh shell wearing it.
+
+The script turns that answer into picker items, using the session `id` rather than its name: remote
+names are editable and repeat across workspaces, so only the id addresses one session. The subtitle shows
+the window and workspace *names*; the rows also carry `windowID` and `workspaceID`, which is what to group
+by if you extend this, since neither name is unique.
+
+Running `agtermctl zmx tree` with no host asks the same question of your own agterm. That is the exact
+form the remote call runs on the far side, so it is the quickest way to see what another machine would
+answer before you point the recipe at it.
+
+`zmx attach HOST ID` opens it. The attach resolves the remote again before touching anything local, so a
+session that disappeared between the listing and your keypress fails cleanly instead of handing back a
+fresh shell.
+
+Both halves report through `agtermctl notify` rather than stdout, because a keymap command runs with its
+output on `/dev/null` and an error printed there is an error nobody sees.
+
+## Limits
+
+An attached session is never written to disk, so it does not come back after a relaunch whatever your
+restore mode is. If the connection drops, the pane holds on a press-any-key prompt showing the host,
+session, pane and exit status; reconnecting means running this recipe again.
+
+The attached view arrives at the far side's window geometry and does not reflow until you press a
+classified key into it: a printable character, Return, Tab or Backspace. Before that keystroke your
+mouse, focus reporting and Ctrl-L do not reach the remote, so a mouse-driven full-screen program can look
+frozen.
+
+Leadership is per pane, so a session whose primary you have typed into can sit beside a split still at
+the far side's geometry until you type in that one too. After you detach, each far-side pane you led
+keeps your geometry until something gives it input or resizes it there; panes you never typed into are
+unaffected.

--- a/cookbook/remote-session-picker/attach-remote.sh
+++ b/cookbook/remote-session-picker/attach-remote.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# pick a session running on another Mac and attach it here, marked remote in the sidebar.
+#
+# takes the host as its first argument, or from $AGT_REMOTE_HOST when it runs as a keymap
+# custom command, where the runner exports the window and socket as $AGT_* variables.
+#
+# each row shows the far side's window and workspace, the session's own note of what it is
+# for, its working directory, and whatever its panes are running.
+set -eu
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+HOST=${1:-${AGT_REMOTE_HOST:-}}
+LIMIT=1000
+
+# carry the socket when the session names one, so this also works in a second instance
+agt() {
+    if [ -n "${AGT_SOCKET:-}" ]; then
+        "$AGTERMCTL" "$@" --socket "$AGT_SOCKET"
+    else
+        "$AGTERMCTL" "$@"
+    fi
+}
+
+# a keybinding runs with stdout and stderr on /dev/null, so anything the reader must see is a banner
+fail() {
+    agt notify "$1" --title "Attach Remote" >/dev/null 2>&1 || true
+    exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is not on PATH"
+[ -n "$HOST" ] || fail "no host. Pass one, or set AGT_REMOTE_HOST in the custom command"
+
+# the local agterm runs the ssh, so a failure here is the far side's or the network's
+TREE=$(agt zmx tree "$HOST" --json 2>&1) || fail "$HOST: $(printf '%s' "$TREE" | tail -1)"
+
+ERR=$(printf '%s' "$TREE" | jq -r 'if .ok then empty else .error end' 2>/dev/null) \
+    || fail "unreadable answer from $HOST"
+[ -z "$ERR" ] || fail "$HOST: $ERR"
+
+# id addresses the row; the subtitle is where it lives on the far side, then what it is doing.
+# names, not ids: the ids are for grouping and neither window nor workspace name is unique.
+ITEMS=$(printf '%s' "$TREE" | jq -c '
+    [.result.remote.sessions[]
+     | {id, label: .name,
+        subtitle: ([ (.windowName + "/" + .workspaceName),
+                     .context,
+                     .cwd,
+                     ([.panes[].foreground // empty | .[0] | split("/") | last] | join(" | "))
+                   ] | map(select(. != null and . != "")) | join("  ·  "))}]') \
+    || fail "unreadable session list from $HOST"
+
+COUNT=$(printf '%s' "$ITEMS" | jq 'length') || fail "unreadable session list from $HOST"
+# an empty list does not diagnose the mode: it reads the same whether the far side is not in Live
+# sessions mode or is and has nothing eligible. `agtermctl zmx list` on that machine says which.
+[ "$COUNT" -gt 0 ] || fail "nothing to attach on $HOST"
+# the picker refuses a longer list outright, so count first and explain rather than fail opaquely
+[ "$COUNT" -le "$LIMIT" ] || fail "$COUNT sessions is over the picker's $LIMIT-item limit"
+
+set +e
+CHOICE=$(printf '%s' "$ITEMS" | agt pick --prompt "attach from $HOST" --window "${AGT_WINDOW_ID:-active}")
+rc=$?
+set -e
+case $rc in
+    0) ;;
+    2) exit 0 ;;  # cancelled at the picker, which is a normal way out
+    *) fail "picker failed (exit $rc)" ;;
+esac
+
+ID=$(printf '%s' "$CHOICE" | jq -r 'select(.result == "picked") | .id') \
+    || fail "unreadable answer from the picker"
+[ -n "$ID" ] || exit 0
+
+# the remote is resolved again by the attach itself, so a session that has gone since the
+# listing fails here rather than handing back a fresh shell wearing its name
+OUT=$(agt zmx attach "$HOST" "$ID" 2>&1) || fail "attach failed: $(printf '%s' "$OUT" | tail -1)"

--- a/docs/backlog/zmx-attach-cannot-target-a-window.md
+++ b/docs/backlog/zmx-attach-cannot-target-a-window.md
@@ -1,0 +1,22 @@
+---
+worth: later
+where: agterm/Control/ControlServer+Zmx.swift:74
+added: 2026-09-02
+---
+# `zmx attach` cannot target a window
+
+`attachRemoteSession` resolves `library.activeStore` and inserts there, so a remote session always lands
+in the frontmost window. Every comparable creation command takes `--window`: `session.new` resolves an
+explicit target before choosing a workspace, and the control-api rule says placement commands accept one.
+
+A scripted caller that wants a remote session in a background window cannot express it. It has to select
+that window first, which moves the user's focus, then attach, then select back — and it races anything
+else changing the frontmost window in between.
+
+The recipe is unaffected: a keymap custom command already runs against the key window, which is the one
+the picker appeared over. So nothing user-facing is broken today, and this only bites automation driving
+several windows.
+
+Adding it is `--window` on the CLI subcommand, `args.window` through the dispatcher, and resolving the
+store through `ControlTargetResolver` instead of `activeStore`, plus the read-back test the rules require.
+Surfaced in Fable's pre-merge review of the remote-sessions branch.

--- a/docs/plans/completed/20260831-remote-sessions.md
+++ b/docs/plans/completed/20260831-remote-sessions.md
@@ -1,0 +1,406 @@
+# Remote (teleport) sessions
+
+## Overview
+
+Attach a local agterm to a session running on another Mac that also runs agterm, so it appears in the
+local sidebar as an ordinary session marked remote. One session at a time, including its split.
+Whole-workspace teleport is out of scope.
+
+Two new control commands:
+
+- `zmx tree <host>` — ssh to the host, ask its agterm what sessions exist in its frontmost window, and
+  return each pane's daemon plus the endpoint metadata needed to attach.
+- `zmx attach <host> <session>` — create one local session whose panes run ssh into that remote
+  session's daemons.
+
+The picker stays in user space: a keymap custom command pipes the tree into `pick.open`.
+
+Everything runs on the current pinned zmx (`ZMX_REV fb1b6b6`). No upstream change, no fork.
+
+## Context (from discovery)
+
+- `agtermCore/Sources/agtermCore/ControlProtocol.swift` — `ControlCommand`, `zmxList/zmxPrune/zmxKill`.
+- `agtermCore/Sources/agtermCore/ControlPayloads.swift` — `ControlZmxInventory`, `ControlZmxEntry`.
+- `agtermCore/Sources/agtermCore/ControlProjection.swift` — `ControlSessionNode` (no daemon name today).
+- `agtermCore/Sources/agtermCore/ControlDispatcher.swift` — `ControlActions`, the effect seam.
+- `agtermCore/Sources/agtermctlKit/ZmxCommands.swift` — the `zmx` CLI group.
+- `agterm/Ghostty/ZmxClient.swift` — holds the executable path and socket directory, both private.
+- `agterm/Ghostty/GhosttySurfaceView.swift:550` — `shouldCloseOnChildExitAction`.
+- `agterm/Ghostty/GhosttyCallbacks.swift:64` — `GHOSTTY_ACTION_SHOW_CHILD_EXITED`.
+- `agtermCore/Sources/agtermCore/AppStore+Snapshot.swift:41,78` — `initialCommand` persistence.
+- `agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift` — the second persistence producer.
+
+## Development Approach
+
+- **testing approach**: regular (code first, then tests in the same task)
+- complete each task fully before the next; tests are a required deliverable of every task
+- all tests pass before starting the next task
+- update this plan when scope changes
+
+## Testing Strategy
+
+- Host-free logic — ssh argv construction, the tree merge, endpoint payloads, dispatcher
+  parsing/validation — is unit tested in `agtermCore` against fixtures and a fake ssh runner.
+- App-side lifecycle — surface routing, persistence exclusion, ownership claims — uses hosted tests in
+  `agtermTests`.
+- End-to-end coverage goes in `agtermUITests/ControlAPIUITests`, scoped with `-only-testing:`, driven by
+  the injected fake runner so no second Mac is needed.
+- Anything that genuinely needs a second Mac lives in Post-Completion, never as a completion gate.
+
+## Solution Overview
+
+A remote pane is an ordinary command surface. Its command is ssh, its process is ssh, and everything
+that already happens to a command surface happens to it. That is the whole design decision: no new
+provenance, no new lifecycle, no daemon ownership.
+
+Consequences that follow for free:
+
+- Closing locally tears down the surface, ssh dies, the remote daemon survives. Detach-on-close is not
+  built. No command ever asks the remote zmx to kill anything.
+- Window close behaves identically, provided remote panes are never wrapped in local zmx.
+
+One ephemeral `remoteHost` on `Session` drives the sidebar icon and lives exactly as long as the row.
+
+### Why remote panes must not be wrapped by local zmx
+
+Local wrapping exists so a pane survives a local app restart. Remote sessions are excluded from
+snapshots and never restored across relaunch, so wrapping buys nothing — and it creates a real defect:
+under live restore mode, window close drops the local zmx client while the local daemon keeps ssh
+connected to the far side with no UI showing it. Route remote sessions before `ZmxLaunch.disposition`
+in both surface factories.
+
+### Why remote sessions must be excluded from every persistence producer
+
+`initialCommand` is persisted (`AppStore+Snapshot.swift:41`) and restored (`:78`). A persisted remote
+session would silently reconnect on a `rerun` launch, and under `none` would start a plain local shell
+while a persisted remote icon lied about what it is.
+
+Launch snapshots are not the only producer. `recordRecentClosedSession` calls `sessionSnapshot`
+directly, and a workspace record computes `sessionCount` and retains `selectedSessionID` before
+`workspaceSnapshot`. So filtering `AppStore.snapshot()` alone is not enough: a filtered workspace would
+claim a count and a selection that include a session no longer in it. Every producer needs the
+exclusion, and the workspace metadata has to be recomputed after filtering.
+
+The three-second undo is in-memory and must keep working. Omit remote sessions from the Recent Closed
+entry written to disk, not from the pending-close record that Reopen reads.
+
+### Why local ownership needs its own projection
+
+`WindowLibrary.liveClaims` converts every live session's pane UUIDs into local `agterm-<uuid>` claims
+unconditionally. Unfiltered, each remote pane shows up in `zmx list` as a fabricated claimed-but-absent
+local daemon, and the zmx ownership commands resolve a session they do not manage. Finalization derives
+names the same way, and `closeSplit` calls `paneFinalizer` directly rather than through
+`finalizePaneIdentities`.
+
+Pinned `zmx kill` ignores an unmatched name, so the current behavior happens to be a harmless no-op — but
+relying on that is the wrong ownership boundary. One model-derived `locallyManagedPaneIdentities` is
+empty when `remoteHost != nil` and otherwise returns primary plus existing split, consumed everywhere
+local zmx ownership is read.
+
+Structural `paneIdentity` stays intact: swap, promotion and control addressing still need a stable pane
+identity even when it is not a local daemon identity.
+
+## Technical Details
+
+### Endpoint metadata
+
+Neither `tree --json` nor `zmx list --json` exposes the remote zmx executable path or its `ZMX_DIR`, and
+both are derived from the far side's state directory, so neither is guessable from here. `zmx list` gains
+them as header fields.
+
+They must be **injected**, not recomputed. `WindowLibrary.directory` and `ZmxClient`'s executable and
+socket directory are private, and recomputing from the process environment inside `ControlServer+Zmx`
+would duplicate runtime selection and break hosted tests that inject a client. Expose them from
+`ZmxClient` and thread them through the restored runtime.
+
+Teleport therefore requires the remote agterm to be new enough to report endpoints. An older remote
+returns a clear error rather than a partial attach.
+
+### Scope: the remote's frontmost window
+
+`tree --json` without `--window` projects the remote's frontmost window; `zmx list --json` is app-wide
+across every window including closed claims. Merging them unfiltered would mix scopes.
+
+v1 is **frontmost remote window only**, which is where the session you are looking at on the other
+machine lives. `zmx list` rows belonging to other windows are dropped during the merge. Widening to all
+remote windows means `window list` plus a `tree --window` per window and is deliberately deferred.
+
+Both remote commands run inside **one** ssh invocation so the two projections come from one moment. A
+topology change between them is still possible in principle; the merge rejects a session whose panes do
+not resolve rather than guessing.
+
+### ssh invocation
+
+Two different shapes, and the difference matters:
+
+- **tree** — `-T`, `BatchMode=yes`, `ConnectTimeout`, plus an outer process deadline. `ConnectTimeout`
+  ends at handshake and cannot bound a hung remote command.
+- **attach** — `-tt` (a remote command does not reliably get a pty, and zmx reads termios and window
+  size), `BatchMode=yes`, connection timeout, no lifetime deadline.
+
+`BatchMode=yes` is what keeps a host-key or password prompt from hanging a dispatcher that cannot answer
+it, so key-based non-interactive auth is a documented precondition. Host, session and remote command are
+argv- or shell-quoted, never interpolated raw.
+
+The ssh runner is **async and off the main actor**, behind an injected seam. `ControlActions` is
+`@MainActor`, so a blocking `Process.wait` would freeze the UI for the whole network deadline. The seam
+is also what lets the end-to-end tests run against a fake instead of a second Mac.
+
+### The create-only guard
+
+`zmx attach <name>` on a **missing** daemon creates one (`loop.zig:661`, `should_create = !exists`) and
+runs a fresh shell under the old name. A daemon that vanished between `zmx tree` and the attach would
+therefore hand you a brand-new remote shell that looks like the session you asked for. That is worse
+than a failed attach.
+
+The attach argv passes a command after the daemon name that exits non-zero. An existing daemon ignores
+it — zmx logs "session already exists, ignoring command" — while a vanished daemon creates the session,
+runs that command, and fails immediately and visibly. This is the same create-only attach payload the
+live-restore fallback already uses.
+
+The merge is the first line of defence: every expected pane must resolve to a `claimed` endpoint
+observed `running`, and an absent, unreadable or partial row is rejected outright. The guard covers the
+race the merge cannot.
+
+### Disconnect
+
+Set `commandWait`/`splitCommandWait` on the remote ssh commands. `shouldCloseOnChildExitAction`
+(`command != nil && !waitAfterCommand`) then returns false, so `GHOSTTY_ACTION_SHOW_CHILD_EXITED`
+returns false without dispatching anything, Ghostty shows its own "press any key to close", and
+`close_surface_cb` runs today's `closePrimaryPane`/`closeSplitPane` after the key.
+
+The ssh wrapper prints one sanitized line before exiting: host, remote session, pane, exit status. It
+says nothing about reconnecting — the picker is a keymap custom command the user supplies, so agterm
+cannot name a path it does not own.
+
+**There is no timer, notification or session-wide coalescing.** An earlier draft had them, and they
+cannot work: returning false schedules no app callback, so app code does not learn ssh exited until the
+keypress. Adding them would mean a new child-exited callback plus transient pending-close state — new
+plumbing for a case the held prompt already covers. A caller's overlay does not block command-wait; it
+only hides the held pane until the overlay closes. Each pane holds and closes on its own, which is also
+the right behavior when only one half of a split dies.
+
+`zmx attach` reports synchronously only pre-model failures — unresolvable host, auth refused, a session
+whose panes do not resolve. Once the model is inserted, transport startup failure and later loss are
+ordinary pane exits on the held path.
+
+### Placement and re-resolution
+
+`zmx attach <host> <session>` carries no endpoint payload from the picker, so it re-runs the remote
+resolution itself before inserting anything. A daemon that vanished in between is a pre-model failure
+and creates no session.
+
+The new row lands in the frontmost window's current workspace and becomes selected, matching what
+`createSession` does today. Placement options are out of scope.
+
+## Accepted v1 limitations
+
+Document these; do not build around them.
+
+Pinned zmx keeps one `leader_client_fd`. Our attach is a follower, so `handleInit` sends a snapshot at
+the **far side's** geometry and does not resize. The first classified keystroke (printable, Enter, Tab,
+Backspace, modified/kitty keys) calls `setLeader`, which asks our client for its size and reflows the
+shared pty.
+
+- Before that keystroke, follower input is **dropped**, not merely non-claiming. Mouse, focus and Ctrl-L
+  (`0x0C` is not among `util.zig:719`'s accepted execute controls) never reach the remote, so a
+  mouse-first TUI looks dead.
+- Leadership is per **daemon**. Typing in the primary reflows only its pty, so a correctly sized primary
+  can sit beside a split still at the far side's geometry; the far side sees the mirror image.
+- On detach, each daemon we led clears its leader and the far side keeps our geometry until that pane
+  receives qualifying input or a resize report. Panes we never claimed stay correct.
+
+A later optional upstream improvement — opt-in `zmx attach --take-leadership` plus handback to the exact
+displaced leader — would remove all three. It is **not** part of this work.
+
+## Progress Tracking
+
+- mark completed items `[x]` immediately
+- new tasks get a ➕ prefix, blockers a ⚠️ prefix
+
+## What Goes Where
+
+- **Implementation Steps**: code, tests, docs in this repo, verified against a fake ssh runner.
+- **Post-Completion**: anything needing a second Mac.
+
+## Implementation Steps
+
+### Task 1: Endpoint metadata and the ssh invocations
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlPayloads.swift`
+- Create: `agtermCore/Sources/agtermCore/RemoteSession.swift`
+- Modify: `agterm/Ghostty/ZmxClient.swift`
+- Modify: `agterm/agtermApp.swift`
+- Modify: `agterm/Control/ControlServer.swift`
+- Modify: `agterm/Control/ControlServer+Zmx.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/RemoteSessionTests.swift`
+- Modify: `agtermTests/ControlServerZmxTests.swift`
+
+- [x] add the zmx executable path and `ZMX_DIR` to `ControlZmxInventory` as header fields, both optional
+      on the wire so an older server still decodes
+- [x] expose them from `ZmxClient` and thread them through the restored runtime into `ControlServer`,
+      never recomputed from the process environment
+- [x] add a host-free builder for the tree invocation: `-T`, `BatchMode=yes`, `ConnectTimeout`, running
+      both remote commands in one invocation
+- [x] add a host-free builder for the attach invocation: `-tt`, `BatchMode=yes`, remote `ZMX_DIR` and
+      executable, daemon name, and the create-only guard command that exits non-zero
+- [x] quote host, session and remote command as argv; reject control characters and an empty host
+- [x] write payload tests for the populated and nil-omitted cases
+- [x] write tests for both argv shapes, for hostile-input quoting, and for the rejection cases
+- [x] write a hosted test that the endpoint comes from the injected client, not the environment
+- [x] run tests — must pass before task 2
+
+### Task 2: Remote session model
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/Session.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+Snapshot.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+Panes.swift`
+- Modify: `agtermCore/Sources/agtermCore/WindowLibrary.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlProjection.swift`
+- Modify: `agterm/Views/WorkspaceSidebar.swift`
+- Modify: `agterm/Views/WorkspaceSidebar+RowRendering.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/WindowLibraryClaimsTests.swift`
+- Modify: `agtermTests/SidebarRowViewsTests.swift`
+
+- [x] add ephemeral `remoteHost: String?` to `Session`, not persisted
+- [x] add `locallyManagedPaneIdentities` — empty when `remoteHost != nil`, else primary plus existing split
+- [x] consume it in `finalizePaneIdentities`, the direct `closeSplit` finalizer path, `liveClaims`, live
+      `finalizeWindowPanes`, and any live-versus-persisted inventory comparison
+- [x] exclude remote sessions from the launch snapshot, the Recent Closed session record, and
+      workspace-close records, recomputing `sessionCount` and `selectedSessionID` after filtering
+- [x] keep the in-memory pending-close record intact so the three-second undo still restores a remote row
+- [x] surface `remoteHost` on `ControlSessionNode`, omitted when nil, and draw the sidebar icon from it
+- [x] write snapshot tests: remote-only selected session, mixed workspace, remote-only workspace
+- [x] write Recent Closed tests: session record, grouped soft close, workspace record metadata
+- [x] write claims tests: a remote pane produces no local claim and no finalizer name
+- [x] write sidebar tests: remote single and split rows, and that a flag still takes precedence
+- [x] write tree read-back tests, populated and omitted
+- [x] run tests — must pass before task 3
+
+### Task 3: `zmx tree <host>`
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher+Zmx.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlActionsDefaults.swift`
+- Modify: `agtermCore/Sources/agtermCore/RemoteSession.swift`
+- Modify: `agterm/Control/ControlServer+Zmx.swift`
+- Modify: `agtermCore/Sources/agtermctlKit/ZmxCommands.swift`
+- Modify: `agtermCore/Sources/agtermctlKit/SocketClient.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/ControlDispatcherZmxTests.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/MockControlActions.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/CommandsTests.swift`
+- Modify: `agtermUITests/ControlAPIUITests.swift`
+
+- [x] add the `zmxTree` command and its response: sessions with pane roles, split axis, per-pane daemon,
+      remote executable and `ZMX_DIR`
+- [x] add a pure `RemoteTreeMerger` joining the two remote projections, scoped to the frontmost window
+- [x] require every expected pane to resolve to a `claimed` endpoint observed `running`; reject absent,
+      unreadable, partial and cross-window rows
+- [x] add the async ssh runner behind an injected seam so the action never blocks the main actor
+- [x] give `ControlActions` its default and mock implementations so the agterm-linux build still compiles
+- [x] return a clear error when the remote reports no endpoint metadata
+- [x] add the CLI subcommand with readable rows and `--json`
+- [x] write merge tests over fixtures: no split, missing split endpoint, mismatched window/session ids,
+      a daemon that disappeared, and rows from another window
+- [x] write dispatcher tests for validation and error text, and CLI parsing tests
+- [x] write a scoped end-to-end test against the fake runner
+- [x] run tests — must pass before task 4
+
+### Task 4: `zmx attach <host> <session>`
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher+Zmx.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlActionsDefaults.swift`
+- Modify: `agterm/Control/ControlServer+Zmx.swift`
+- Modify: `agterm/agtermApp.swift`
+- Modify: `agtermCore/Sources/agtermctlKit/ZmxCommands.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/ControlDispatcherZmxTests.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/MockControlActions.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/CommandsTests.swift`
+- Modify: `agtermTests/ControlServerZmxTests.swift`
+- Modify: `agtermUITests/ControlAPIUITests.swift`
+
+- [x] add the `zmxAttach` command taking host and remote session
+- [x] re-run the remote resolution before inserting anything; an unresolvable session is a pre-model
+      failure that creates no session
+- [x] create one local session in the frontmost window's current workspace, selected, with `remoteHost`
+      set, primary running the attach invocation, and the split against the second daemon with the
+      remote session's axis when it has one
+- [x] set `commandWait`/`splitCommandWait` so each pane holds with Ghostty's own press-any-key prompt
+- [x] route remote sessions before `ZmxLaunch.disposition` in both surface factories so they are never
+      wrapped by local zmx and never set `backedByZmx`
+- [x] have the attach invocation print one sanitized line on exit: host, session, pane, exit status —
+      and no reconnect advice, the picker being user-supplied
+- [x] add the CLI subcommand
+- [x] write dispatcher tests for validation and the pre-model failure, and CLI parsing tests
+- [x] write tests for the single-pane and split cases, and for the diagnostic line with a hostile
+      session name
+- [x] write hosted tests that a remote surface is unwrapped, reports `backedByZmx == false`, and that
+      its exit closes only its own pane
+- [x] write a scoped end-to-end test that a remote session's row carries `remoteHost` in `tree`
+- [x] run tests — must pass before task 5
+
+### Task 5: Update documentation
+
+- [x] update `site/docs.html` and `site/commands.html` with both commands and their read-back
+- [x] update `plugins/agterm/skills/agterm/` — the source for installed Claude/Codex copies
+- [x] update `.claude/rules/control-api.md` with the remote-session contract, the endpoint-metadata
+      requirement, the frontmost-window scope, and the create-only guard
+- [x] record the accepted v1 limitations where the contract lives, not scattered across surfaces
+- [x] update `README.md` and `site/llms.txt` only if the synchronized facts change
+
+### Task 6: [Final] Verify and gate
+
+- [x] verify against the fake runner: a split session attaches both panes to the right daemons
+- [x] verify a remote session is absent from every persistence producer after close and after quit
+- [x] verify a vanished daemon fails visibly instead of creating a fresh remote shell
+- [x] verify an older remote without endpoint metadata fails with a clear message
+- [x] run `make build`
+- [x] run `cd agtermCore && swift test`
+- [x] run `make test-app`
+- [x] run `make lint` — zero findings required
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification** (needs a second Mac running agterm):
+
+- attach to a live remote session and confirm the first keystroke reflows it
+- confirm the far side keeps working after a local close
+- pull the network mid-session and confirm the held prompt explains what happened
+
+**Deferred, not part of this work:**
+
+- opt-in `zmx attach --take-leadership` upstream, with handback to the displaced leader
+- whole-workspace teleport
+
+## Scope change during the run
+
+Every task above was planned and executed against a **frontmost-window** scope, composing the far side's
+`tree --json` and `zmx list --json` into one ssh invocation split by a framing marker. That is what the
+ticked boxes record, and the sections describing it are left as written.
+
+It is **not what shipped**. After the tasks completed, the frontmost limit was judged an arbitrary
+restriction rather than a real constraint: `tree --window` already accepted any open window, so nothing
+had forced it. Rather than widen the composition, `zmx.tree`'s host became optional — bare it builds the
+whole all-window projection locally, and with a host it runs that same bare form once over ssh. The far
+side answers with one already-joined document.
+
+That removed the framing marker, the two-sequential-calls race, and the rule that the exit status had to
+be read before the marker could be trusted, none of which have anything to answer for any more. It also
+retired "remote windows beyond the frontmost one" from the deferred list above, and added
+`windowID`/`windowName` and `workspaceID`/`workspaceName` to each row: names to display, ids to group by,
+since neither rename path enforces uniqueness.
+
+Read `.claude/rules/control-api.md` for the contract as it actually stands. Where this plan and that file
+disagree, the plan is the older document.

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -15,8 +15,8 @@ description: >
   subscribe to status, notification, session lifecycle, and tree-change events; diagnose problems
   (keymap editor, custom actions, logs); and file a bug as a GitHub issue or a
   feature request / question as a GitHub Discussion. Also list, fetch and install the repository's
-  cookbook recipes, and read one as reference for a tricky workflow; and report the version of the app
-  serving the socket.
+  cookbook recipes, and read one as reference for a tricky workflow; report the version of the app
+  serving the socket; and list and attach a session running on another Mac that also runs agterm.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.split.close, session.swap, session.scratch, session.focus, session.resize, surface.zoom, surface.cursor, cursor column, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, pane-id, session.search, session.status,
@@ -24,7 +24,8 @@ when_to_use: >
   session.hud, hud panel, show a message over a session, workspace.new, workspace.select, workspace.go, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, sidebar.width, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
-  AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: agterm cookbook,
+  AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: zmx.tree, zmx.attach,
+  remote session, teleport a session, attach a session from another Mac. Also: agterm cookbook,
   cookbook recipe, list recipes, install a recipe, agterm recipe for X, what recipes are there, and
   agterm version, which agterm is running, agterm version check. Also troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
@@ -239,6 +240,8 @@ created by a scheduled job overnight stays unrealized until the displays wake an
 Poll this after an unattended create),
 `backedByZmx` (true only when every existing primary/split pane is currently zmx-backed; primary/split
 entries in `surfaces` report their own Boolean, while scratch and overlays omit it),
+`remoteHost` (the machine an attached session came from, the read side of `zmx attach`; omitted for a local
+session, and never present after a relaunch because a remote session is not persisted),
 `hasSplit` (whether a second pane exists at all, shown or hidden; omitted when there is none — read this
 rather than `split`, which is false for a split hidden with ⌘D even though its pane is still alive),
 `splitAxis` (`vertical` for left/right or `horizontal` for top/bottom; omitted without a split),
@@ -568,8 +571,19 @@ state rather than a leak · `zmx prune` - kill the daemons no pane claims and no
 refusing outright on an incomplete or conflicted inventory, and reporting each daemon separately since a
 stale-socket cleanup is not a kill · `zmx kill --target ID --pane left|right --force` - destroy one pane's
 daemon and the process in it; all three are required because this kills a backend process that reaches a
-pane no window is showing and every client attached to it, and none of its outcomes gets the undo grace.
-Every zmx command needs a running agterm.
+pane no window is showing and every client attached to it, and none of its outcomes gets the undo grace ·
+`zmx tree [HOST]` - attachable sessions across EVERY open window, on another Mac with a HOST or this app
+without one (the bare form is exactly what the remote call runs on the far side). Each row carries the id
+`zmx attach` takes plus `windowID`/`windowName`, `workspaceID`/`workspaceName` (show the names, group by
+the ids: neither is unique), `context` when set, and per-pane `foreground`; only a session whose every pane
+still has a live daemon is listed, and an empty list does NOT mean the far side is not in live mode -
+`zmx list` reports that · `zmx attach
+HOST SESSION` - open one of them here, marked remote and carrying its split; takes the ID from that
+listing, not the name, and resolves the remote again first, so a session that has gone fails instead of
+handing back a fresh shell wearing its name. Closing it here ends only this side's connection and it is
+never restored after a relaunch. Both run ssh non-interactively, so key-based auth must already work, and
+the far side needs `agtermctl` installed by the cask or the Help action: a machine merely running agterm
+has no CLI an ssh command can find. Every zmx command needs a running agterm.
 
 **version** — `agtermctl version` — which agterm is serving this socket, as `result.app` (`version`, plus
 `commit` when the build recorded one). App-global: no target, no `--window`, no window need be open, so it
@@ -620,7 +634,7 @@ Full detail, templates, and the exact `gh` commands are in **troubleshooting.md*
 ## Reference files
 
 - **reference.md** — full per-command detail: every flag, the JSON return shapes
-  (`result.id`/`text`/`exitCode`/`count`/`affected`/`tree`/`windows`/`app`/`restore`/`zmx`), error strings, the scratch/overlay/split
+  (`result.id`/`text`/`exitCode`/`count`/`affected`/`tree`/`windows`/`app`/`restore`/`zmx`/`remote`), error strings, the scratch/overlay/split
   lifecycle, and the keymap.conf format (`map` / `command`, chords, leaders, `|` alternatives,
   `{AGT_X}` tokens).
 - **examples.md** — copy-paste agtermctl examples for common tasks (build a layout, run a program in a

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -62,8 +62,36 @@ attached to it:
 agtermctl zmx kill --target 3f2a --pane left --force
 ```
 
-Read or change the restore policy without opening Settings. A mode you set applies to the NEXT launch,
-because a pane is wrapped in a daemon or not at the moment it is created:
+## Attach a session running on another Mac
+
+List what the other machine offers across every open window, then open one here by its ID. The far side
+has to be in `live` mode, reachable over ssh with key-based auth, and carry `agtermctl` from the cask or
+the Help action — running agterm alone leaves no CLI an ssh command can find. Run it with no host to ask
+the same of this app, which is the form the remote call runs over there:
+
+```bash
+agtermctl zmx tree studio.local
+agtermctl zmx attach studio.local 7c1e4a02-...
+```
+
+To let the user choose, pipe the listing through the picker:
+
+```bash
+s=$(agtermctl zmx tree studio.local --json |
+  jq '[.result.remote.sessions[] | {id, label: .name,
+        subtitle: (.windowName + "/" + .workspaceName + "  " + .cwd)}]' |
+  agtermctl pick --prompt "Attach which session?" | jq -r '.id // empty')
+[ -n "$s" ] && agtermctl zmx attach studio.local "$s"
+```
+
+The row is marked remote and carries `remoteHost` in the tree. Closing it ends only this side's connection,
+and it does not come back after a relaunch.
+
+## Read or change the local restore policy
+
+This is about THIS instance, not a remote one: `zmx attach` requires nothing of the local restore mode.
+A mode you set applies to the NEXT launch, because a pane is wrapped in a daemon or not at the moment it
+is created:
 
 ```bash
 agtermctl restore mode          # what settings hold, what this launch asked for, what it got

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -15,7 +15,8 @@ Full detail for every `agtermctl` command. See `SKILL.md` for the model and addr
 - **Response shape**: `{"ok": true, "result": {…}}` or `{"ok": false, "error": "<message>"}`.
   `result` carries one of: `id` (affected/new session/workspace/window), `text` (session copy/text),
   `exitCode` (overlay result), `count` (diagnostics/search), `restore` (the restore-mode policy),
-  `zmx` (the daemon inventory), `affected` (things actually changed: sessions
+  `zmx` (the daemon inventory), `remote` (another Mac's attachable sessions, for `zmx tree`),
+  `affected` (things actually changed: sessions
   for a batch close/move, daemons killed for `zmx prune`), `tree` (the tree), `windows` (window list), `app` (the serving app's identity, for
   `version`). The process exit code is non-zero when
   `ok` is false.
@@ -120,6 +121,8 @@ nothing here. Poll this after creating a session unattended; `agtermctl tree` al
 `(not realized)`),
 `backedByZmx` (true only when every existing primary/split pane is currently zmx-backed; older servers omit
 it),
+`remoteHost` (the machine an attached session came from — the read side of `zmx attach`; omitted for a
+local session, and never present after a relaunch because a remote session is never written to disk),
 `hasSplit` (whether a second pane exists at all, shown or hidden with ⌘D; omitted when there is none —
 read THIS to decide whether a session has a split, because a hidden split reports `split: false` while
 its pane stays alive, and it is present exactly when `splitRatio`/`splitFocused` can be),
@@ -1324,6 +1327,8 @@ header. `state` is `claimed`, `orphan`, `unknown`, `conflicted`, `pendingClose` 
 is gone and one zmx could not read are different answers. A CLOSED window's panes are `claimed` with zero
 clients. That is the resting state after you close a window, not a leak, which is why the owner's window
 state is its own column. `unknown` means the pane inventory was incomplete, so no row can be called an orphan.
+The header also carries `endpoint.executable` and `endpoint.socketDirectory`, which is what another machine
+needs to reach these daemons; a server older than remote sessions omits the key.
 
 `agtermctl zmx prune` — kill the daemons no pane claims and nothing is attached to. It refuses outright on
 an incomplete or conflicted inventory. The gate is checked and revalidated rather than atomic: zmx has no
@@ -1345,6 +1350,47 @@ daemon of the pane you are typing in can kill the calling `agtermctl` before it 
 Omit it to search every window, closed and unindexed ones included; `active` is not accepted, and neither
 is it for `--target`. Without it an ambiguous prefix reports `no left pane daemon for session ID`, the
 same answer a target that does not exist gets.
+
+`agtermctl zmx tree [HOST]` — attachable sessions across EVERY open window. With a `HOST` it reads another
+Mac over ssh; with none it reports this app's own, which is exactly the form the remote call runs on the
+far side, so it is also how to see what another machine would answer without sshing anywhere.
+`result.remote` carries `endpoint` (the zmx `executable` and `socketDirectory`), `host` when one was given,
+and `sessions`, each with `id`, `name`, `windowID`/`windowName` and `workspaceID`/`workspaceName` (show the
+names, group by the ids — neither is unique, so two windows called `main` merge if you group by name),
+`context` when its owner set one, `cwd`, `splitAxis` when it has a split, and `panes`
+(`{pane, daemon, foreground}`, the last being the argv that pane is running and omitted when none is
+reported). `host` is the ssh destination the REQUESTING app was given, stamped on after decoding: the far
+side has no idea which name reached it.
+
+Only a session whose every pane still has a live daemon is listed: attaching to a name that no longer
+exists would CREATE a daemon and hand back a fresh shell wearing it, so an incomplete one is omitted
+rather than offered half. An empty list is a successful answer and does NOT diagnose the restore mode —
+`zmx list` does that. The far side must be running in `live` mode, which is what puts a daemon behind each
+pane, and be new enough to answer `zmx tree` at all; an older one is refused by name rather than
+half-attached. It also needs `agtermctl` installed by the cask or the Help action: a machine merely
+running agterm has no CLI an ssh command can find, and the read fails with exit 127.
+
+`agtermctl zmx attach HOST SESSION` — open one of those sessions here, marked remote, in the current
+window's current workspace, selected, with the remote session's split when it has one. `SESSION` is the
+`id` from `zmx tree`, never the name: remote names are editable and repeat across workspaces. Returns the
+new local session's `id`; read `remoteHost` on its tree node. The remote is resolved AGAIN before anything
+is created, so a session that has gone since the listing fails and creates nothing. Everything reported
+here is a failure found before that point — a connection that starts and later drops is an ordinary pane
+exit, which holds on Ghostty's press-any-key prompt under one line naming the host, the session, the pane
+and the exit status.
+
+Closing a remote session here ends only this side's connection: the far-side processes keep running and
+nothing agterm does from this end can kill them. It is never written to disk, so it does not come back
+after a relaunch whatever the restore mode is.
+
+Both commands run ssh non-interactively (`BatchMode`), so key-based auth must already work for the host —
+a password or host-key prompt is a failure, not a question. An attach joins as a follower and pinned zmx
+keeps one leader per pane, so the pane arrives at the OTHER machine's window size and drops input until
+the first CLASSIFIED key (a printable character, Return, Tab or Backspace) takes the lead and reflows
+it. Until then the mouse, focus reporting and Ctrl-L do not reach the far side, so a mouse-driven TUI looks
+dead, and an ordinary control key may not wake it. Because the lead is per pane, typing in one half of a split leaves the other at the
+remote's geometry, and after the session closes the far side keeps that size until something there resizes
+it.
 
 Every zmx command needs a running agterm: only the app can join its live windows, its pending closes and
 its persisted snapshots against what zmx reports. With agterm stopped there is nothing to ask.

--- a/site/commands.html
+++ b/site/commands.html
@@ -297,6 +297,8 @@
               for <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">zmx prune</span>),
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">restore</span> (the restore-mode policy),
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">zmx</span> (the daemon inventory),
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">remote</span> (another Mac's attachable
+              sessions, for <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">zmx tree</span>),
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">tree</span>,
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">windows</span>, or
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">app</span>
@@ -509,7 +511,11 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commandWait</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitCommandWait</span> (whether either pane's
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--command</span> was created with
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session new --wait</span>; each omitted otherwise), and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session new --wait</span>; each omitted otherwise),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">remoteHost</span> (the machine an attached session
+                came from, the read side of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">zmx attach</span>; omitted for a
+                local session, and never present after a relaunch because a remote session is not persisted), and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unseen</span>.
               </p>
               <p style="font-size: 14px; line-height: 1.65; color: #949ba4; margin: 8px 0 0">
@@ -2849,6 +2855,9 @@
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 A <em>closed</em> window's panes are claimed with zero clients: that is the resting state after you close a window, not a leak, which is why the owner's window state is its own column. <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown</span> means the pane inventory was incomplete, so no row can be called an orphan and nothing can be pruned.
               </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--json</span> adds <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.zmx.endpoint.executable</span> and <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.zmx.endpoint.socketDirectory</span> to the header — what another machine needs to reach these daemons. A server older than remote sessions omits the key.
+              </p>
             </div>
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
@@ -2875,6 +2884,58 @@
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> scopes the search to one window's claims, for a session prefix claimed in more than one. Omit it to search every window, closed and unindexed ones included. Neither it nor <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> accepts <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>.
+              </p>
+            </div>
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl zmx tree [HOST]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">zmx.tree</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                List the sessions that can be attached to. With a host it runs over ssh against a machine also running agterm and reports what it offers across <em>every</em> open window; with no host it reports this app's own in the same shape, which is the form the remote call runs on the far side. Feed the result to a picker and hand what the user chooses to <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zmx attach</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Only a session whose every pane has a live daemon is listed; one whose daemon has gone is omitted rather than offered, because attaching to a name that no longer exists would create a fresh shell wearing it. The remote must be new enough to report where its zmx and its daemons live, or the command says so and lists nothing.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                The connection is non-interactive: ssh runs with <span style="font-family: &quot;JetBrains Mono&quot;, monospace">BatchMode</span>, so key-based auth must already work for the host and a password or host-key prompt is a failure rather than a question. The far side also needs <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl</span> installed by the cask or the Help action, since a machine merely running agterm has no CLI an ssh command can find.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <strong style="color: #bfbab0">Result:</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">remote</span> —
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">host</span> (only when one was given — the ssh destination the requesting app was handed, stamped on after decoding, since the far side cannot know which name reached it),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">endpoint</span> (the zmx
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">executable</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">socketDirectory</span>), and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">sessions</span>, each with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">id</span> (what
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zmx attach</span> takes),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">name</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">windowID</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">windowName</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">workspaceID</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">workspaceName</span> (show the names, group by the ids — neither is unique, so grouping by name merges two windows called <span style="font-family: &quot;JetBrains Mono&quot;, monospace">main</span>),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">context</span> (only when its owner set one),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cwd</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitAxis</span> (only when it has a split), and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">panes</span>
+                (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">{pane, daemon, foreground}</span>, the last being the argv that pane is running, omitted when the remote reports none).
+              </p>
+            </div>
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl zmx attach HOST SESSION
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">zmx.attach</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Open one of the sessions <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zmx tree</span> listed as a session here, marked remote. It takes the session <em>id</em> from that listing — remote names are editable and repeat across workspaces — and lands in the current window's current workspace, selected, carrying the remote session's split when it has one. Returns the new session's <span style="font-family: &quot;JetBrains Mono&quot;, monospace">id</span>; read <span style="font-family: &quot;JetBrains Mono&quot;, monospace">remoteHost</span> on its tree node.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                The remote is resolved again before anything is created, so a session gone since the listing fails and creates nothing rather than handing back a fresh shell wearing its name. Only failures found before that point are reported here; a connection that starts and later drops is an ordinary pane exit.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Each pane holds on Ghostty's own press-any-key prompt when its ssh exits, under one line naming the host, the session, the pane and the exit status. Closing the session here ends only this side's connection: the far-side processes keep running, and nothing this command does can kill them. A remote session is never written to disk, so it does not come back after a relaunch.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Pinned zmx has a single leader, and an attach joins as a follower, so the remote arrives at the <em>other</em> machine's window size and ignores input until the first <em>classified</em> key — a printable character, Return, Tab or Backspace — takes the lead and reflows it. Until then the mouse, focus reporting and Ctrl-L do not reach the far side, so a mouse-driven TUI looks dead, and an ordinary control key may not wake it either. Leadership is per pane, so typing in one half of a split leaves the other at the remote's geometry, and after you close the session the far side keeps your size until something else resizes it.
               </p>
             </div>
           </section>

--- a/site/docs.html
+++ b/site/docs.html
@@ -2413,6 +2413,80 @@
               <span style="color: #f2b45c">"tests passed"</span>
             </div>
 
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 28px 0 12px;
+              "
+            >
+              Remote sessions
+            </h3>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              A session running on another Mac that is also running agterm can be opened here, in the sidebar, marked remote.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl zmx tree [HOST]</span> lists what
+              that machine has to offer across <em>every</em> open window, and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl zmx attach HOST ID</span> opens
+              one of them, split included. Both need the far side in
+              <strong style="color: #e6e1d7">Live sessions</strong> mode, since that is what puts a daemon behind each pane, and both
+              run ssh non-interactively — key-based auth has to work for the host already, because a password or host-key prompt is a
+              failure rather than a question. The far side also needs <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span>
+              installed by the cask or the Help action: a machine merely running agterm has no CLI an ssh command can find.
+              To check the connection before you need it, run
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ssh -o BatchMode=yes studio.local true</span> —
+              that is the same non-interactive form agterm uses, so if it exits without printing anything, agterm can reach the host;
+              if it asks for a password or a host key, agterm fails the same way. One difference to know about: agterm runs ssh from the
+              app, which inherits the launch environment rather than your shell's, so an agent exported in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">.zshrc</span> passes this check and still fails here.
+              Put <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">IdentityAgent</span> and key settings in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">~/.ssh/config</span>, which both paths read.
+            </p>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13.5px;
+                line-height: 1.95;
+                overflow-x: auto;
+                color: #e6e1d7;
+              "
+            >
+              agtermctl zmx tree <span style="color: #f2b45c">studio.local</span>
+              <span style="color: #6b727a">&nbsp;# window/workspace/name  (split)  [id]  cwd</span><br />agtermctl zmx attach
+              <span style="color: #f2b45c">studio.local</span> <span style="color: #f2b45c">7c1e…</span>
+              <span style="color: #6b727a">&nbsp;# the id from that listing, not the name</span><br /><br /><span
+                style="color: #6b727a"
+                ># pipe the listing into the picker and attach what was chosen</span
+              ><br /><span style="color: #6d82f3">s</span>=$(agtermctl zmx tree
+              <span style="color: #f2b45c">studio.local</span> --json | jq
+              <span style="color: #f2b45c">'[.result.remote.sessions[] | {id, label: .name, subtitle: (.windowName + "/" + .workspaceName + "  " + .cwd)}]'</span> |<br />agtermctl
+              pick --prompt <span style="color: #f2b45c">"Attach which session?"</span> | jq -r
+              <span style="color: #f2b45c">'.id // empty'</span>)<br />[ -n
+              <span style="color: #f2b45c">"$s"</span> ] &amp;&amp; agtermctl zmx attach
+              <span style="color: #f2b45c">studio.local</span> <span style="color: #f2b45c">"$s"</span>
+            </div>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              Only a session whose every pane still has a live daemon is listed, and the remote is resolved again at attach time, so a
+              session that has gone in between fails instead of handing back a fresh shell wearing its name. Closing the row here ends
+              only this side's connection — the far-side processes keep running, and nothing agterm does from this end can kill them.
+              A remote session is never written to disk, so it does not come back after a relaunch. Its tree node carries
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">remoteHost</span>.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 12px 0 0">
+              An attach joins as a follower, and pinned zmx has one leader per pane, so the pane arrives at the <em>other</em>
+              machine's window size and ignores input until your first <em>classified</em> key — a printable character, Return, Tab or
+              Backspace — takes the lead and reflows it. Until then the mouse, focus reporting and Ctrl-L do not reach the far side,
+              so a mouse-driven TUI looks dead, and an ordinary control key may not wake it either. Because the lead is per pane, typing in one half of a split
+              leaves the other at the remote's geometry, and after you close the session the far side keeps your size until something
+              there resizes it. When a connection drops, the pane holds on Ghostty's press-any-key prompt under one line naming the
+              host, the session, the pane and the exit status.
+            </p>
+
             <div
               style="
                 background: rgba(94, 161, 242, 0.07);


### PR DESCRIPTION
attach a session running on another Mac and have it show up in the local sidebar as an ordinary session marked remote. Two new control commands: `zmx tree [HOST]` lists the sessions that can be attached to, across every open window, and `zmx attach HOST SESSION` opens one of them here, split included, each pane holding its own ssh connection for as long as the session is open.

every remote form goes over ssh, and nothing else does. There is no agterm-to-agterm protocol, no port, no listener, nothing new exposed on either machine. The attached pane is an ssh process running `zmx attach` against a daemon that already exists there, which is why a remote pane needs no new surface kind: it is a command surface whose command happens to be ssh.

each attach imports one session. Nothing stops several remote rows sitting side by side, but whole-workspace teleport is out of scope. Built entirely on the currently pinned zmx, with no upstream change and no new dependency.

**the host is optional, and that is the whole design**

bare, `zmx tree` joins this app's open-window trees with one zmx inventory. With a host, it sshes once and runs *that same bare form* on the far side, returning one joined document.

so the far-side operation is an ordinary public command you can run and test on its own, and there is no second internal-export noun. What it removes: the framing between two documents, the mismatch between a tree and an inventory fetched separately over the network, and a second authentication.

`ControlRemoteTree.host` is stamped by the requesting app after decoding, never self-reported: the far side cannot know which name reached it. It is absent from the bare local answer, which sshed nowhere.

**the model**

a remote pane is an ordinary command surface, so there is no new surface kind, no new lifecycle and no remote daemon ownership. Closing the session locally tears the surface down and ssh dies, while the far-side processes keep running. Nothing in this feature sends a remote kill: the local close and finalizer paths ask the remote zmx for nothing.

`Session.remoteHost` is immutable and set at construction, because `addSession` saves. A marker written afterwards would let one snapshot reach disk carrying the ssh command.

`locallyManagedPaneIdentities` is the single local-ownership predicate and is empty for a remote session, so `liveClaims` never invents an `agterm-<uuid>` claim for a daemon living on another machine. `ZmxLaunch.wrapsLocally` is the one gate both surface factories read, so a remote pane is never wrapped in a local daemon.

**what a row carries**

rows are flat, and each names where it lives: `windowID`/`windowName` and `workspaceID`/`workspaceName` beside the session's own `id` and `name`. Show the names, group by the ids. Neither rename path nor `addWorkspace` enforces uniqueness, so two windows called `main`, and a `dev` workspace in each of them, are ordinary. A picker grouping by name would silently merge them.

each row also carries the session's `context` when its owner set one, and per-pane `foreground`, so a picker can say what it is about to attach to. Without those a caller would need a second ssh joining `agtermctl tree --json` by session id, paying another authentication for data the walk already held and threw away.

**which sessions are offered**

a session is offered only when its store reports `backedByZmx` and every pane resolves to a `claimed` daemon observed `running` under an agterm daemon name. A claimed daemon on its own proves nothing, since a requested-live launch that fell back preserves its daemons while showing fresh shells. An incomplete split is dropped whole, never offered half.

those checks remain with one returned document. They define attachability, and they also protect the gap between the zmx snapshot and the model walk beside it. The far side applies them before returning rows. An empty list is a successful answer and deliberately does not distinguish "not running live" from "live with nothing eligible". `zmx list` is that diagnostic, and no surface claims otherwise.

the attach argv appends a create-only guard command that exits non-zero. Stock zmx *creates* a daemon whose name is absent, so a daemon that vanished since the tree was read would otherwise hand back a fresh remote shell wearing the session's name. An existing daemon ignores the guard; a vanished one runs it and fails visibly.

**transport**

tree uses `-T` with an outer process deadline, attach uses `-tt` because a remote command does not reliably get a pty and zmx reads termios and window size. Both pass `BatchMode=yes`, so key-based auth is a precondition and a password or host-key prompt fails the call; a dispatcher has no way to answer it.

the exit status is read before the output. `agtermctl --json` prints a not-ok response to stdout and exits nonzero, and an ssh that dies mid-write can leave output that still parses, so an ok-looking payload from a nonzero process is never accepted.

the remote command is sent as `/bin/sh -c '<chain>'`, because sshd runs it through the *account's* shell, where a bare `VAR=value` assignment is a syntax error in fish and tcsh. The whole read dies while the account shell is still parsing, before the first `agtermctl` runs. The account shell can change under a running agterm, so this is reachable in practice: live-backed panes survive a `chsh` that a later sshd command honors.

PATH is widened by appending the two documented install directories. So the far side needs `agtermctl` on sshd's remote-command PATH, and a PATH deliberately supplied to sshd still wins. Neither the host nor the session target reaches an error message unless it passed validation.

**when a connection drops**

both panes set `commandWait`, so Ghostty holds its own press-any-key prompt and the wrapper's one sanitized line (host, session, pane, exit status) can be read under the last remote screen. No timer, no notification, no session-wide coalescing. Each pane holds and closes on its own, which is also the right behavior when one half of a split dies. Reconnecting is left to a keymap custom command the user supplies.

**shipped with it**

a cookbook recipe that pipes the listing through agterm's picker and attaches what the user chooses, with the far side's window, workspace, purpose, directory and running command in each row's subtitle.

**accepted v1 limitation**

pinned zmx keeps one leader client and our attach is a follower, so the snapshot arrives at the far side's geometry and does not reflow until a classified key arrives: a printable character, Return, Tab or Backspace. Before that keystroke follower input is dropped outright, so mouse, focus and Ctrl-L never reach the remote and a mouse-first TUI looks dead. Leadership is per daemon, so a typed primary can sit beside a split still at the far side's geometry. On detach each daemon we led keeps our geometry until it gets qualifying input or a resize report, while panes we never claimed stay correct.

this is documented and left alone. Removing it needs an opt-in upstream `zmx attach --take-leadership` with handback.
