### PR TITLE
feat(control): report the foreground shell on a session node

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -650,9 +650,25 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   no `TERM_PROGRAM_VERSION` (`CustomCommandRunner` merges `ProcessInfo.processInfo.environment` with the
   `AGT_*` context only). That is why a recipe preflight uses `agtermctl version` rather than the variable.
 
-- Session nodes include foreground/split foreground argv, background spec, overlay size, pane overlays,
-  split axis, split ratio, split focus, status fields, flag, unseen, restore pins, surfaces, `realized`,
-  and `backedByZmx`.
+- Session nodes include foreground/split foreground argv, idle shell basenames, background spec, overlay
+  size, pane overlays, split axis, split ratio, split focus, status fields, flag, unseen, restore pins,
+  surfaces, `realized`, and `backedByZmx`.
+- `foregroundShell`/`splitForegroundShell` name the RECOGNIZED shell HOLDING a pane's foreground, present
+  exactly when that pane's `foreground` is absent because a shell holds it.
+  For a pane that EXISTS, neither field means agterm could not determine the foreground state — a bare nil
+  foreground alone conflated the two, which `cookbook/park-and-resume` documents as a data-loss limit: an
+  unreadable pane is parked as idle and replayed as a plain shell. Consult `hasSplit` before interpreting the
+  split pair: with no split pane both are absent because there is no pane, and `hasSplit` is itself omitted
+  when false. Do not make `hasSplit` always present to compensate.
+- The pair is NOT proof of an interactive prompt and must never be treated as permission to type. A builtin
+  such as `read` or `vared`, and a shell loop, run inside the shell process, so argv stays the shell's and a
+  pane blocked on input is indistinguishable from one at a prompt; libghostty exposes no OSC 133 mark, so agterm
+  has no prompt signal to offer instead. This is why the field says `foregroundShell` rather than naming
+  idleness. Recognized is `CommandRestore.knownShells` plus `$SHELL`; a shell outside both reports in
+  `foreground` like any program, and widening that set is NOT the fix — `paneForeground` is the one
+  classifier behind both the tree read and the restore capture, so it would change what restore re-runs too.
+  The basename comes from `stripLoginDash(argv)[0]`, in that order: `basename` splits on `/`, so it drops the
+  login mark from `-/bin/zsh` but keeps it on the bare `-zsh`.
 - `backedByZmx` on a session is true only when every existing primary/split pane is currently backed.
   Primary/split entries in `surfaces` report their own Boolean; scratch and overlays omit it. Older servers
   omit both levels. There is no sidebar indicator.

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -688,13 +688,13 @@ final class ControlServer {
         // dashboard read-backs: the keyboard-driven dashboard bypasses the command path, so a cache goes stale.
         let dashboard = DashboardControllerRegistry.shared.controller(for: windowID)
         return store.controlTree(
-            foreground: { session in
+            paneForeground: { session in
                 (session.surface as? GhosttySurfaceView).flatMap {
                     ForegroundProcess.running(for: $0, shellBasename: shellBasename,
                                               zmxResolver: zmxForegroundResolver)
                 }
             },
-            splitForeground: { session in
+            splitPaneForeground: { session in
                 (session.splitSurface as? GhosttySurfaceView).flatMap {
                     ForegroundProcess.running(for: $0, shellBasename: shellBasename,
                                               zmxResolver: zmxForegroundResolver)

--- a/agterm/Ghostty/ForegroundProcess.swift
+++ b/agterm/Ghostty/ForegroundProcess.swift
@@ -28,11 +28,14 @@ enum ForegroundProcess {
             pid = view.foregroundPid()
         }
         guard let pid, let argv = procArgs(pid: pid) else { return nil }
-        return usable(argv, shellBasename: shellBasename)
+        guard case .program(let command) = CommandRestore.paneForeground(argv: argv, extra: shellBasename)
+        else { return nil }
+        return command
     }
 
-    /// The pane's foreground command for the `tree` read-side: as `command`, plus a descent into the
-    /// process group when the leader's argv is unreadable.
+    /// The pane's foreground state for the `tree` read-side: as `command`, plus a descent into the
+    /// process group when the leader's argv is unreadable, and it KEEPS the shell case that `command`
+    /// discards, so the tree can name the shell holding the foreground. Nil means unreadable.
     ///
     /// libghostty's `foreground_pid` is `tcgetpgrp`, a process GROUP id. An interactive shell puts each
     /// job in its own group, so the leader IS the program. A pane with no job-control shell (a
@@ -45,7 +48,7 @@ enum ForegroundProcess {
     /// pipeline that outlives its `sudo` does report — see `groupDescentCandidates`.
     @MainActor
     static func running(for view: GhosttySurfaceView, shellBasename: String?,
-                        zmxResolver: ZmxForegroundResolver? = nil) -> [String]? {
+                        zmxResolver: ZmxForegroundResolver? = nil) -> CommandRestore.PaneForeground? {
         let pgid: pid_t?
         if view.backedByZmx, let sessionName = view.zmxSessionName {
             pgid = zmxResolver?.foregroundPID(sessionName: sessionName)
@@ -53,21 +56,16 @@ enum ForegroundProcess {
             pgid = view.foregroundPid()
         }
         guard let pgid else { return nil }
-        if let argv = procArgs(pid: pgid) { return usable(argv, shellBasename: shellBasename) }
+        if let argv = procArgs(pid: pgid) {
+            return CommandRestore.paneForeground(argv: argv, extra: shellBasename)
+        }
         let members = CommandRestore.groupDescentCandidates(pgid: pgid, members: processGroup(pgid: pgid))
         for pid in members {
-            if let argv = procArgs(pid: pid) { return usable(argv, shellBasename: shellBasename) }
+            if let argv = procArgs(pid: pid) {
+                return CommandRestore.paneForeground(argv: argv, extra: shellBasename)
+            }
         }
         return nil
-    }
-
-    /// Normalize a raw argv and drop it when it is an idle shell: a shell is skipped ONLY at its prompt (no
-    /// script/command argument); a shell running a script (a `#!/bin/sh` wrapper like `cld`) is a real
-    /// foreground process to report.
-    private static func usable(_ argv: [String], shellBasename: String?) -> [String]? {
-        guard !argv.isEmpty else { return nil }
-        if CommandRestore.isIdleShell(argv: argv, extra: shellBasename) { return nil }
-        return CommandRestore.stripLoginDash(argv)
     }
 
     /// Fetch and parse a process's argv via `sysctl(KERN_PROCARGS2)`; nil on any syscall failure, which is

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -252,8 +252,10 @@ public final class AppStore {
 
     /// Projects this store's workspace/session model into the control-channel `tree` payload. Foreground
     /// command lookup is supplied by the host because live process inspection is platform-specific.
-    public func controlTree(foreground: (Session) -> [String]? = { _ in nil },
-                            splitForeground: (Session) -> [String]? = { _ in nil },
+    /// `paneForeground` takes no default on purpose: the argv-shaped compatibility overload defaults every
+    /// closure, so one here would leave a bare `controlTree()` ambiguous between the two.
+    public func controlTree(paneForeground: (Session) -> CommandRestore.PaneForeground?,
+                            splitPaneForeground: (Session) -> CommandRestore.PaneForeground? = { _ in nil },
                             fontSize: (Session) -> Double? = { _ in nil },
                             splitFontSize: (Session) -> Double? = { _ in nil },
                             scratchFontSize: (Session) -> Double? = { _ in nil },
@@ -270,6 +272,9 @@ public final class AppStore {
         let activeWorkspaceID = currentWorkspaceID
         let nodes = workspaces.map { workspace in
             let sessions = workspace.sessions.map { session in
+                // each closure inspects live processes, so call it once and split the answer in two.
+                let mainPane = paneForeground(session)
+                let splitPane = splitPaneForeground(session)
                 let idle = session.agentIndicator.status == .idle
                 let status = idle ? nil : session.agentIndicator.status.rawValue
                 let statusPane = idle ? nil : session.agentIndicator.statusPane?.rawValue
@@ -296,7 +301,8 @@ public final class AppStore {
                                           commandWait: (session.initialCommand != nil && session.commandWait) ? true : nil,
                                           splitCommandWait: (session.splitInitialCommand != nil && session.splitCommandWait)
                                               ? true : nil,
-                                          foreground: foreground(session), splitForeground: splitForeground(session),
+                                          foreground: mainPane?.command, splitForeground: splitPane?.command,
+                                          foregroundShell: mainPane?.shellName, splitForegroundShell: splitPane?.shellName,
                                           // the PERSISTED overrides, not the transient pending payloads, so
                                           // a read after one fired still reports what stays pinned.
                                           restoreCommand: session.restoreCommand,

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -5,7 +5,7 @@ import Foundation
 /// back into a shell command line. The app target owns only the `sysctl`/libghostty calls; every
 /// judgement defers here so it stays unit-tested and off the C boundary.
 public enum CommandRestore {
-    /// The login shells treated as "no program to restore" (the pane was at its prompt).
+    /// The login shells treated as "no program to restore" (a shell held the pane, nothing to re-run).
     private static let knownShells: Set<String> = ["zsh", "bash", "sh", "fish", "dash", "ksh", "tcsh", "csh"]
 
     /// Sanity cap on argc: a corrupt header must not drive `reserveCapacity` into a huge allocation.
@@ -27,8 +27,9 @@ public enum CommandRestore {
         return false
     }
 
-    /// Whether `argv` is an interactive shell at its prompt — the "idle pane, nothing to restore" case:
-    /// `argv[0]` is a known shell (or `$SHELL`, passed as `extra`) AND only option flags follow it. A
+    /// Whether `argv` is shell-shaped with nothing to restore: `argv[0]` is a known shell (or `$SHELL`,
+    /// passed as `extra`) AND only option flags follow it. NOT proof of an interactive prompt, since a
+    /// builtin or a shell loop runs in the shell process and leaves argv untouched. A
     /// shell RUNNING something is NOT idle and IS captured — a script path (`/bin/sh /usr/local/bin/cld`,
     /// the foreground of any `#!/bin/sh` wrapper) or a `-c` command leaves a non-flag argument after
     /// `argv[0]`.
@@ -38,14 +39,14 @@ public enum CommandRestore {
     }
 
     /// What a pane's foreground argv means to the `tree` read: a program to report, or a recognized shell in
-    /// the foreground. The restore capture collapses `foregroundShell` back to nil — see
-    /// `ForegroundProcess.command` for why it must.
+    /// the foreground. The restore capture collapses `foregroundShell` to nil: otherwise `hadForeground`
+    /// would suppress `initialCommand` in `restorePlan`.
     public enum PaneForeground: Sendable, Equatable {
         /// A real foreground program, argv dash-stripped and ready to render.
         case program([String])
         /// A RECOGNIZED shell IN THE FOREGROUND, as its basename (`zsh`, `fish`) — not a claim that it sits at
-        /// a prompt, since a builtin runs in the shell process and leaves argv unchanged. A shell outside
-        /// `knownShells` and `$SHELL` is not recognized and reports as `program` instead.
+        /// a prompt, since a builtin runs in the shell process and leaves argv unchanged. A shell matching
+        /// neither the known set nor `$SHELL` is not recognized and reports as `program` instead.
         case foregroundShell(String)
 
         /// The argv the tree reports as `foreground`; nil when a shell holds the foreground.

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -37,6 +37,44 @@ public enum CommandRestore {
         return !argv.dropFirst().contains { !$0.hasPrefix("-") }
     }
 
+    /// What a pane's foreground argv means to the `tree` read: a program to report, or a recognized shell in
+    /// the foreground. The restore capture collapses `foregroundShell` back to nil — see
+    /// `ForegroundProcess.command` for why it must.
+    public enum PaneForeground: Sendable, Equatable {
+        /// A real foreground program, argv dash-stripped and ready to render.
+        case program([String])
+        /// A RECOGNIZED shell IN THE FOREGROUND, as its basename (`zsh`, `fish`) — not a claim that it sits at
+        /// a prompt, since a builtin runs in the shell process and leaves argv unchanged. A shell outside
+        /// `knownShells` and `$SHELL` is not recognized and reports as `program` instead.
+        case foregroundShell(String)
+
+        /// The argv the tree reports as `foreground`; nil when a shell holds the foreground.
+        public var command: [String]? {
+            if case .program(let argv) = self { return argv }
+            return nil
+        }
+
+        /// The basename the tree reports as `foregroundShell`; nil while a program runs.
+        public var shellName: String? {
+            if case .foregroundShell(let name) = self { return name }
+            return nil
+        }
+    }
+
+    /// Classify a pane's raw foreground argv for the `tree` read. Nil for an empty argv only; the two live
+    /// answers are the cases of `PaneForeground`. `extra` is the user's `$SHELL` basename, widening
+    /// recognition to a non-standard login shell exactly as `isIdleShell` does.
+    ///
+    /// The shell basename is taken AFTER `stripLoginDash`, never before: `basename` splits on `/`, so it
+    /// drops the login mark from a path form (`-/bin/zsh`) but keeps it on the bare form (`-zsh`), which is
+    /// the common case and would otherwise reach callers as `-zsh`.
+    public static func paneForeground(argv: [String], extra: String? = nil) -> PaneForeground? {
+        guard !argv.isEmpty else { return nil }
+        let stripped = stripLoginDash(argv)
+        if isIdleShell(argv: argv, extra: extra) { return .foregroundShell(basename(stripped[0])) }
+        return .program(stripped)
+    }
+
     /// Drop the leading `-` macOS dash-marks a login process's argv[0] with, so the argv names a program
     /// that can actually be rendered and re-run (`-sleep` → `sleep`). Only argv[0] carries the mark, and
     /// only the mark is removed: a path form (`-/bin/zsh`) keeps the rest of the path.

--- a/agtermCore/Sources/agtermCore/ControlProjection.swift
+++ b/agtermCore/Sources/agtermCore/ControlProjection.swift
@@ -145,8 +145,9 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     ///
     /// NOT proof of an interactive prompt, so it is never permission to type: a builtin such as `read` or
     /// `vared`, and a shell loop, run inside the shell process, leaving a pane blocked on input
-    /// indistinguishable from one at a prompt. Recognized is `CommandRestore.knownShells` or `$SHELL`; a shell outside both reports in
-    /// `foreground` like any other program.
+    /// indistinguishable from one at a prompt. Recognized means agterm knows the argv as a shell, by a
+    /// built-in set widened with the user's `$SHELL`; a shell outside both reports in `foreground` like any
+    /// other program.
     public let foregroundShell: String?
     /// The split (right) pane's foreground shell basename, the split analogue of `foregroundShell`. Read
     /// `hasSplit` before interpreting the split pair: with no split pane both are absent because there is no

--- a/agtermCore/Sources/agtermCore/ControlProjection.swift
+++ b/agtermCore/Sources/agtermCore/ControlProjection.swift
@@ -132,11 +132,26 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let commandWait: Bool?
     /// The split pane's hold-after-exit policy; nil/omitted without a holding split creation command.
     public let splitCommandWait: Bool?
-    /// The LIVE foreground process command (full argv) in the main pane; nil/omitted at the shell prompt —
-    /// the same capture restore-running-command uses.
+    /// The LIVE foreground process command (full argv) in the main pane; nil/omitted when the foreground IS a
+    /// recognized shell (`foregroundShell` names it) and whenever the process cannot be read — no foreground
+    /// pid, a setuid leader like `top`/`sudo`, an unresolved zmx pane, a failed syscall. Shares the restore
+    /// capture's extraction but not its rules: this read descends the process group, the capture does not.
     public let foreground: [String]?
     /// The split (right) pane's live foreground command (full argv), the split analogue of `foreground`.
     public let splitForeground: [String]?
+    /// The main pane's foreground process when it IS a recognized shell, as its basename (`zsh`, `fish`);
+    /// nil/omitted whenever `foreground` is present. For a pane that exists, neither field means agterm could
+    /// not determine the foreground state at all — the two a bare nil `foreground` used to conflate.
+    ///
+    /// NOT proof of an interactive prompt, so it is never permission to type: a builtin such as `read` or
+    /// `vared`, and a shell loop, run inside the shell process, leaving a pane blocked on input
+    /// indistinguishable from one at a prompt. Recognized is `CommandRestore.knownShells` or `$SHELL`; a shell outside both reports in
+    /// `foreground` like any other program.
+    public let foregroundShell: String?
+    /// The split (right) pane's foreground shell basename, the split analogue of `foregroundShell`. Read
+    /// `hasSplit` before interpreting the split pair: with no split pane both are absent because there is no
+    /// pane, not because anything could not be read.
+    public let splitForegroundShell: String?
     /// The main pane's PERSISTED restore-command override, the read side of `session.restore`. Tri-state:
     /// omitted = no override (auto-capture), `""` = pinned to nothing (a plain shell), a command = that shell
     /// line runs on the next launch. Read from persisted state, so it still reports the pin after the
@@ -207,6 +222,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
                 hud: ControlHudNode? = nil, scratch: Bool = false, flagged: Bool = false,
                 commandWait: Bool? = nil, splitCommandWait: Bool? = nil,
                 foreground: [String]? = nil, splitForeground: [String]? = nil,
+                foregroundShell: String? = nil, splitForegroundShell: String? = nil,
                 restoreCommand: String? = nil, splitRestoreCommand: String? = nil, status: String? = nil,
                 statusPane: String? = nil, statusBlink: Bool? = nil, statusColor: String? = nil,
                 statusShape: String? = nil, statusChangedAt: Double? = nil,
@@ -236,6 +252,8 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.splitCommandWait = splitCommandWait
         self.foreground = foreground
         self.splitForeground = splitForeground
+        self.foregroundShell = foregroundShell
+        self.splitForegroundShell = splitForegroundShell
         self.restoreCommand = restoreCommand
         self.splitRestoreCommand = splitRestoreCommand
         self.status = status

--- a/agtermCore/Sources/agtermCore/ControlProtocolCompatibility.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocolCompatibility.swift
@@ -28,3 +28,28 @@ extension ControlSessionNode {
                   surfaces: surfaces, realized: realized)
     }
 }
+
+extension AppStore {
+    /// Keeps the pre-`foregroundShell` `controlTree` callable for agterm-linux, whose lookups answer with an
+    /// argv and nil for a shell. That shape cannot name the shell, so nodes built through here carry no
+    /// `foregroundShell`/`splitForegroundShell` — the "an older caller receives nil" contract above.
+    public func controlTree(foreground: (Session) -> [String]? = { _ in nil },
+                            splitForeground: (Session) -> [String]? = { _ in nil },
+                            fontSize: (Session) -> Double? = { _ in nil },
+                            splitFontSize: (Session) -> Double? = { _ in nil },
+                            scratchFontSize: (Session) -> Double? = { _ in nil },
+                            quickVisible: () -> Bool? = { nil },
+                            zoomedSurface: () -> String? = { nil },
+                            pickPending: () -> String? = { nil },
+                            dashboardMembers: () -> [String]? = { nil },
+                            dashboardHighlighted: () -> String? = { nil },
+                            dashboardFontSize: () -> Double? = { nil },
+                            dashboardFontMode: () -> String? = { nil }, app: AppIdentity? = nil) -> ControlTree {
+        controlTree(paneForeground: { foreground($0).map { .program($0) } },
+                    splitPaneForeground: { splitForeground($0).map { .program($0) } },
+                    fontSize: fontSize, splitFontSize: splitFontSize, scratchFontSize: scratchFontSize,
+                    quickVisible: quickVisible, zoomedSurface: zoomedSurface, pickPending: pickPending,
+                    dashboardMembers: dashboardMembers, dashboardHighlighted: dashboardHighlighted,
+                    dashboardFontSize: dashboardFontSize, dashboardFontMode: dashboardFontMode, app: app)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTreeProjectionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTreeProjectionTests.swift
@@ -321,13 +321,44 @@ struct AppStoreTreeProjectionTests {
         store.selectSession(active.id)
 
         let tree = store.controlTree(
-            foreground: { session in session.id == active.id ? ["ssh", "host"] : nil },
-            splitForeground: { session in session.id == other.id ? ["tail", "-f", "app.log"] : nil }
+            paneForeground: { session in session.id == active.id ? .program(["ssh", "host"]) : nil },
+            splitPaneForeground: { session in session.id == other.id ? .program(["tail", "-f", "app.log"]) : nil }
         )
 
         #expect(tree.workspaces[0].sessions[0].foreground == ["ssh", "host"])
         #expect(tree.workspaces[0].sessions[0].splitForeground == nil)
         #expect(tree.workspaces[0].sessions[1].foreground == nil)
         #expect(tree.workspaces[0].sessions[1].splitForeground == ["tail", "-f", "app.log"])
+    }
+
+    @Test func controlTreeSplitsPaneForegroundIntoCommandAndForegroundShell() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "one")
+        _ = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+
+        var node = store.controlTree(paneForeground: { _ in .foregroundShell("zsh") },
+                                     splitPaneForeground: { _ in .program(["tail", "-f", "/x"]) })
+            .workspaces[0].sessions[0]
+        #expect(node.foreground == nil)
+        #expect(node.foregroundShell == "zsh")
+        #expect(node.splitForeground == ["tail", "-f", "/x"])
+        #expect(node.splitForegroundShell == nil)
+
+        node = store.controlTree(paneForeground: { _ in nil }).workspaces[0].sessions[0]
+        #expect(node.foreground == nil)
+        #expect(node.foregroundShell == nil)
+    }
+
+    @Test func controlTreeCompatibilityOverloadKeepsArgvCallersAndReportsNoForegroundShell() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        _ = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+
+        // the argv-shaped lookup an older consumer supplies: it cannot name a shell, so foregroundShell stays nil.
+        let node = store.controlTree(foreground: { _ in ["ssh", "host"] }).workspaces[0].sessions[0]
+
+        #expect(node.foreground == ["ssh", "host"])
+        #expect(node.foregroundShell == nil)
+        #expect(node.splitForegroundShell == nil)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -88,6 +88,41 @@ struct CommandRestoreTests {
         #expect(!CommandRestore.isIdleShell(argv: []))
     }
 
+    @Test func paneForegroundNamesTheForegroundShellAndStripsTheLoginDash() {
+        #expect(CommandRestore.paneForeground(argv: ["-zsh"]) == .foregroundShell("zsh"))
+        #expect(CommandRestore.paneForeground(argv: ["-/bin/zsh"]) == .foregroundShell("zsh"))
+        #expect(CommandRestore.paneForeground(argv: ["/bin/zsh"]) == .foregroundShell("zsh"))
+        #expect(CommandRestore.paneForeground(argv: ["zsh", "-i", "-l"]) == .foregroundShell("zsh"))
+        #expect(CommandRestore.paneForeground(argv: ["fish"]) == .foregroundShell("fish"))
+        #expect(CommandRestore.paneForeground(argv: ["-nu"], extra: "nu") == .foregroundShell("nu"))
+        #expect(CommandRestore.paneForeground(argv: []) == nil)
+    }
+
+    @Test func paneForegroundCannotSeeAShellBusyInsideItself() {
+        // pins the contract, not a defect: `read`, `vared` and a shell loop all run IN the shell, so argv is still
+        // the shell's and a pane blocked on input classifies exactly as one at a prompt. Callers are told
+        // foregroundShell is never permission to type; if this ever stops matching, that promise moved.
+        #expect(CommandRestore.paneForeground(argv: ["-zsh"]) == .foregroundShell("zsh"))
+        #expect(CommandRestore.paneForeground(argv: ["-bash"]) == .foregroundShell("bash"))
+    }
+
+    @Test func paneForegroundReportsProgramsIncludingUnrecognizedShells() {
+        #expect(CommandRestore.paneForeground(argv: ["htop"]) == .program(["htop"]))
+        #expect(CommandRestore.paneForeground(argv: ["-sleep", "5"]) == .program(["sleep", "5"]))
+        #expect(CommandRestore.paneForeground(argv: ["/bin/sh", "/usr/local/bin/cld"])
+            == .program(["/bin/sh", "/usr/local/bin/cld"]))
+        #expect(CommandRestore.paneForeground(argv: ["bash", "-c", "echo hi"]) == .program(["bash", "-c", "echo hi"]))
+        // a shell in neither knownShells nor $SHELL is not recognized, so it reports as any program does.
+        #expect(CommandRestore.paneForeground(argv: ["nu"]) == .program(["nu"]))
+    }
+
+    @Test func paneForegroundProjectsOneCasePerTreeField() {
+        #expect(CommandRestore.paneForeground(argv: ["-zsh"])?.command == nil)
+        #expect(CommandRestore.paneForeground(argv: ["-zsh"])?.shellName == "zsh")
+        #expect(CommandRestore.paneForeground(argv: ["htop"])?.command == ["htop"])
+        #expect(CommandRestore.paneForeground(argv: ["htop"])?.shellName == nil)
+    }
+
     @Test func shouldRestoreSkipsDenylistByBasename() {
         let denylist: Set<String> = ["vim", "tmux", "hx"]
         #expect(CommandRestore.shouldRestore(argv: ["ssh", "gate"], denylist: denylist))

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -652,6 +652,20 @@ struct ControlProtocolTests {
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("foreground"), "a nil foreground must be omitted from the JSON; got \(json)")
+        #expect(!json.contains("foregroundShell"), "a nil foregroundShell must be omitted from the JSON; got \(json)")
+    }
+
+    @Test func treeSessionNodeRoundTripsWithIdleShell() throws {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true,
+                                         backedByZmx: nil, foregroundShell: "zsh", splitForegroundShell: "fish")
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        let node = decoded.result?.tree?.workspaces.first?.sessions.first
+        #expect(node?.foregroundShell == "zsh")
+        #expect(node?.splitForegroundShell == "fish")
+        #expect(node?.foreground == nil)
     }
 
     @Test func treeSessionNodeRoundTripsWithFontSizes() throws {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -72,6 +72,49 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(fg, ["tee", marker], "tree should expose the session's live foreground command")
     }
 
+    // the idle direction of the same real prompt/pty/sysctl path: a pane at its prompt names its shell, and
+    // the name goes away the moment a program takes the foreground. Pins `running` -> `buildTree` -> wire:
+    // a tree that dropped the idle case reports null here while every host-free test stays green.
+    func testTreeNamesTheForegroundShellAndDropsItWhenAProgramRuns() throws {
+        var shell: String?
+        for _ in 0..<40 {
+            let resp = try sendCommand(#"{"cmd":"tree"}"#)
+            if let name = firstSessionNode(resp)?["foregroundShell"] as? String {
+                XCTAssertNil(firstSessionNode(resp)?["foreground"], "foregroundShell and foreground are exclusive")
+                shell = name
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        let idle = try XCTUnwrap(shell, "a pane sitting at its prompt should name its shell")
+        XCTAssertFalse(idle.hasPrefix("-"), "the login dash must be stripped before the basename: got \(idle)")
+
+        let marker = markerDir.appendingPathComponent("idlefg-\(UUID().uuidString)").path
+        let payload: [String: Any] = ["cmd": "session.type", "args": ["text": "tee \(marker)\n"]]
+        let line = String(data: try JSONSerialization.data(withJSONObject: payload), encoding: .utf8)!
+        XCTAssertEqual(try sendCommand(line)["ok"] as? Bool, true, "session.type should succeed")
+
+        var ranWithoutShell = false
+        for _ in 0..<40 {
+            let resp = try sendCommand(#"{"cmd":"tree"}"#)
+            if let f = firstSessionForeground(resp), f.first == "tee" {
+                ranWithoutShell = firstSessionNode(resp)?["foregroundShell"] == nil
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        XCTAssertTrue(ranWithoutShell, "a pane running a program must drop foregroundShell")
+    }
+
+    /// The first session's whole node from a `tree` response dict, or nil.
+    private func firstSessionNode(_ response: [String: Any]) -> [String: Any]? {
+        guard let result = response["result"] as? [String: Any],
+              let tree = result["tree"] as? [String: Any],
+              let workspaces = tree["workspaces"] as? [[String: Any]],
+              let sessions = workspaces.first?["sessions"] as? [[String: Any]] else { return nil }
+        return sessions.first
+    }
+
     /// The first session's `foreground` argv from a `tree` response dict, or nil if at the prompt.
     private func firstSessionForeground(_ response: [String: Any]) -> [String]? {
         guard let result = response["result"] as? [String: Any],

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -197,7 +197,11 @@ examples in **examples.md**; installable community workflows in **cookbook.md**.
 **tree** — print the workspace/session tree (`--json` for structured). Each session node carries
 `foreground`/`splitForeground` (the live argv of each pane's foreground process, omitted when the pane
 is at its shell prompt, or running a setuid/setgid program like `top` or `sudo` whose argv macOS won't
-expose) — i.e. what each pane is currently running — `restoreCommand`/`splitRestoreCommand` (each pane's
+expose) — i.e. what each pane is currently running — `foregroundShell`/`splitForegroundShell` (the shell
+holding each pane's foreground as a basename, present exactly when that pane's `foreground` is omitted
+because a shell holds it, so an EXISTING pane with neither is one whose process could not be read; check
+`hasSplit` before reading the split pair. Not a claim the pane is at a prompt and never permission to type —
+a builtin like `read` runs inside the shell), `restoreCommand`/`splitRestoreCommand` (each pane's
 persisted restore-command override set via `session restore` — the read side: omitted = auto-capture, `""`
 = pinned to nothing (a plain shell), a command = the shell line that runs on the next launch), `status` (the agent-status set
 via `session status`: `active`|`completed`|`blocked`, omitted when idle), `statusPane` (which pane set

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -13,7 +13,10 @@ agtermctl tree --json        # workspaces -> sessions, active/split/overlay/scra
 agtermctl window list --json # windows, with open/active flags
 
 # what is each pane RUNNING right now (foreground argv; absent at the shell prompt or for a setuid program like top/sudo)
-agtermctl tree --json | jq -r '.result.tree.workspaces[].sessions[] | "\(.name): \(.foreground // "shell")"'
+# foregroundShell names the shell holding the foreground, so an existing pane with neither could not be read.
+# it does NOT mean the pane is at a prompt: a builtin like `read` runs inside the shell and looks the same
+agtermctl tree --json | jq -r '.result.tree.workspaces[].sessions[]
+  | "\(.name): \(.foreground // .foregroundShell // "unknown")"'
 ```
 
 ## Capture or reset the restore-on-restart commands

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -174,6 +174,14 @@ Ephemeral like `unseen`: never persisted, so it is absent after a restart even f
 `foreground`/`splitForeground` (the live argv of each pane's foreground
 process — what it is running — omitted when the pane sits at its shell prompt, and also for a
 setuid/setgid foreground process like `top` or `sudo`, whose argv macOS refuses to expose),
+`foregroundShell`/`splitForegroundShell` (the shell HOLDING each pane's foreground as a basename — `zsh`,
+`fish` — present exactly when that pane's `foreground` is omitted because a shell holds it. For a pane that
+EXISTS, both omitted together means agterm could not read the process, which is how you tell "a shell has it"
+from "cannot tell"; check `hasSplit` before reading the split pair, since a session with no split omits both
+simply because there is no pane. It is NOT a claim the pane is at a prompt and NEVER permission to type: a
+builtin like `read` runs inside the shell, so a pane blocked on input is indistinguishable from an idle one.
+A shell agterm does not recognize, outside its known set and your `$SHELL`, reports in `foreground` like any
+other program),
 `restoreCommand`/`splitRestoreCommand` (each pane's persisted restore-command override — the read side of
 `session restore`: omitted = no override (auto-capture), `""` = pinned to nothing (a plain shell), a
 command string = the shell line that runs on the next launch; reported from persisted state, so a read

--- a/site/commands.html
+++ b/site/commands.html
@@ -486,6 +486,22 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">foreground</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitForeground</span> (each pane's live foreground
                 argv, omitted at the shell prompt or for a setuid program like top/sudo),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">foregroundShell</span> /
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitForegroundShell</span> (the shell holding each
+                pane's foreground, as a basename like
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zsh</span> or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">fish</span>; present exactly when that pane's
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">foreground</span> is omitted because a shell holds it.
+                For a pane that exists, both omitted together means agterm could not read the process at all — check
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">hasSplit</span> before reading the split pair, since a
+                session with no split pane omits both simply because there is no pane.
+                This is <em>not</em> a claim that the pane sits at a prompt, and it is never permission to type into one: a
+                shell builtin such as
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">read</span> runs inside the shell itself, so a pane
+                blocked waiting for input looks exactly like one at a prompt.
+                A shell agterm does not recognize — outside the known set and your
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">$SHELL</span> — reports in
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">foreground</span> like any other program),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">background</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">restoreCommand</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitRestoreCommand</span> (each pane's pinned


### PR DESCRIPTION
`tree` omitted `foreground` in two different situations: a recognized shell was holding the pane, or agterm could not determine the pane's foreground state. A caller could not tell those apart.

That ambiguity is already documented as a data-loss limit in `cookbook/park-and-resume`: a pane whose foreground cannot be determined is parked as idle, comes back as a plain shell, and the record of what it was running goes with the deleted workspace.

**What the node carries now**

`foregroundShell` / `splitForegroundShell`, the basename of the recognized shell holding each pane's foreground. Present exactly when that pane's `foreground` is absent because a shell holds it. For a pane that exists, both absent now means agterm could not determine the foreground state.

**What it deliberately does not promise**

It is not a claim that the pane sits at a prompt, and it is never permission to type into one. A builtin such as `read` or `vared`, and a shell loop, run inside the shell process, so argv stays the shell's and a pane blocked waiting for input looks exactly like one at a prompt. libghostty exposes no OSC 133 mark, so there is no prompt signal to report instead.

So this does not make the prompt-marker injection in #508 safe. It supplies a shell name, not a prompt signal. A regression test pins that contract.

**Reading the split pair**

Check `hasSplit` first. With no split pane both fields are absent because there is no pane, not because anything was unreadable. `hasSplit` stays omitted when false.

**Implementation**

`CommandRestore` gains `PaneForeground` and a `paneForeground` classifier. `ForegroundProcess.running` returns it while the restore capture collapses the shell case back to nil, so what a pane re-runs at launch is unchanged. The basename comes from the dash-stripped argv, in that order: `basename` splits on `/`, so the reverse order leaves a bare `-zsh` intact.

`AppStore.controlTree`'s primary entry point takes one `PaneForeground` closure per pane under new labels. `ControlProtocolCompatibility` keeps the old `foreground:` / `splitForeground:` argv shape callable, mapping a non-nil argv to `program` and nil to nil. agterm-linux calls that overload and keeps compiling, and gets no `foregroundShell` fields until it adopts the classifier.

Docs synced across `control-api.md`, `site/commands.html` and the bundled skill.

Related to https://github.com/umputun/agterm/discussions/508
