### PR TITLE
Pace pane startup on launches that replay commands

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -255,6 +255,14 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   unrealized session, with or without `select`, so `session.new --no-select` plus an immediate type does
   not race the mount+layout gap (#349). The probe precedes every sleep, so a realized session pays nothing
   and `select` moves selection only when the surface was not ready. `right`/`scratch` still fail fast.
+- A restored pane still waiting on its launch spawn permit (a replaying launch paces spawns) is expedited
+  by every command that must act on a live surface: `session.type` (left before its poll, right before
+  the inject), `session.search`, `session.paste`, `session.selectall` and `font.inc/dec/reset`. Reads never
+  do: `session.text`, `session.copy` and `surface.cursor` answer `session not realized` or
+  `surface not realized` and leave the pane queued. No command sets that state, so there is no read-back
+  beyond `realized` and the tree's `(not realized)` tag, and both describe the MAIN pane only: a queued
+  right pane shows nothing, so an empty tree is no proof the queue drained. The pacer's `onDrain` debug
+  log is the drain signal.
 - `injectText` resolves only `surface`/`splitSurface`/`scratchSurface`, so like `session.text` every `--pane`
   addresses the pane UNDER a covering overlay: the keystrokes run in the hidden shell, unseen until it closes,
   while the call answers ok. This is the intended behavior, not a gap — the panes are the session's durable

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -114,6 +114,12 @@ paths:
   when `ghostty_surface_new` fails, so until then the captured argv and restore pin stay on the session.
   Only a burst or pre-expedited key is granted inside `request` itself; `SpawnRegistry.grant` resumes only
   a pane already denied, because re-entering under the requester spawned the surface twice.
+- The pacer never jumps an expected key, and only a built view cancels one, so a pane leaving the visible
+  model before its window mounts would hold the queue at the head forever and silence `onDrain`. Every
+  hard or soft session close, workspace removal, shown-split hide or close, and loaded-window close or
+  delete therefore calls the store's `launchPaneDrop`, wired to `SpawnPacer.discard`, so the key is
+  dropped even when no view exists. A new removal path owes the same call; a drop after a view's teardown
+  is harmless.
 - `ghostty_surface_new` returns NULL for as long as the DISPLAY is asleep, with a valid backing size —
   measured 21 consecutive failures over 40s, then success within ~2s of wake while the screen was still
   LOCKED. Unlock is irrelevant; display wake is the earliest moment creation can succeed, so retrying

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -102,6 +102,18 @@ paths:
   nil every store-capturing callback to break the store/session/surface/closure cycle.
 - Create surfaces only with nonzero backing size; otherwise Metal stays blank. Defer through
   `pendingSurfaceCreation` until `setFrameSize`.
+- After the size guard `createSurface()` asks the launch `SpawnPacer` for a permit, then resolves the
+  launch seed, in that order. A launch that replays commands arms the pacer before any window mounts with
+  every open window's restored primary and shown split. Among those keys, a pane whose seed would start a
+  program is denied unless it is in the burst (each window's selected panes) or was expedited before it
+  asked; a key outside the armed order, a hidden split shown later for one, is granted synchronously; a
+  denied pane is resumed by its grant, which
+  re-enters `createSurface()` against the bounds the view has THEN, so the wait cannot race layout: a
+  zero-size pane never asks, and its later `setFrameSize` retry is the request. The seed resolves on the
+  first PERMITTED creation attempt, right before `ghostty_surface_config_new`, and stays cached on the view
+  when `ghostty_surface_new` fails, so until then the captured argv and restore pin stay on the session.
+  Only a burst or pre-expedited key is granted inside `request` itself; `SpawnRegistry.grant` resumes only
+  a pane already denied, because re-entering under the requester spawned the surface twice.
 - `ghostty_surface_new` returns NULL for as long as the DISPLAY is asleep, with a valid backing size —
   measured 21 consecutive failures over 40s, then success within ~2s of wake while the screen was still
   LOCKED. Unlock is irrelevant; display wake is the earliest moment creation can succeed, so retrying

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -180,6 +180,10 @@ paths:
   Anything else that must cancel an armed replay clears those slots too, never the persisted fields:
   `recoverOrphanedWindows`, `Session.clearPendingRestoreOverrides` on the soft-close round trip, and
   `restore.clear`, which the socket can receive before the later windows' decks have mounted.
+  The pending pair is consumed on the first PERMITTED surface-creation attempt, not at view construction
+  (`LaunchSeedProvider`): while a pane waits on its launch spawn permit the argv and pin stay on the
+  session, so `restore.clear` disarms it and a clean quit re-captures it across that window. The on-demand
+  arm (`restore.capture`) keeps its rerun-only boundary.
   Against STALE files from older builds, `loadStore` also rewrites a snapshot that carried captures on a
   mid-run reopen, and `recoverOrphanedWindows` drops captures while the sticky override still arms
   (a corrupt index must not re-execute a closed window's last command).

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -13,6 +13,7 @@ extension ControlServer {
             guard let surface = store.session(withID: id)?.addressableSurface as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
+            surface.expediteSpawn()
             // the cast alone only proves the SLOT is filled; a false return is the view without a surface.
             guard surface.performBindingAction(action) else {
                 return ControlResponse(ok: false, error: "session not realized")
@@ -55,6 +56,7 @@ extension ControlServer {
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
+            surface.expediteSpawn()
             // a false return = surface not realized yet; report it, not a false ok (session.type's contract).
             guard surface.performBindingAction(action) else {
                 return ControlResponse(ok: false, error: "session not realized")
@@ -406,6 +408,7 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "session not realized")
         }
 
+        openSurface.expediteSpawn()
         // `searchActive` here means a prior open settled (set by the async START callback); two rapid
         // scripted opens could mis-toggle, but the GUI's single-⌘F path is the common case.
         if !session.searchActive { openSurface.startSearch() }
@@ -488,7 +491,13 @@ extension ControlServer {
             }
             // inject returns false when the view exists but its libghostty surface isn't realized yet (there
             // is no realize/select path for the split pane) — report that instead of a false ok.
-            guard let surface = split as? GhosttySurfaceView, surface.injectAsUserInput(text: text) else {
+            guard let surface = split as? GhosttySurfaceView else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            // a queued split is granted here, so the inject lands; an unmounted one still fails fast, there
+            // being no poll for the split pane.
+            surface.expediteSpawn()
+            guard surface.injectAsUserInput(text: text) else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
@@ -513,6 +522,8 @@ extension ControlServer {
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
         if select { store.selectSession(id) }
+        // a queued pane is granted now, so the poll waits only for libghostty, never for the pane's turn.
+        (store.session(withID: id)?.surface as? GhosttySurfaceView)?.expediteSpawn()
         for _ in 0..<12 {
             try? await Task.sleep(nanoseconds: 30_000_000)
             // poll for the surface AND its realization (a false inject keeps polling), so a just-created or

--- a/agterm/Ghostty/GhosttySurfaceView+FirstResponder.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+FirstResponder.swift
@@ -1,0 +1,59 @@
+import AppKit
+import GhosttyKit
+
+/// Who may take keyboard focus on a surface, which clicks reach the terminal at all, and how a responder
+/// transition is reported to libghostty and to the session model.
+extension GhosttySurfaceView {
+    override var acceptsFirstResponder: Bool { !viewOnly }
+
+    /// In view-only mode refuse hit-testing, so a click passes THROUGH to the SwiftUI cell overlay instead of
+    /// reaching `mouseDown` — AppKit routes clicks here regardless of `.allowsHitTesting(false)`.
+    ///
+    /// `deckVisible` deliberately does NOT gate this. Refusing while off-screen only promotes the hidden deck
+    /// entry's own container — its `NSSplitView` or pane view — to answer in its place, and that is not a
+    /// `GhosttySurfaceView`, so `ownsPointer` then declines across the whole visible terminal and it loses
+    /// every cursor shape it paints.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        viewOnly ? nil : super.hitTest(point)
+    }
+
+    /// Deliver the LEFT click that reactivates a background window straight to the surface (a "first mouse")
+    /// instead of letting AppKit swallow it to raise the window: otherwise clicking a pane of a two-pane split
+    /// from another window raises it but never runs `mouseDown`, leaving `splitFocused` on the previous pane.
+    /// The click then behaves like any in-window one — selects the pane AND is reported to the program — as in
+    /// Terminal.app/iTerm2/Ghostty. Gated to `.leftMouseDown`: a first-mouse right/middle click reaches
+    /// `rightMouseDown`/`otherMouseDown`, which forward to libghostty, where the default
+    /// `right-click-action = paste` would paste into a window you only meant to raise.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        // with auto-hide-inactive-sidebars on, activating an inactive window expands its hidden sidebar and
+        // resizes THIS surface, so an activating click on the terminal would drag the still-held press into a
+        // phantom selection. in that mode the click only raises; a follow-up click selects once key.
+        if GhosttyApp.shared.autoHideSidebarInactiveWindows { return false }
+        return event?.type == .leftMouseDown
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result, let surface {
+            // report focused, gated on the window being key (a background window's surface stays hollow). push
+            // directly: `window.firstResponder` is not yet self inside this call, so `liveFocus` reads stale.
+            // onFocusChange (split-pane tracking) is independent of key state.
+            ghostty_surface_set_focus(surface, window?.isKeyWindow ?? false)
+            if !suppressFocusChange { onFocusChange?(true) }
+        }
+        // AX hears the move from here, NOT from `updateGhosttyFocus` (which this path deliberately skips):
+        // the post is deferred a run-loop turn precisely because `window.firstResponder` reads stale here.
+        postAccessibilityFocusChange()
+        return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result, let surface {
+            ghostty_surface_set_focus(surface, false)
+            if !suppressFocusChange { onFocusChange?(false) }
+        }
+        postAccessibilityFocusChange() // see becomeFirstResponder; the deferred post coalesces the pair
+        return result
+    }
+}

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -38,6 +38,17 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     /// factories, resolved once in `createSurface`, dropped on resolution and on teardown.
     var launchSeed: LaunchSeedProvider?
 
+    /// This pane's place in the launch spawn queue: the key the pacer grants and the pacer holding it, both
+    /// nil for every view that spawns on request (fresh panes, overlays, scratch, quick, HUD, and a restored
+    /// pane that replays nothing). The pacer is `weak` — the app owns it — and both are
+    /// `nonisolated(unsafe)` so the nonisolated `deinit` net can read them; written on the main actor only.
+    nonisolated(unsafe) private weak var spawnPacer: SpawnPacer?
+    nonisolated(unsafe) private var spawnKey: UUID?
+
+    /// Whether this pane is mounted and sized but still waiting for its spawn permit. `isRealized` already
+    /// reports it unrealized; this separates waiting on the pacer from waiting on a nonzero size.
+    private(set) var awaitingSpawnPermit = false
+
     /// Whether this surface grabs first responder as soon as it is created — the overlay's path: it mounts
     /// over an already-focused session, and `TerminalView.focusIfNeeded` grabs only when the view is in a
     /// window at the first `updateNSView`, which the deferred overlay surface is not, with no later update.
@@ -473,6 +484,11 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     deinit {
         // free directly, not via destroySurface(): deinit is nonisolated and can't call the @MainActor method,
         // while the nonisolated(unsafe) fields free with plain C calls. the net for a view dropped untorn.
+        // the queue exit is the exception: `cancel` is main-actor, so schedule it by KEY, capturing the pacer
+        // and the key but never `self`, which is already being freed.
+        if let pacer = spawnPacer, let key = spawnKey {
+            Task { @MainActor in pacer.cancel(key) }
+        }
         focusObservers.forEach { NotificationCenter.default.removeObserver($0) }
         if let surface { ghostty_surface_free(surface) }
         configCStrings.forEach { free($0) }
@@ -585,8 +601,9 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
             return
         }
         pendingSurfaceCreation = false
-        // after the size guard: a pane deferred on a zero size keeps its captured argv and restore pin
-        // armed on the session until it really spawns.
+        // after the size guard so a zero-size pane holds no pacer token; the pacer re-enters createSurface
+        // on grant. before the seed resolves so a denied pane keeps its captured argv and restore pin armed.
+        guard requestSpawnPermit() else { return }
         resolveLaunchSeed()
 
         var config = ghostty_surface_config_new()
@@ -692,6 +709,24 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         requestAutoFocus(in: window)
     }
 
+    /// Puts this pane in the launch spawn queue: `createSurface` asks `pacer` for `key` once the view is
+    /// sized, and spawns when the grant comes back through the registry. Called by the pane factories for a
+    /// restored pane that replays a program; every other view spawns on request.
+    func useSpawnPacer(_ pacer: SpawnPacer, key: UUID) {
+        spawnPacer = pacer
+        spawnKey = key
+    }
+
+    /// Whether the surface may spawn now. False leaves the pane queued and the caller returns: the pacer
+    /// re-enters `createSurface` on the grant, against the bounds the view has then, so this deferral is the
+    /// pacer's own rather than a next-tick hop racing layout. True for an unarmed or drained pacer, for a
+    /// key already granted, and for every view outside the queue, which is today's behavior unchanged.
+    func requestSpawnPermit() -> Bool {
+        guard let spawnPacer, let spawnKey else { return true }
+        awaitingSpawnPermit = !spawnPacer.request(spawnKey)
+        return !awaitingSpawnPermit
+    }
+
     /// Consumes the deferred launch seed on the first call, latching it into `command`/`initialInput`/
     /// `waitAfterCommand` and dropping the closure, so a creation retried after an unrelated failure never
     /// takes the session's pending slots twice. Returns the seed in force, which for a view built without a
@@ -790,6 +825,11 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     func destroySurface() {
         // a pane torn down before it spawned must not consume its pending slots; the session keeps them.
         launchSeed = nil
+        // leave the launch queue: a key nobody will ever request holds every pane behind it for an interval,
+        // and the grant that arrives anyway finds a destroyed view and no-ops.
+        if let spawnKey, let spawnPacer { spawnPacer.cancel(spawnKey) }
+        spawnKey = nil
+        awaitingSpawnPermit = false
         cancelPendingRendererVisibility()
         hiddenJanitorTask?.cancel()
         hiddenJanitorTask = nil
@@ -937,60 +977,5 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         // the split re-parent invalidates the Metal drawable, and neither a same-grid set_size nor the tick
         // (dirty surfaces only) repaints it — force one or the re-hosted pane stays blank over a live buffer.
         ghostty_surface_refresh(surface)
-    }
-
-    // MARK: - First responder
-
-    override var acceptsFirstResponder: Bool { !viewOnly }
-
-    /// In view-only mode refuse hit-testing, so a click passes THROUGH to the SwiftUI cell overlay instead of
-    /// reaching `mouseDown` — AppKit routes clicks here regardless of `.allowsHitTesting(false)`.
-    ///
-    /// `deckVisible` deliberately does NOT gate this. Refusing while off-screen only promotes the hidden deck
-    /// entry's own container — its `NSSplitView` or pane view — to answer in its place, and that is not a
-    /// `GhosttySurfaceView`, so `ownsPointer` then declines across the whole visible terminal and it loses
-    /// every cursor shape it paints.
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        viewOnly ? nil : super.hitTest(point)
-    }
-
-    /// Deliver the LEFT click that reactivates a background window straight to the surface (a "first mouse")
-    /// instead of letting AppKit swallow it to raise the window: otherwise clicking a pane of a two-pane split
-    /// from another window raises it but never runs `mouseDown`, leaving `splitFocused` on the previous pane.
-    /// The click then behaves like any in-window one — selects the pane AND is reported to the program — as in
-    /// Terminal.app/iTerm2/Ghostty. Gated to `.leftMouseDown`: a first-mouse right/middle click reaches
-    /// `rightMouseDown`/`otherMouseDown`, which forward to libghostty, where the default
-    /// `right-click-action = paste` would paste into a window you only meant to raise.
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        // with auto-hide-inactive-sidebars on, activating an inactive window expands its hidden sidebar and
-        // resizes THIS surface, so an activating click on the terminal would drag the still-held press into a
-        // phantom selection. in that mode the click only raises; a follow-up click selects once key.
-        if GhosttyApp.shared.autoHideSidebarInactiveWindows { return false }
-        return event?.type == .leftMouseDown
-    }
-
-    override func becomeFirstResponder() -> Bool {
-        let result = super.becomeFirstResponder()
-        if result, let surface {
-            // report focused, gated on the window being key (a background window's surface stays hollow). push
-            // directly: `window.firstResponder` is not yet self inside this call, so `liveFocus` reads stale.
-            // onFocusChange (split-pane tracking) is independent of key state.
-            ghostty_surface_set_focus(surface, window?.isKeyWindow ?? false)
-            if !suppressFocusChange { onFocusChange?(true) }
-        }
-        // AX hears the move from here, NOT from `updateGhosttyFocus` (which this path deliberately skips):
-        // the post is deferred a run-loop turn precisely because `window.firstResponder` reads stale here.
-        postAccessibilityFocusChange()
-        return result
-    }
-
-    override func resignFirstResponder() -> Bool {
-        let result = super.resignFirstResponder()
-        if result, let surface {
-            ghostty_surface_set_focus(surface, false)
-            if !suppressFocusChange { onFocusChange?(false) }
-        }
-        postAccessibilityFocusChange() // see becomeFirstResponder; the deferred post coalesces the pair
-        return result
     }
 }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -20,16 +20,23 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
 
     /// The command run as the surface's process instead of the login shell, nil for the login shell; read in
     /// `createSurface`. The overlay uses it to run one program (e.g. a TUI) whose exit closes the overlay.
-    private let command: String?
+    /// The three seed fields are `nonisolated(unsafe)` for `shouldCloseOnChildExitAction`, read from a C
+    /// callback: `resolveLaunchSeed` writes them on the main actor before the surface exists.
+    nonisolated(unsafe) private var command: String?
 
     /// Text fed to the pty as if typed at startup (libghostty `initial_input`), nil for none.
     /// Restore-running-command uses it: the captured foreground command line + `\n`, so a restored login
     /// shell re-runs it and returns to a prompt on exit — UNLIKE `command`, which replaces the shell.
-    private let initialInput: String?
+    nonisolated(unsafe) private var initialInput: String?
 
     /// Whether a `command`'s exit leaves the surface open on libghostty's "press any key to close" prompt
     /// instead of closing immediately. Only meaningful with `command`.
-    private let waitAfterCommand: Bool
+    nonisolated(unsafe) private var waitAfterCommand: Bool
+
+    /// Defers this pane's seed to spawn time; nil for a view built with explicit constructor values (the
+    /// overlay, scratch, quick terminal and HUD, none of which restore anything). Set by the pane
+    /// factories, resolved once in `createSurface`, dropped on resolution and on teardown.
+    var launchSeed: LaunchSeedProvider?
 
     /// Whether this surface grabs first responder as soon as it is created — the overlay's path: it mounts
     /// over an already-focused session, and `TerminalView.focusIfNeeded` grabs only when the view is in a
@@ -546,7 +553,7 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     /// Whether a child-exit should close this surface immediately, suppressing ghostty's "press any key"
     /// prompt. True only for a command surface (the overlay) that did NOT opt into the wait prompt, which
     /// instead closes via `close_surface_cb` after the keypress. `nonisolated` so the C action callback reads
-    /// it with no main-actor hop — both backing fields are `let`s.
+    /// it with no main-actor hop.
     nonisolated var shouldCloseOnChildExitAction: Bool { command != nil && !waitAfterCommand }
 
     func reportFontSize() {
@@ -578,6 +585,9 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
             return
         }
         pendingSurfaceCreation = false
+        // after the size guard: a pane deferred on a zero size keeps its captured argv and restore pin
+        // armed on the session until it really spawns.
+        resolveLaunchSeed()
 
         var config = ghostty_surface_config_new()
         config.platform_tag = GHOSTTY_PLATFORM_MACOS
@@ -682,6 +692,23 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         requestAutoFocus(in: window)
     }
 
+    /// Consumes the deferred launch seed on the first call, latching it into `command`/`initialInput`/
+    /// `waitAfterCommand` and dropping the closure, so a creation retried after an unrelated failure never
+    /// takes the session's pending slots twice. Returns the seed in force, which for a view built without a
+    /// provider is its constructor values.
+    @discardableResult
+    func resolveLaunchSeed() -> LaunchSeed {
+        guard let provider = launchSeed else {
+            return LaunchSeed(command: command, initialInput: initialInput, waitAfterCommand: waitAfterCommand)
+        }
+        launchSeed = nil
+        let seed = provider.resolve(isSplitPane ? .right : .left)
+        command = seed.command
+        initialInput = seed.initialInput
+        waitAfterCommand = seed.waitAfterCommand
+        return seed
+    }
+
     /// Marks the surface focused in libghostty after a retried `makeFirstResponder` (the overlay/reparent
     /// grabs). By now `window.firstResponder === self`, so `updateGhosttyFocus` reports the true state.
     private func notifySurfaceFocused() {
@@ -761,6 +788,8 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     }
 
     func destroySurface() {
+        // a pane torn down before it spawned must not consume its pending slots; the session keeps them.
+        launchSeed = nil
         cancelPendingRendererVisibility()
         hiddenJanitorTask?.cancel()
         hiddenJanitorTask = nil

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -205,7 +205,11 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     /// first responder on attach, so without this gate one opened in a BACKGROUND session would steal the
     /// keyboard from the visible one; `TerminalView` sets it before `createSurface`, and going inactive
     /// mid-retry bails the loop. Inert for main/split panes, which take focus via `focusIfNeeded`.
-    var deckActive = true
+    var deckActive = true {
+        // the user is looking at this pane, so it goes to the front of a paced launch. a no-op when
+        // unpaced, granted or already expedited, so the per-update rewrites mint nothing.
+        didSet { if deckActive { expediteSpawn() } }
+    }
 
     /// Whether this surface's deck slot is on-screen (session selected, not hidden by a full overlay/scratch).
     /// Unlike `deckActive` it is not split-pane-focus-gated, so both panes of a visible split are
@@ -715,6 +719,20 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     func useSpawnPacer(_ pacer: SpawnPacer, key: UUID) {
         spawnPacer = pacer
         spawnKey = key
+    }
+
+    /// Moves this pane to the front of a paced launch and grants it now. A no-op for an unpaced pane and
+    /// for a key already granted or expedited, so a caller may repeat it freely.
+    func expediteSpawn() {
+        guard let spawnPacer, let spawnKey else { return }
+        spawnPacer.expedite(spawnKey)
+    }
+
+    /// Moves the queued panes among `views` to the front, in that order, releasing none: a dashboard
+    /// opening on many queued members fills its cells at the paced rate rather than in one burst.
+    static func prioritizeSpawn(_ views: [GhosttySurfaceView]) {
+        guard let pacer = views.lazy.compactMap(\.spawnPacer).first else { return }
+        pacer.prioritize(views.compactMap { $0.spawnPacer === pacer ? $0.spawnKey : nil })
     }
 
     /// Whether the surface may spawn now. False leaves the pane queued and the caller returns: the pacer

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -205,11 +205,7 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     /// first responder on attach, so without this gate one opened in a BACKGROUND session would steal the
     /// keyboard from the visible one; `TerminalView` sets it before `createSurface`, and going inactive
     /// mid-retry bails the loop. Inert for main/split panes, which take focus via `focusIfNeeded`.
-    var deckActive = true {
-        // the user is looking at this pane, so it goes to the front of a paced launch. a no-op when
-        // unpaced, granted or already expedited, so the per-update rewrites mint nothing.
-        didSet { if deckActive { expediteSpawn() } }
-    }
+    var deckActive = true
 
     /// Whether this surface's deck slot is on-screen (session selected, not hidden by a full overlay/scratch).
     /// Unlike `deckActive` it is not split-pane-focus-gated, so both panes of a visible split are
@@ -221,6 +217,11 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     /// the cursor. `didSet` (un)registers the drag types and the mouse-tracking area for the same reason.
     var deckVisible = true {
         didSet {
+            // the user is looking at this pane, so it goes to the front of a paced launch; a no-op when
+            // unpaced, granted or already expedited, so the per-update rewrites mint nothing. ahead of the
+            // equality guard because the first mount writes true over the default true. `deckActive` is
+            // split-focus-gated and would leave the other half of a shown split queued.
+            if deckVisible { expediteSpawn() }
             // `TerminalView` assigns this on every SwiftUI update pass, so skip the tracking-area teardown/
             // rebuild + drag re-registration unless the visibility actually flipped.
             guard deckVisible != oldValue else { return }

--- a/agterm/Ghostty/LaunchSeed.swift
+++ b/agterm/Ghostty/LaunchSeed.swift
@@ -1,0 +1,171 @@
+import agtermCore
+import Foundation
+
+/// What a pane spawns with: the exec `command`, the `initialInput` typed into a login shell, and whether a
+/// command's exit holds on libghostty's "press any key" prompt. `command` and `initialInput` are mutually
+/// exclusive except on a zmx-backed pane, whose command is the attach client.
+struct LaunchSeed: Equatable {
+    let command: String?
+    let initialInput: String?
+    let waitAfterCommand: Bool
+}
+
+/// A pane's seed, computed at SPAWN time rather than at construction, so the captured argv and the
+/// `session.restore` pin stay on the `Session` — clearable and preservable — throughout the wait for a
+/// spawn permit. `shouldPace` answers "would this pane start a program" without consuming anything.
+struct LaunchSeedProvider {
+    let shouldPace: Bool
+    /// Takes the pane's LIVE role, never the one it was built in: `session.swap` moves a mounted surface to
+    /// the other slot and swaps the pending payloads with it, so a captured role would read the other
+    /// terminal's argv.
+    let resolve: @MainActor (StatusPane) -> LaunchSeed
+}
+
+/// The launch-wide inputs a pane's seed is decided against: whether this process replays commands at all,
+/// the user's `restore-denylist.conf`, and the daemon names the launch reap observed alive. `runningNames`
+/// is a SCHEDULING hint only: nil (the list failed) paces every replaying live pane, and a name that died
+/// between the list and the attach merely spawns unpaced.
+struct LaunchSeedPolicy {
+    let restoreEnabled: Bool
+    let denylist: Set<String>
+    let runningNames: Set<String>?
+}
+
+extension LaunchSeedProvider {
+    /// The provider for one restored or created pane. `resolve` is the factory's own seed computation for
+    /// this disposition, so `ZmxLaunch.surfaceSeed` and `CommandRestore.restorePlan` precedence is
+    /// unchanged; only when it runs moves. The session is captured WEAKLY: the view it ends up on is held
+    /// by that session, so a strong capture would leak every pane destroyed before it spawned.
+    @MainActor
+    static func pane(session: Session, pane: StatusPane, disposition: ZmxLaunch.Disposition,
+                     policy: LaunchSeedPolicy) -> LaunchSeedProvider {
+        let paces = shouldPace(session: session, pane: pane, disposition: disposition, policy: policy)
+        return LaunchSeedProvider(shouldPace: paces) { [weak session] livePane in
+            guard let session else { return unownedSeed(disposition: disposition) }
+            return seed(session: session, pane: livePane, disposition: disposition, policy: policy)
+        }
+    }
+
+    @MainActor
+    private static func seed(session: Session, pane: StatusPane, disposition: ZmxLaunch.Disposition,
+                             policy: LaunchSeedPolicy) -> LaunchSeed {
+        switch disposition {
+        case .wrapped:
+            guard let seed = ZmxLaunch.surfaceSeed(disposition: disposition, session: session, pane: pane,
+                                                   denylist: policy.denylist)
+            else { preconditionFailure("wrapped zmx disposition has no surface seed") }
+            return LaunchSeed(command: seed.command, initialInput: seed.initialInput, waitAfterCommand: false)
+        case .ordinary:
+            let capture = session.takePendingForegroundCommand(pane: pane)
+            let plan = CommandRestore.restorePlan(.init(
+                wasRestored: session.wasRestored,
+                restoreEnabled: policy.restoreEnabled,
+                hadForeground: capture != nil,
+                foregroundInput: restoreInitialInput(capture, policy: policy),
+                initialCommand: durableCommand(session: session, pane: pane),
+                restoreOverride: session.takePendingRestoreOverride(pane: pane),
+                requestedWait: requestedWait(session: session, pane: pane)))
+            return LaunchSeed(command: plan.command, initialInput: plan.initialInput,
+                              waitAfterCommand: plan.waitAfterCommand)
+        case .fallback:
+            // live was requested and is unavailable: neither pending slot is read, so both stay armed for
+            // the next launch, and the durable command is held back exactly as a restored rerun-off pane.
+            let plan = CommandRestore.restorePlan(.init(
+                wasRestored: session.wasRestored,
+                restoreEnabled: false,
+                hadForeground: false,
+                foregroundInput: nil,
+                initialCommand: durableCommand(session: session, pane: pane),
+                restoreOverride: nil,
+                requestedWait: requestedWait(session: session, pane: pane)))
+            return LaunchSeed(command: plan.command, initialInput: plan.initialInput,
+                              waitAfterCommand: plan.waitAfterCommand)
+        }
+    }
+
+    /// Whether this pane's seed would start a program, peeking the slots its disposition will read without
+    /// consuming any of them. Only a RESTORED pane qualifies: fresh and runtime panes are never queued, so
+    /// their host attachment must not wait on a permit.
+    @MainActor
+    private static func shouldPace(session: Session, pane: StatusPane, disposition: ZmxLaunch.Disposition,
+                                   policy: LaunchSeedPolicy) -> Bool {
+        guard session.wasRestored else { return false }
+        switch disposition {
+        case .wrapped(let configuration):
+            // an observed daemon is attached to, which runs no program.
+            if policy.runningNames?.contains(configuration.daemonName) == true { return false }
+            // the pending `session.restore` pin is deliberately absent: `surfaceSeed` never reads it.
+            if let capture = peekCapture(session: session, pane: pane) {
+                return CommandRestore.shouldRestore(argv: capture, denylist: policy.denylist)
+            }
+            return durableCommand(session: session, pane: pane) != nil
+        case .ordinary:
+            let capture = peekCapture(session: session, pane: pane)
+            let plan = CommandRestore.restorePlan(.init(
+                wasRestored: true,
+                restoreEnabled: policy.restoreEnabled,
+                hadForeground: capture != nil,
+                foregroundInput: restoreInitialInput(capture, policy: policy),
+                initialCommand: durableCommand(session: session, pane: pane),
+                restoreOverride: peekRestoreOverride(session: session, pane: pane),
+                requestedWait: false))
+            return plan.command != nil || plan.initialInput != nil
+        case .fallback:
+            return false
+        }
+    }
+
+    /// The seed for a view whose session is already gone: a plain shell, or a bare attach for a wrapped
+    /// pane, since the daemon name is the only thing left that can be honored.
+    private static func unownedSeed(disposition: ZmxLaunch.Disposition) -> LaunchSeed {
+        guard case .wrapped(let configuration) = disposition else {
+            return LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        }
+        return LaunchSeed(command: configuration.command, initialInput: nil, waitAfterCommand: false)
+    }
+
+    /// The `initial_input` for a restored pane: the captured foreground argv re-rendered as a shell command
+    /// line + newline, or nil outside rerun mode or when `shouldRestore` refuses the argv — a denylisted
+    /// basename, a control character, or a lossily-decoded byte (→ plain shell).
+    private static func restoreInitialInput(_ argv: [String]?, policy: LaunchSeedPolicy) -> String? {
+        guard policy.restoreEnabled, let argv,
+              CommandRestore.shouldRestore(argv: argv, denylist: policy.denylist) else { return nil }
+        return CommandRestore.shellQuotedLine(argv) + "\n"
+    }
+
+    @MainActor
+    private static func peekCapture(session: Session, pane: StatusPane) -> [String]? {
+        switch pane {
+        case .left: session.pendingForegroundCommand
+        case .right: session.pendingSplitForegroundCommand
+        case .scratch: nil
+        }
+    }
+
+    @MainActor
+    private static func peekRestoreOverride(session: Session, pane: StatusPane) -> String? {
+        switch pane {
+        case .left: session.pendingRestoreCommand
+        case .right: session.pendingSplitRestoreCommand
+        case .scratch: nil
+        }
+    }
+
+    @MainActor
+    private static func durableCommand(session: Session, pane: StatusPane) -> String? {
+        switch pane {
+        case .left: session.initialCommand
+        case .right: session.splitInitialCommand
+        case .scratch: nil
+        }
+    }
+
+    @MainActor
+    private static func requestedWait(session: Session, pane: StatusPane) -> Bool {
+        switch pane {
+        case .left: session.commandWait
+        case .right: session.splitCommandWait
+        case .scratch: false
+        }
+    }
+}

--- a/agterm/Ghostty/SpawnRegistry.swift
+++ b/agterm/Ghostty/SpawnRegistry.swift
@@ -1,0 +1,51 @@
+import agtermCore
+import Foundation
+
+/// Turns a `SpawnPacer` grant back into a spawn. The pacer is host-free and knows only pane keys, so the
+/// app owns one registry that maps a granted key to the view waiting on it and re-enters `createSurface()`.
+///
+/// Entries are WEAK. A queued pane the user closed, or one whose window went away before its turn, must be
+/// dropped rather than resurrected by its own grant, and the view must never keep the launch queue alive.
+@MainActor
+final class SpawnRegistry {
+    /// The pacer this registry routes for. Unarmed until a launch restore arms it, and passthrough again
+    /// once the queue drains, so a pane created later never waits.
+    let pacer: SpawnPacer
+
+    private struct Entry {
+        weak var view: GhosttySurfaceView?
+    }
+
+    private var entries: [UUID: Entry] = [:]
+
+    init(pacer: SpawnPacer) {
+        self.pacer = pacer
+        pacer.onGrant = { [weak self] key in self?.grant(key) }
+    }
+
+    /// Queues `view` under `key` when its provider says the pane replays a program, and otherwise drops the
+    /// key from the expected order. Arming runs before any provider exists, so a pane that spawns unpaced
+    /// must discard its key or the queue waits on a request it will never make. A pane with no key — a fresh
+    /// or runtime split — was never expected and needs neither.
+    func enqueue(_ view: GhosttySurfaceView, key: UUID?, provider: LaunchSeedProvider) {
+        guard let key else { return }
+        guard provider.shouldPace else {
+            pacer.discard(key)
+            return
+        }
+        entries[key] = Entry(view: view)
+        view.useSpawnPacer(pacer, key: key)
+    }
+
+    /// The pane queued under `key`, nil once it is granted or its view deallocates.
+    func view(for key: UUID) -> GhosttySurfaceView? { entries[key]?.view }
+
+    /// Spawns the granted pane against the bounds it has NOW and forgets it: a key is granted once, and a
+    /// view already gone is simply dropped. Only a pane DENIED earlier is resumed here. A burst or expedited
+    /// key is granted synchronously inside the pane's own request, while its `createSurface` is still on
+    /// the stack, and that caller consumes the grant; re-entering would spawn the surface twice.
+    func grant(_ key: UUID) {
+        guard let view = entries.removeValue(forKey: key)?.view, view.awaitingSpawnPermit else { return }
+        view.createSurface()
+    }
+}

--- a/agterm/Ghostty/ZmxClient.swift
+++ b/agterm/Ghostty/ZmxClient.swift
@@ -38,33 +38,43 @@ final class ZmxClient {
         self.runner = runner
     }
 
+    /// What the launch reap learned. `runningNames` is every daemon whose client count the listing could
+    /// read, alive with or without a client, so an unreadable `err=` row is absent and its pane paces like
+    /// a missing daemon; nil when the list was skipped, failed or did not parse. `killedAll` is whether
+    /// every orphan it chose to kill was confirmed gone.
+    struct ReapOutcome: Equatable {
+        let runningNames: Set<String>?
+        let killedAll: Bool
+    }
+
     @discardableResult
-    func reap(knownPaneIdentities: Set<UUID>?, launchDecision: RestoreLaunchDecision) -> Bool {
+    func reap(knownPaneIdentities: Set<UUID>?, launchDecision: RestoreLaunchDecision) -> ReapOutcome {
         let requestedMode = launchDecision.requested
         if requestedMode == .live, knownPaneIdentities == nil {
             Self.logger.error("skipping live zmx reap because the persisted pane inventory is incomplete")
-            return true
+            return ReapOutcome(runningNames: nil, killedAll: true)
         }
         let output: String
         do {
             output = try invoke(["list"])
         } catch {
             Self.logger.error("zmx list failed during launch reap: \(String(describing: error), privacy: .public)")
-            return false
+            return ReapOutcome(runningNames: nil, killedAll: false)
         }
         let sessions: [ZmxSessionRecord]
         do {
             sessions = try ZmxListParser.parse(output)
         } catch {
             Self.logger.error("zmx list output was incomplete: \(String(describing: error), privacy: .public)")
-            return false
+            return ReapOutcome(runningNames: nil, killedAll: false)
         }
+        let running = Set(sessions.filter { $0.clients != nil }.map(\.name))
         let knownNames = knownPaneIdentities.map { Set($0.map(ZmxSupport.daemonName(for:))) }
         guard let names = ZmxReapPolicy.namesToKill(
             sessions: sessions, requestedMode: requestedMode, knownNames: knownNames) else {
-            return true
+            return ReapOutcome(runningNames: running, killedAll: true)
         }
-        return kill(names: names)
+        return ReapOutcome(runningNames: running, killedAll: kill(names: names))
     }
 
     @discardableResult

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -53,6 +53,15 @@ struct DashboardView: View {
     /// caption text opacity on an UNSELECTED cell, so the highlighted cell's name stands out.
     private static let unselectedCaptionTextOpacity: Double = 0.55
 
+    /// Puts the members' queued panes at the front of a paced launch, in grid order, releasing none: the
+    /// cells still fill one interval apart. Each pane ref resolves to the slot its cell hosts.
+    static func prioritizeSpawns(of members: [DashboardMember], in store: AppStore) {
+        GhosttySurfaceView.prioritizeSpawn(members.compactMap { member in
+            guard let session = store.session(withID: member.session) else { return nil }
+            return (member.surface == .split ? session.splitSurface : session.surface) as? GhosttySurfaceView
+        })
+    }
+
     var body: some View {
         let members = controller.members
         let (cols, rows) = DashboardLayout.grid(count: members.count)
@@ -66,6 +75,7 @@ struct DashboardView: View {
             }
         }
         .padding(Self.gridSpacing)
+        .onChange(of: members, initial: true) { Self.prioritizeSpawns(of: members, in: store) }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         // an OPAQUE themed backdrop: the layer beneath (sidebar, add-buttons, deck) must not bleed through
         // the margins, deliberately dropping window translucency/blur. Not a black scrim — over the

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -30,6 +30,11 @@ struct agtermApp: App {
     private let zmxForegroundResolver: ZmxForegroundResolver?
     private let captureOnExit: AppDelegate.ExitCapture?
 
+    /// The launch spawn queue and the routing of its grants, handed to both pane factories. It stays UNARMED
+    /// here, so every pane spawns on request exactly as it did before pacing existed; a launch restore is
+    /// what arms it.
+    private let spawnRegistry = SpawnRegistry(pacer: SpawnPacer())
+
     /// The plain `WindowGroup`'s scene id, used by `openWindow(id:)` to spawn additional windows.
     private static let windowGroupID = "terminal"
 
@@ -109,13 +114,11 @@ struct agtermApp: App {
                     library: library,
                     makeSurface: {
                         Self.makeSurface(for: $0, store: $1,
-                                         env: surfaceEnv(for: $0, pane: .left), library: library,
-                                         zmxForegroundResolver: zmxForegroundResolver)
+                                         env: surfaceEnv(for: $0, pane: .left), services: surfaceServices)
                     },
                     makeSplitSurface: {
                         Self.makeSplitSurface(for: $0, store: $1,
-                                              env: surfaceEnv(for: $0, pane: .right), library: library,
-                                              zmxForegroundResolver: zmxForegroundResolver)
+                                              env: surfaceEnv(for: $0, pane: .right), services: surfaceServices)
                     },
                     makeOverlaySurface: {
                         Self.makeOverlaySurface(for: $0, store: $1, pane: $2, env: surfaceEnv(for: $0))
@@ -286,13 +289,23 @@ struct agtermApp: App {
         store.setFontSize(sessionID, size)
     }
 
+    /// App-owned services every pane factory wires into the view it builds.
+    struct SurfaceServices {
+        let library: WindowLibrary
+        let zmxForegroundResolver: ZmxForegroundResolver?
+        let spawnRegistry: SpawnRegistry?
+    }
+
+    private var surfaceServices: SurfaceServices {
+        SurfaceServices(library: library, zmxForegroundResolver: zmxForegroundResolver, spawnRegistry: spawnRegistry)
+    }
+
     /// Surface factory: a libghostty-backed view for the session, spawning a login shell in its initial working
     /// directory. On shell exit the view calls back to close the owning session in the store.
     /// Internal rather than private: `SurfaceFactorySeedTests` drives it to pin the launch-seed wiring.
     @MainActor
     static func makeSurface(for session: Session, store: AppStore, env: [String: String],
-                            library: WindowLibrary,
-                            zmxForegroundResolver: ZmxForegroundResolver?) -> GhosttySurfaceView {
+                            services: SurfaceServices) -> GhosttySurfaceView {
         // GhosttyApp resolved resources and latched restore mode before WindowLibrary assembled the launch
         // inventory, so every later factory reads the same process policy and GHOSTTY_RESOURCES_DIR.
         let ghostty = GhosttyApp.shared
@@ -307,17 +320,19 @@ struct agtermApp: App {
             : nil
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,
                                                 active: ghostty.launchRestoreMode, configuration: zmx)
-        if disposition.backedByZmx { zmxForegroundResolver?.noteLifecycleChange() }
+        if disposition.backedByZmx { services.zmxForegroundResolver?.noteLifecycleChange() }
         let view = GhosttySurfaceView(workingDirectory: session.initialCwd, fontSize: session.fontSize.map(Float.init),
                                       env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
-        view.launchSeed = LaunchSeedProvider.pane(session: session, pane: .left, disposition: disposition,
-                                                  policy: Self.launchSeedPolicy(ghostty))
+        let provider = LaunchSeedProvider.pane(session: session, pane: .left, disposition: disposition,
+                                               policy: Self.launchSeedPolicy(ghostty))
+        view.launchSeed = provider
+        services.spawnRegistry?.enqueue(view, key: session.paneIdentity, provider: provider)
         view.session = session
         let sessionID = session.id
         view.onExit = { [weak view] in
             guard let view else { return }
-            Self.handlePaneExit(view, store: store, sessionID: sessionID, library: library)
+            Self.handlePaneExit(view, store: store, sessionID: sessionID, library: services.library)
         }
         view.onFocusChange = { [weak view] focused in
             guard let splitFocused = Self.focusedSplitState(focused, surface: view) else { return }
@@ -337,7 +352,7 @@ struct agtermApp: App {
         view.onFontSizeChange = { [weak view] size in
             Self.persistFontSize(size, from: view, store: store, sessionID: sessionID)
         }
-        Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
+        Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: services.library)
         return view
     }
 
@@ -458,8 +473,7 @@ struct agtermApp: App {
     /// Internal rather than private: `SurfaceFactorySeedTests` drives it to pin the launch-seed wiring.
     @MainActor
     static func makeSplitSurface(for session: Session, store: AppStore, env: [String: String],
-                                 library: WindowLibrary,
-                                 zmxForegroundResolver: ZmxForegroundResolver?) -> GhosttySurfaceView {
+                                 services: SurfaceServices) -> GhosttySurfaceView {
         // cwd is the persisted `initialSplitCwd` (a restored split keeps its own directory), else the session's
         // effectiveCwd. Font size matches the primary; env inherits the parent's window/workspace/session ids.
         // Creation, capture and override precedence matches the primary.
@@ -469,19 +483,21 @@ struct agtermApp: App {
             : nil
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,
                                                 active: ghostty.launchRestoreMode, configuration: zmx)
-        if disposition.backedByZmx { zmxForegroundResolver?.noteLifecycleChange() }
+        if disposition.backedByZmx { services.zmxForegroundResolver?.noteLifecycleChange() }
         let view = GhosttySurfaceView(workingDirectory: session.initialSplitCwd ?? session.effectiveCwd,
                                       fontSize: session.fontSize.map(Float.init),
                                       env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
-        view.launchSeed = LaunchSeedProvider.pane(session: session, pane: .right, disposition: disposition,
-                                                  policy: Self.launchSeedPolicy(ghostty))
+        let provider = LaunchSeedProvider.pane(session: session, pane: .right, disposition: disposition,
+                                               policy: Self.launchSeedPolicy(ghostty))
+        view.launchSeed = provider
+        services.spawnRegistry?.enqueue(view, key: session.splitPaneIdentity, provider: provider)
         view.session = session
         view.isSplitPane = true
         let sessionID = session.id
         view.onExit = { [weak view] in
             guard let view else { return }
-            Self.handlePaneExit(view, store: store, sessionID: sessionID, library: library)
+            Self.handlePaneExit(view, store: store, sessionID: sessionID, library: services.library)
         }
         view.onFocusChange = { [weak view] focused in
             guard let splitFocused = Self.focusedSplitState(focused, surface: view) else { return }
@@ -499,7 +515,7 @@ struct agtermApp: App {
         view.onFontSizeChange = { [weak view] size in
             Self.persistFontSize(size, from: view, store: store, sessionID: sessionID)
         }
-        Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
+        Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: services.library)
         return view
     }
 

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -288,10 +288,11 @@ struct agtermApp: App {
 
     /// Surface factory: a libghostty-backed view for the session, spawning a login shell in its initial working
     /// directory. On shell exit the view calls back to close the owning session in the store.
+    /// Internal rather than private: `SurfaceFactorySeedTests` drives it to pin the launch-seed wiring.
     @MainActor
-    private static func makeSurface(for session: Session, store: AppStore, env: [String: String],
-                                    library: WindowLibrary,
-                                    zmxForegroundResolver: ZmxForegroundResolver?) -> GhosttySurfaceView {
+    static func makeSurface(for session: Session, store: AppStore, env: [String: String],
+                            library: WindowLibrary,
+                            zmxForegroundResolver: ZmxForegroundResolver?) -> GhosttySurfaceView {
         // GhosttyApp resolved resources and latched restore mode before WindowLibrary assembled the launch
         // inventory, so every later factory reads the same process policy and GHOSTTY_RESOURCES_DIR.
         let ghostty = GhosttyApp.shared
@@ -299,64 +300,19 @@ struct agtermApp: App {
         // (like kitty); it is the durable creation identity, re-emitted by every `snapshot()`. `foregroundCommand`,
         // a distinct child captured at quit, is consumed run-once; an exec-replacing command has a nil libghostty
         // foreground pid, so it is never captured and restores via the exec `command` path, keeping close-on-exit.
-        // On the ordinary path, precedence is host-free `CommandRestore.restorePlan`: fresh always runs, restored
-        // honors rerun mode, and a captured foreground preempts `initialCommand` even when denylist-suppressed. A
-        // `session.restore` override beats both from the TRANSIENT pending slot. A wrapped live pane consumes only
-        // its captured foreground argv; zmx ignores that create-only payload when the daemon survived.
+        // `LaunchSeedProvider` owns the precedence between them and resolves it at spawn time, not here, so
+        // the pending slots stay on the session until the pane really spawns.
         let zmx = ghostty.launchRestoreMode == .live
             ? ZmxLaunch.configuration(paneIdentity: session.paneIdentity, pane: "primary", environment: env)
             : nil
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,
                                                 active: ghostty.launchRestoreMode, configuration: zmx)
         if disposition.backedByZmx { zmxForegroundResolver?.noteLifecycleChange() }
-        let command: String?
-        let initialInput: String?
-        let waitAfterCommand: Bool
-        let surfaceEnv: [String: String]
-        switch disposition {
-        case .wrapped(let zmx):
-            guard let seed = ZmxLaunch.surfaceSeed(
-                disposition: disposition, session: session, pane: .left, denylist: ghostty.restoreDenylist
-            ) else { preconditionFailure("wrapped zmx disposition has no surface seed") }
-            command = seed.command
-            initialInput = seed.initialInput
-            waitAfterCommand = false
-            surfaceEnv = zmx.environment
-        case .ordinary:
-            let pendingForeground = session.takePendingForegroundCommand(pane: .left)
-            let restoreInput = Self.restoreInitialInput(pendingForeground)
-            let inputs = CommandRestore.RestoreInputs(
-                wasRestored: session.wasRestored,
-                restoreEnabled: ghostty.restoreRunningCommand,
-                hadForeground: pendingForeground != nil,
-                foregroundInput: restoreInput,
-                initialCommand: session.initialCommand,
-                restoreOverride: session.takePendingRestoreOverride(pane: .left),
-                requestedWait: session.commandWait
-            )
-            let plan = CommandRestore.restorePlan(inputs)
-            command = plan.command
-            initialInput = plan.initialInput
-            waitAfterCommand = plan.waitAfterCommand
-            surfaceEnv = env
-        case .fallback:
-            let plan = CommandRestore.restorePlan(.init(
-                wasRestored: session.wasRestored,
-                restoreEnabled: false,
-                hadForeground: false,
-                foregroundInput: nil,
-                initialCommand: session.initialCommand,
-                restoreOverride: nil,
-                requestedWait: session.commandWait))
-            command = plan.command
-            initialInput = plan.initialInput
-            waitAfterCommand = plan.waitAfterCommand
-            surfaceEnv = env
-        }
         let view = GhosttySurfaceView(workingDirectory: session.initialCwd, fontSize: session.fontSize.map(Float.init),
-                                      command: command, initialInput: initialInput,
-                                      waitAfterCommand: waitAfterCommand, env: surfaceEnv,
+                                      env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
+        view.launchSeed = LaunchSeedProvider.pane(session: session, pane: .left, disposition: disposition,
+                                                  policy: Self.launchSeedPolicy(ghostty))
         view.session = session
         let sessionID = session.id
         view.onExit = { [weak view] in
@@ -414,15 +370,20 @@ struct agtermApp: App {
         (target as? GhosttySurfaceView)?.focusAfterReparent()
     }
 
-    /// The `initial_input` for a restored pane: the captured foreground argv re-rendered as a shell command
-    /// line + newline, or nil outside rerun mode or when `shouldRestore` refuses the
-    /// argv — a denylisted basename, a control character, or a lossily-decoded byte (→ plain shell). The
-    /// denylist is the user's `restore-denylist.conf`, parsed at launch into `GhosttyApp.shared.restoreDenylist`.
+    /// This launch's replay policy, latched before the deck mounted: the rerun master switch and the user's
+    /// `restore-denylist.conf`.
     @MainActor
-    private static func restoreInitialInput(_ argv: [String]?) -> String? {
-        guard GhosttyApp.shared.restoreRunningCommand, let argv,
-              CommandRestore.shouldRestore(argv: argv, denylist: GhosttyApp.shared.restoreDenylist) else { return nil }
-        return CommandRestore.shellQuotedLine(argv) + "\n"
+    private static func launchSeedPolicy(_ ghostty: GhosttyApp) -> LaunchSeedPolicy {
+        LaunchSeedPolicy(restoreEnabled: ghostty.restoreRunningCommand, denylist: ghostty.restoreDenylist,
+                         runningNames: nil)
+    }
+
+    /// A wrapped pane's shell environment is zmx's own; every other disposition inherits the pane env.
+    /// Fixed at construction like `backedByZmx`, because the disposition is.
+    private static func surfaceEnv(disposition: ZmxLaunch.Disposition,
+                                   fallback: [String: String]) -> [String: String] {
+        guard case .wrapped(let zmx) = disposition else { return fallback }
+        return zmx.environment
     }
 
     /// Wires the four `onSearch*` callbacks to the owning session's search fields, resolved live via `sessionID`.
@@ -494,14 +455,14 @@ struct agtermApp: App {
     /// Split-pane surface factory: a second independent login shell in the session's current directory, wired as
     /// `isSplitPane` so its PWD/title reports go to `session.splitCwd`/`splitTitle` and its shell exit closes
     /// just the split (hide + teardown), not the session.
+    /// Internal rather than private: `SurfaceFactorySeedTests` drives it to pin the launch-seed wiring.
     @MainActor
-    private static func makeSplitSurface(for session: Session, store: AppStore, env: [String: String],
-                                         library: WindowLibrary,
-                                         zmxForegroundResolver: ZmxForegroundResolver?) -> GhosttySurfaceView {
+    static func makeSplitSurface(for session: Session, store: AppStore, env: [String: String],
+                                 library: WindowLibrary,
+                                 zmxForegroundResolver: ZmxForegroundResolver?) -> GhosttySurfaceView {
         // cwd is the persisted `initialSplitCwd` (a restored split keeps its own directory), else the session's
         // effectiveCwd. Font size matches the primary; env inherits the parent's window/workspace/session ids.
-        // Creation, capture and override precedence matches the primary. A wrapped live pane passes its captured
-        // command as a create-only payload, so an existing daemon wins without replaying it.
+        // Creation, capture and override precedence matches the primary.
         let ghostty = GhosttyApp.shared
         let zmx = ghostty.launchRestoreMode == .live
             ? ZmxLaunch.configuration(paneIdentity: session.splitPaneIdentity, pane: "split", environment: env)
@@ -509,51 +470,12 @@ struct agtermApp: App {
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,
                                                 active: ghostty.launchRestoreMode, configuration: zmx)
         if disposition.backedByZmx { zmxForegroundResolver?.noteLifecycleChange() }
-        let command: String?
-        let initialInput: String?
-        let waitAfterCommand: Bool
-        let surfaceEnv: [String: String]
-        switch disposition {
-        case .wrapped(let zmx):
-            guard let seed = ZmxLaunch.surfaceSeed(
-                disposition: disposition, session: session, pane: .right, denylist: ghostty.restoreDenylist
-            ) else { preconditionFailure("wrapped zmx disposition has no surface seed") }
-            command = seed.command
-            initialInput = seed.initialInput
-            waitAfterCommand = false
-            surfaceEnv = zmx.environment
-        case .ordinary:
-            let pendingForeground = session.takePendingForegroundCommand(pane: .right)
-            let plan = CommandRestore.restorePlan(.init(
-                wasRestored: session.wasRestored,
-                restoreEnabled: ghostty.restoreRunningCommand,
-                hadForeground: pendingForeground != nil,
-                foregroundInput: Self.restoreInitialInput(pendingForeground),
-                initialCommand: session.splitInitialCommand,
-                restoreOverride: session.takePendingRestoreOverride(pane: .right),
-                requestedWait: session.splitCommandWait))
-            command = plan.command
-            initialInput = plan.initialInput
-            waitAfterCommand = plan.waitAfterCommand
-            surfaceEnv = env
-        case .fallback:
-            let plan = CommandRestore.restorePlan(.init(
-                wasRestored: session.wasRestored,
-                restoreEnabled: false,
-                hadForeground: false,
-                foregroundInput: nil,
-                initialCommand: session.splitInitialCommand,
-                restoreOverride: nil,
-                requestedWait: session.splitCommandWait))
-            command = plan.command
-            initialInput = plan.initialInput
-            waitAfterCommand = plan.waitAfterCommand
-            surfaceEnv = env
-        }
         let view = GhosttySurfaceView(workingDirectory: session.initialSplitCwd ?? session.effectiveCwd,
-                                      fontSize: session.fontSize.map(Float.init), command: command,
-                                      initialInput: initialInput, waitAfterCommand: waitAfterCommand, env: surfaceEnv,
+                                      fontSize: session.fontSize.map(Float.init),
+                                      env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
+        view.launchSeed = LaunchSeedProvider.pane(session: session, pane: .right, disposition: disposition,
+                                                  policy: Self.launchSeedPolicy(ghostty))
         view.session = session
         view.isSplitPane = true
         let sessionID = session.id

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -36,7 +36,7 @@ struct agtermApp: App {
     /// The launch spawn queue and the routing of its grants, handed to both pane factories. It stays UNARMED
     /// here, so every pane spawns on request exactly as it did before pacing existed; a launch restore is
     /// what arms it.
-    private let spawnRegistry = SpawnRegistry(pacer: SpawnPacer())
+    private let spawnRegistry: SpawnRegistry
     private let launchContext: LaunchSpawnContext
 
     /// The plain `WindowGroup`'s scene id, used by `openWindow(id:)` to spawn additional windows.
@@ -67,7 +67,11 @@ struct agtermApp: App {
         // FIRST, before anything reads or writes the state directory: `WindowLibrary`'s bootstrap seeds a
         // window and saves it, which a later read would see as evidence of an earlier launch.
         let hadPriorState = FirstRunWelcome.hasPriorState(in: stateDirectory)
-        let restored = agtermApp.restoredRuntime(stateDirectory: stateDirectory)
+        // the pacer exists before the library so the model can discard the key of a pane it removes before
+        // that pane's window ever mounts; the registry that routes grants comes after
+        let pacer = SpawnPacer()
+        let restored = agtermApp.restoredRuntime(stateDirectory: stateDirectory, pacer: pacer)
+        spawnRegistry = SpawnRegistry(pacer: pacer)
         let library = restored.library
         zmxForegroundResolver = restored.foregroundResolver
         launchContext = restored.spawnContext
@@ -264,7 +268,7 @@ struct agtermApp: App {
 
     /// Builds the window library and zmx foreground resolver for the state directory. Bootstrap
     /// migrates/recovers persisted windows and inventories claimed pane identities before surfaces mount.
-    private static func restoredRuntime(stateDirectory: URL) -> RestoredRuntime {
+    private static func restoredRuntime(stateDirectory: URL, pacer: SpawnPacer) -> RestoredRuntime {
         guard !isHostedUnitTest else {
             return RestoredRuntime(library: WindowLibrary(directory: stateDirectory),
                                    foregroundResolver: nil, zmxClient: nil, spawnContext: LaunchSpawnContext())
@@ -287,6 +291,9 @@ struct agtermApp: App {
                 context.runningNames = client.reap(knownPaneIdentities: $0,
                                                    launchDecision: ghostty.restoreLaunchDecision).runningNames
                 foregroundResolver.noteLifecycleChange()
+            },
+            launchPaneDrop: { identities in
+                for identity in identities { pacer.discard(identity) }
             })
         return RestoredRuntime(library: library, foregroundResolver: foregroundResolver, zmxClient: client,
                                spawnContext: context)

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -1,6 +1,9 @@
 import agtermCore
 import Foundation
+import os
 import SwiftUI
+
+private let logger = Logger(subsystem: "com.umputun.agterm", category: "agtermApp")
 
 @main
 struct agtermApp: App {
@@ -34,6 +37,7 @@ struct agtermApp: App {
     /// here, so every pane spawns on request exactly as it did before pacing existed; a launch restore is
     /// what arms it.
     private let spawnRegistry = SpawnRegistry(pacer: SpawnPacer())
+    private let launchContext: LaunchSpawnContext
 
     /// The plain `WindowGroup`'s scene id, used by `openWindow(id:)` to spawn additional windows.
     private static let windowGroupID = "terminal"
@@ -66,6 +70,7 @@ struct agtermApp: App {
         let restored = agtermApp.restoredRuntime(stateDirectory: stateDirectory)
         let library = restored.library
         zmxForegroundResolver = restored.foregroundResolver
+        launchContext = restored.spawnContext
         _library = State(initialValue: library)
         let actions = AppActions(library: library)
         _actions = State(initialValue: actions)
@@ -100,6 +105,16 @@ struct agtermApp: App {
         // re-attempts surface creation on display wake: libghostty refuses to create one while the display
         // sleeps, which leaves a scheduled job's session realized-never and its --command unrun (#416).
         _wakeObserver = State(initialValue: SystemWakeObserver())
+        // the library restored the model and ran the reap inside its init, and no window has mounted yet;
+        // arm records expectations only, so nothing here waits on a view.
+        if !Self.isHostedUnitTest {
+            let plan = library.launchSpawnPlan()
+            spawnRegistry.pacer.arm(order: plan.order, burst: plan.burst)
+            spawnRegistry.pacer.onDrain = { drained in
+                logger.debug("launch spawn queue drained in \(drained / .milliseconds(1), format: .fixed(precision: 0)) ms")
+            }
+            logger.debug("launch spawn queue armed with \(plan.order.count) panes, \(plan.burst.count) in the burst")
+        }
     }
 
     var body: some Scene {
@@ -236,6 +251,15 @@ struct agtermApp: App {
         /// Handed to `ControlServer` so the zmx commands can list and kill. It used to live only inside the
         /// finalizer/reap closures, where nothing else could reach it.
         let zmxClient: ZmxClient?
+        let spawnContext: LaunchSpawnContext
+    }
+
+    /// What the launch reap learned before any window mounted, read by every pane factory: the daemon names
+    /// observed alive, a scheduling hint only. A class because the inventory sink fills it inside
+    /// `WindowLibrary.init`, before the runtime that carries it exists.
+    @MainActor
+    final class LaunchSpawnContext {
+        var runningNames: Set<String>?
     }
 
     /// Builds the window library and zmx foreground resolver for the state directory. Bootstrap
@@ -243,7 +267,7 @@ struct agtermApp: App {
     private static func restoredRuntime(stateDirectory: URL) -> RestoredRuntime {
         guard !isHostedUnitTest else {
             return RestoredRuntime(library: WindowLibrary(directory: stateDirectory),
-                                   foregroundResolver: nil, zmxClient: nil)
+                                   foregroundResolver: nil, zmxClient: nil, spawnContext: LaunchSpawnContext())
         }
         let ghostty = GhosttyApp.shared
         let environment = ProcessInfo.processInfo.environment
@@ -252,6 +276,7 @@ struct agtermApp: App {
         let client = ZmxClient(executablePath: executable,
                               socketDirectory: ZmxSupport.socketDirectory(forStateDirectory: stateDirectory.path))
         let foregroundResolver = ZmxForegroundResolver(leaderProvider: { client.sessionLeaderPIDs(timeout: $0) })
+        let context = LaunchSpawnContext()
         let library = WindowLibrary(
             directory: stateDirectory,
             paneFinalizer: {
@@ -259,10 +284,12 @@ struct agtermApp: App {
                 foregroundResolver.noteLifecycleChange()
             },
             launchInventorySink: {
-                _ = client.reap(knownPaneIdentities: $0, launchDecision: ghostty.restoreLaunchDecision)
+                context.runningNames = client.reap(knownPaneIdentities: $0,
+                                                   launchDecision: ghostty.restoreLaunchDecision).runningNames
                 foregroundResolver.noteLifecycleChange()
             })
-        return RestoredRuntime(library: library, foregroundResolver: foregroundResolver, zmxClient: client)
+        return RestoredRuntime(library: library, foregroundResolver: foregroundResolver, zmxClient: client,
+                               spawnContext: context)
     }
 
     /// Opens the windows open at quit beyond the one SwiftUI auto-opened at launch (which claimed the launch
@@ -294,10 +321,12 @@ struct agtermApp: App {
         let library: WindowLibrary
         let zmxForegroundResolver: ZmxForegroundResolver?
         let spawnRegistry: SpawnRegistry?
+        let launchContext: LaunchSpawnContext
     }
 
     private var surfaceServices: SurfaceServices {
-        SurfaceServices(library: library, zmxForegroundResolver: zmxForegroundResolver, spawnRegistry: spawnRegistry)
+        SurfaceServices(library: library, zmxForegroundResolver: zmxForegroundResolver, spawnRegistry: spawnRegistry,
+                        launchContext: launchContext)
     }
 
     /// Surface factory: a libghostty-backed view for the session, spawning a login shell in its initial working
@@ -325,7 +354,7 @@ struct agtermApp: App {
                                       env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
         let provider = LaunchSeedProvider.pane(session: session, pane: .left, disposition: disposition,
-                                               policy: Self.launchSeedPolicy(ghostty))
+                                               policy: Self.launchSeedPolicy(ghostty, context: services.launchContext))
         view.launchSeed = provider
         services.spawnRegistry?.enqueue(view, key: session.paneIdentity, provider: provider)
         view.session = session
@@ -385,12 +414,12 @@ struct agtermApp: App {
         (target as? GhosttySurfaceView)?.focusAfterReparent()
     }
 
-    /// This launch's replay policy, latched before the deck mounted: the rerun master switch and the user's
-    /// `restore-denylist.conf`.
+    /// This launch's replay policy, latched before the deck mounted: the rerun master switch, the user's
+    /// `restore-denylist.conf` and the daemons the reap saw alive. Internal so a test can pin the last.
     @MainActor
-    private static func launchSeedPolicy(_ ghostty: GhosttyApp) -> LaunchSeedPolicy {
+    static func launchSeedPolicy(_ ghostty: GhosttyApp, context: LaunchSpawnContext) -> LaunchSeedPolicy {
         LaunchSeedPolicy(restoreEnabled: ghostty.restoreRunningCommand, denylist: ghostty.restoreDenylist,
-                         runningNames: nil)
+                         runningNames: context.runningNames)
     }
 
     /// A wrapped pane's shell environment is zmx's own; every other disposition inherits the pane env.
@@ -489,7 +518,7 @@ struct agtermApp: App {
                                       env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
         let provider = LaunchSeedProvider.pane(session: session, pane: .right, disposition: disposition,
-                                               policy: Self.launchSeedPolicy(ghostty))
+                                               policy: Self.launchSeedPolicy(ghostty, context: services.launchContext))
         view.launchSeed = provider
         services.spawnRegistry?.enqueue(view, key: session.splitPaneIdentity, provider: provider)
         view.session = session

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -31,6 +31,13 @@ extension AppStore {
         if !identities.isEmpty { paneFinalizer?(identities) }
     }
 
+    /// Every pane identity of `sessions` leaves mount eligibility. A hidden split's identity is included;
+    /// the pacer ignores a key outside its armed order.
+    func dropLaunchPanes(_ sessions: [Session]) {
+        let identities = PaneIdentityInventory.identities(in: sessions)
+        if !identities.isEmpty { launchPaneDrop?(identities) }
+    }
+
     /// Toggles the one-level split. With no axis this is the legacy preserve-axis hide/show operation. With
     /// an axis it is the axis-specific UI command: the same shown axis hides, another shown axis transposes,
     /// and a hidden or absent split is shown in the requested arrangement.
@@ -55,6 +62,8 @@ extension AppStore {
     }
 
     private func setSplitVisibility(_ session: Session, shown: Bool) {
+        // hiding a shown split unmounts its right host, so the pacer must stop expecting that key
+        if !shown, session.isSplit, let split = session.splitPaneIdentity { launchPaneDrop?([split]) }
         session.isSplit = shown
         // a NEW split focuses the new (right) pane; RE-showing a hidden one keeps the pane focused before
         // hiding, so a hide/show round-trip (the tmux-style zoom script) doesn't jerk focus right. hiding
@@ -168,6 +177,7 @@ extension AppStore {
         if let splitPaneIdentity = session.splitPaneIdentity, splitPaneIdentity != alreadyFinalized {
             paneFinalizer?([splitPaneIdentity])
         }
+        if let split = session.splitPaneIdentity { launchPaneDrop?([split]) }
         session.isSplit = false
         session.hasSplit = false
         session.splitFocused = false

--- a/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
@@ -89,6 +89,7 @@ extension AppStore {
         let wasActive = selectedSessionID == sessionID
         let session = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
         emitSessionClosed(session, workspace: workspace.id)
+        dropLaunchPanes([session])
         // undo reinserts THIS object, so an override armed at bootstrap and never consumed would survive the
         // round trip and fire when the restored surface is built. drop it; the persisted pin is untouched
         // and still fires on the next launch.
@@ -158,6 +159,7 @@ extension AppStore {
                   workspaces[close.workspaceIndex].sessions[close.sessionIndex].id == close.session.id else { continue }
             _ = workspaces[close.workspaceIndex].sessions.remove(at: close.sessionIndex)
         }
+        dropLaunchPanes(closes.map(\.session))
         for close in closes {
             recordRecentClosedSession(close.session, workspaceID: close.workspaceID, workspaceName: close.workspaceName,
                                       workspaceIndex: close.workspaceIndex, sessionIndex: close.sessionIndex,
@@ -198,6 +200,7 @@ extension AppStore {
     public func softRemoveWorkspace(_ workspaceID: UUID, grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
         guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return false }
         let visibleWorkspace = workspaces.remove(at: index)
+        dropLaunchPanes(visibleWorkspace.sessions)
         forgetFreshWorkspace(workspaceID)
         for session in visibleWorkspace.sessions { emitSessionClosed(session, workspace: visibleWorkspace.id) }
         if visibleWorkspace.sessions.isEmpty { scheduleTreeChanged() }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -127,6 +127,11 @@ public final class AppStore {
     @ObservationIgnored var recentClosedDidChange: (() -> Void)?
     @ObservationIgnored let controlEventSink: ((ControlEventDraft) -> Void)?
     @ObservationIgnored let paneFinalizer: (([UUID]) -> Void)?
+
+    /// Told the pane identities of every session or split leaving the visible model, hard or soft, which
+    /// can happen before any view was built for them. The launch spawn pacer discards those keys, or an
+    /// expected key nobody can claim holds its queue at the head forever.
+    @ObservationIgnored let launchPaneDrop: (([UUID]) -> Void)?
     /// Coalesces the high-frequency selection/font saves: a click-storm or a font ramp writes once after the
     /// burst settles instead of hitting disk per event.
     @ObservationIgnored private let saveDebouncer = Debouncer()
@@ -170,7 +175,8 @@ public final class AppStore {
                 recentClosedStore: RecentClosedStore? = nil,
                 recentClosedDidChange: (() -> Void)? = nil,
                 controlEventSink: ((ControlEventDraft) -> Void)? = nil,
-                paneFinalizer: (([UUID]) -> Void)?) {
+                paneFinalizer: (([UUID]) -> Void)?,
+                launchPaneDrop: (([UUID]) -> Void)? = nil) {
         self.workspaces = workspaces
         self.selectedSessionID = selectedSessionID
         self.persistence = persistence
@@ -178,6 +184,7 @@ public final class AppStore {
         self.recentClosedDidChange = recentClosedDidChange
         self.controlEventSink = controlEventSink
         self.paneFinalizer = paneFinalizer
+        self.launchPaneDrop = launchPaneDrop
     }
 
     /// The currently selected session, derived from `selectedSessionID`.
@@ -483,6 +490,7 @@ public final class AppStore {
         let workspace = workspaces[location.workspaceIndex]
         let removed = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
         emitSessionClosed(removed, workspace: workspace.id)
+        dropLaunchPanes([removed])
         recordRecentClosedSession(removed, workspaceID: workspace.id, workspaceName: workspace.name,
                                   workspaceIndex: location.workspaceIndex, sessionIndex: location.sessionIndex)
         finalizePaneIdentities([removed], alreadyFinalized: alreadyFinalized)
@@ -522,6 +530,7 @@ public final class AppStore {
         for session in workspace.sessions { emitSessionClosed(session, workspace: workspace.id) }
         if workspace.sessions.isEmpty { scheduleTreeChanged() }
         finalizePaneIdentities(workspace.sessions)
+        dropLaunchPanes(workspace.sessions)
         for session in workspace.sessions {
             session.surface?.teardown()
             session.splitSurface?.teardown()

--- a/agtermCore/Sources/agtermCore/LaunchSpawnPlan.swift
+++ b/agtermCore/Sources/agtermCore/LaunchSpawnPlan.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// One open window's part of the launch spawn order: its selected session and its sessions in model order.
+struct LaunchSpawnWindow {
+    let selectedSessionID: UUID?
+    let sessions: [Session]
+}
+
+/// The expected spawn order of a launch restore and the keys exempt from pacing, taken from the model
+/// before any window mounts. Each open window's selected session's on-screen panes come first and form
+/// the burst; the rest follow window by window, session by session, primary before shown split. A hidden
+/// split, a session that was not restored, and every runtime surface are never expected, so a pane that
+/// replays nothing has to leave the queue itself.
+public struct LaunchSpawnPlan: Equatable, Sendable {
+    public let order: [UUID]
+    public let burst: Set<UUID>
+
+    @MainActor
+    static func make(windows: [LaunchSpawnWindow]) -> LaunchSpawnPlan {
+        var burst: [UUID] = []
+        var rest: [UUID] = []
+        for window in windows {
+            for session in window.sessions where session.wasRestored {
+                let keys = panes(of: session)
+                if session.id == window.selectedSessionID { burst += keys } else { rest += keys }
+            }
+        }
+        return LaunchSpawnPlan(order: burst + rest, burst: Set(burst))
+    }
+
+    @MainActor
+    private static func panes(of session: Session) -> [UUID] {
+        // `isSplit`, not `hasSplit`: a hidden split has an identity but no right host to request or discard,
+        // and an expected key nobody claims stalls the queue at its head.
+        guard session.isSplit, let split = session.splitPaneIdentity else { return [session.paneIdentity] }
+        return [session.paneIdentity, split]
+    }
+}
+
+public extension WindowLibrary {
+    /// The plan for this launch over every open window, in `windows` order.
+    func launchSpawnPlan() -> LaunchSpawnPlan {
+        LaunchSpawnPlan.make(windows: windows.compactMap { window in
+            guard let store = store(for: window.id) else { return nil }
+            return LaunchSpawnWindow(selectedSessionID: store.selectedSessionID,
+                                     sessions: store.workspaces.flatMap(\.sessions))
+        })
+    }
+}

--- a/agtermCore/Sources/agtermCore/SpawnPacer.swift
+++ b/agtermCore/Sources/agtermCore/SpawnPacer.swift
@@ -31,6 +31,10 @@ public final class SpawnPacer {
     /// Called with each granted key so the caller can spawn that pane's surface.
     public var onGrant: (@MainActor (UUID) -> Void)?
 
+    /// Called once per launch when the last armed key is granted, cancelled or discarded, with the time
+    /// since `arm`. Diagnostics only: the pacer is already passthrough when it fires.
+    public var onDrain: (@MainActor (Duration) -> Void)?
+
     /// Minimum gap between paced grants.
     public let interval: Duration
 
@@ -51,6 +55,7 @@ public final class SpawnPacer {
     private var states: [UUID: State] = [:]
     private var immediate: Set<UUID> = []
     private var lastGrant: ContinuousClock.Instant?
+    private var armedAt: ContinuousClock.Instant?
     private var wakeScheduled = false
 
     /// Creates a pacer driven by the system clock.
@@ -75,6 +80,7 @@ public final class SpawnPacer {
         immediate = burst.intersection(order)
         lastGrant = nil
         wakeScheduled = false
+        armedAt = now()
     }
 
     /// Marks `key` ready to spawn and answers whether it may spawn now. False leaves it queued for a later
@@ -126,6 +132,14 @@ public final class SpawnPacer {
         pending.removeAll { $0 == key }
         immediate.remove(key)
         scheduleWake()
+        noteDrain()
+    }
+
+    private func noteDrain() {
+        guard armed, pending.isEmpty, let armedAt else { return }
+        armed = false
+        self.armedAt = nil
+        onDrain?(now() - armedAt)
     }
 
     private func grant(_ key: UUID) {
@@ -135,6 +149,7 @@ public final class SpawnPacer {
         lastGrant = now()
         onGrant?(key)
         scheduleWake()
+        noteDrain()
     }
 
     private func scheduleWake() {

--- a/agtermCore/Sources/agtermCore/SpawnPacer.swift
+++ b/agtermCore/Sources/agtermCore/SpawnPacer.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// SpawnPacer rate-limits terminal spawns so a launch that replays captured commands does not start every
+/// pane's program at the same instant. It is a leaky bucket: at most one paced grant per `interval`, the
+/// next deadline measured from the ACTUAL previous grant, so a stalled main thread releases one grant on
+/// waking rather than a catch-up burst.
+///
+/// Every key is a pane identity UUID (`Session.paneIdentity` or `splitPaneIdentity`), stable for the
+/// surface wrapper's lifetime.
+///
+/// A launch restore arms it with the expected pane order and the burst set (the on-screen panes of every
+/// window's selected session, which the user is looking at). Arming grants nothing: no view exists yet, so
+/// a grant issued then would release a pane that spawns whenever SwiftUI later mounts it, collapsing
+/// several spawns into one pass while every timestamp still looked paced. A key becomes grantable only
+/// once its view calls `request`.
+///
+/// Host-free: the monotonic clock and the timer are injected, so the pacing is testable without real time.
+@MainActor
+public final class SpawnPacer {
+    /// Runs `body` on the main actor after `delay`.
+    typealias Scheduler = @MainActor (Duration, @escaping @MainActor () -> Void) -> Void
+
+    /// The default `Scheduler`: a main-actor task that sleeps on the system clock.
+    static let liveSchedule: Scheduler = { delay, body in
+        Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            body()
+        }
+    }
+
+    /// Called with each granted key so the caller can spawn that pane's surface.
+    public var onGrant: (@MainActor (UUID) -> Void)?
+
+    /// Minimum gap between paced grants.
+    public let interval: Duration
+
+    /// True when nothing is queued: unarmed, or every armed key granted, cancelled or discarded. In that
+    /// state `request` answers synchronously, so a session created after the launch never waits.
+    public var isPassthrough: Bool { !armed || pending.isEmpty }
+
+    private enum State {
+        case expected
+        case ready
+        case granted
+    }
+
+    private let now: @MainActor () -> ContinuousClock.Instant
+    private let schedule: Scheduler
+    private var armed = false
+    private var pending: [UUID] = []
+    private var states: [UUID: State] = [:]
+    private var immediate: Set<UUID> = []
+    private var lastGrant: ContinuousClock.Instant?
+    private var wakeScheduled = false
+
+    /// Creates a pacer driven by the system clock.
+    public convenience init(interval: Duration = .milliseconds(120)) {
+        self.init(interval: interval, now: { ContinuousClock().now }, schedule: SpawnPacer.liveSchedule)
+    }
+
+    init(interval: Duration,
+         now: @escaping @MainActor () -> ContinuousClock.Instant,
+         schedule: @escaping Scheduler) {
+        self.interval = interval
+        self.now = now
+        self.schedule = schedule
+    }
+
+    /// Records the expected spawn order and the keys exempt from pacing, and nothing else: no grant is
+    /// issued and no timer starts. Called once per launch restore, before any window mounts.
+    public func arm(order: [UUID], burst: Set<UUID>) {
+        armed = true
+        pending = order
+        states = order.reduce(into: [:]) { $0[$1] = .expected }
+        immediate = burst.intersection(order)
+        lastGrant = nil
+        wakeScheduled = false
+    }
+
+    /// Marks `key` ready to spawn and answers whether it may spawn now. False leaves it queued for a later
+    /// `onGrant`. True for a burst or expedited key, for a key already granted, and for any key outside the
+    /// armed order, so calling it again after a grant is safe.
+    public func request(_ key: UUID) -> Bool {
+        guard !isPassthrough, let state = states[key] else { return true }
+        if state == .granted { return true }
+        if immediate.contains(key) {
+            grant(key)
+            return true
+        }
+        states[key] = .ready
+        scheduleWake()
+        return false
+    }
+
+    /// Grants `key` now, consuming the next token so the queue waits a full `interval` after it. A key
+    /// whose view has not requested yet is marked instead and granted on that request. No-op for a granted,
+    /// unknown or already-expedited key, so repeated selection of one pane cannot mint tokens.
+    public func expedite(_ key: UUID) {
+        guard let state = states[key], state != .granted, !immediate.contains(key) else { return }
+        guard state == .ready else {
+            immediate.insert(key)
+            return
+        }
+        grant(key)
+    }
+
+    /// Moves `keys` to the front of the queue in the given order, releasing nothing. For a host that opens
+    /// on many queued panes at once, such as the dashboard.
+    public func prioritize(_ keys: [UUID]) {
+        var seen: Set<UUID> = []
+        let promoted = keys.filter { pending.contains($0) && seen.insert($0).inserted }
+        guard !promoted.isEmpty else { return }
+        pending = promoted + pending.filter { !seen.contains($0) }
+        scheduleWake()
+    }
+
+    /// Drops `key` because its pane or its view is gone.
+    public func cancel(_ key: UUID) { drop(key) }
+
+    /// Drops `key` because it spawns without a permit: a pane that replays nothing, or one already
+    /// realized elsewhere. It leaves the queue without a grant, so the pacing of the rest is unchanged.
+    public func discard(_ key: UUID) { drop(key) }
+
+    private func drop(_ key: UUID) {
+        guard states.removeValue(forKey: key) != nil else { return }
+        pending.removeAll { $0 == key }
+        immediate.remove(key)
+        scheduleWake()
+    }
+
+    private func grant(_ key: UUID) {
+        states[key] = .granted
+        pending.removeAll { $0 == key }
+        immediate.remove(key)
+        lastGrant = now()
+        onGrant?(key)
+        scheduleWake()
+    }
+
+    private func scheduleWake() {
+        guard !wakeScheduled, grantableHead != nil else { return }
+        wakeScheduled = true
+        schedule(remainingDelay()) { [weak self] in self?.wake() }
+    }
+
+    private func wake() {
+        wakeScheduled = false
+        guard let head = grantableHead else { return }
+        guard remainingDelay() == .zero else {
+            scheduleWake()
+            return
+        }
+        grant(head)
+    }
+
+    /// The next key to grant: the head of the expected order, and only when its view has requested. A later
+    /// ready key never jumps it, so the queue drains in model order.
+    private var grantableHead: UUID? {
+        guard let head = pending.first, states[head] == .ready else { return nil }
+        return head
+    }
+
+    private func remainingDelay() -> Duration {
+        guard let lastGrant else { return .zero }
+        let elapsed = now() - lastGrant
+        return elapsed >= interval ? .zero : interval - elapsed
+    }
+}

--- a/agtermCore/Sources/agtermCore/SpawnPacer.swift
+++ b/agtermCore/Sources/agtermCore/SpawnPacer.swift
@@ -36,7 +36,7 @@ public final class SpawnPacer {
     public var onDrain: (@MainActor (Duration) -> Void)?
 
     /// Minimum gap between paced grants.
-    public let interval: Duration
+    private let interval: Duration
 
     /// True when nothing is queued: unarmed, or every armed key granted, cancelled or discarded. In that
     /// state `request` answers synchronously, so a session created after the launch never waits.

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -87,6 +87,7 @@ public final class WindowLibrary {
     /// One bounded run-identified ring shared by every window store for this library/app lifetime.
     @ObservationIgnored private let controlEventRing: ControlEventRing
     @ObservationIgnored private let paneFinalizer: (([UUID]) -> Void)?
+    @ObservationIgnored private let launchPaneDrop: (([UUID]) -> Void)?
     @ObservationIgnored private let launchInventorySink: ((Set<UUID>?) -> Void)?
     @ObservationIgnored private var launchInventoryComplete = true
     @ObservationIgnored private var treeEventDebouncers: [UUID: Debouncer]
@@ -126,12 +127,14 @@ public final class WindowLibrary {
     public init(directory: URL = PersistenceStore.defaultDirectory,
                 paneFinalizer: (([UUID]) -> Void)?,
                 launchInventorySink: ((Set<UUID>?) -> Void)? = nil,
+                launchPaneDrop: (([UUID]) -> Void)? = nil,
                 controlEventRing: ControlEventRing? = nil) {
         self.directory = directory
         self.recentClosedStore = RecentClosedStore(directory: directory)
         self.controlEventRing = controlEventRing ?? ControlEventRing()
         self.paneFinalizer = paneFinalizer
         self.launchInventorySink = launchInventorySink
+        self.launchPaneDrop = launchPaneDrop
         self.treeEventDebouncers = [:]
         self.stores = [:]
         self.windows = []
@@ -450,6 +453,7 @@ public final class WindowLibrary {
         // the undo window dies with the store, so a soft-closed session left pending here would keep its
         // daemon with nothing able to finalize it. `WindowAccessor` already does this, so it is idempotent.
         store.finalizeAllPendingCloses()
+        store.dropLaunchPanes(store.workspaces.flatMap(\.sessions))
         for workspace in store.workspaces {
             for session in workspace.sessions { store.emitSessionClosed(session, workspace: workspace.id) }
         }
@@ -489,6 +493,7 @@ public final class WindowLibrary {
         stores[id]?.finalizeAllPendingCloses()
         finalizeWindowPanes(id)
         if let store = stores[id] {
+            store.dropLaunchPanes(store.workspaces.flatMap(\.sessions))
             for workspace in store.workspaces {
                 for session in workspace.sessions { store.emitSessionClosed(session, workspace: workspace.id) }
             }
@@ -711,7 +716,8 @@ public final class WindowLibrary {
                     payload: draft.payload
                 ))
             },
-            paneFinalizer: paneFinalizer
+            paneFinalizer: paneFinalizer,
+            launchPaneDrop: launchPaneDrop
         )
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -1779,4 +1779,56 @@ struct AppStorePaneTests {
         #expect(store.closeScratch(session.id) == true)
         #expect(session.agentIndicator.status == .blocked)
     }
+    // MARK: - launch pane drops
+
+    private func droppingStore() -> (AppStore, DropLog) {
+        let log = DropLog()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let store = AppStore(persistence: PersistenceStore(directory: dir), paneFinalizer: nil,
+                             launchPaneDrop: { log.identities += $0 })
+        store.workspaces = [Workspace(name: "workspace 1", sessions: [])]
+        return (store, log)
+    }
+
+    private final class DropLog {
+        var identities: [UUID] = []
+    }
+
+    @Test func hidingAShownSplitDropsOnlyTheSplitKey() throws {
+        let (store, log) = droppingStore()
+        let session = Session(initialCwd: "/tmp")
+        store.workspaces[0].sessions.append(session)
+        store.setSplitVisibility(session.id, shown: true)
+        let split = try #require(session.splitPaneIdentity)
+
+        store.setSplitVisibility(session.id, shown: false)
+
+        #expect(log.identities == [split])
+    }
+
+    @Test func hidingAHiddenSplitAndShowingOneDropNothing() {
+        let (store, log) = droppingStore()
+        let session = Session(initialCwd: "/tmp")
+        session.hasSplit = true
+        session.splitPaneIdentity = UUID()
+        store.workspaces[0].sessions.append(session)
+
+        store.setSplitVisibility(session.id, shown: false)
+        store.setSplitVisibility(session.id, shown: true)
+
+        #expect(log.identities.isEmpty)
+    }
+
+    @Test func closingASplitDropsItsKey() throws {
+        let (store, log) = droppingStore()
+        let session = Session(initialCwd: "/tmp")
+        store.workspaces[0].sessions.append(session)
+        store.setSplitVisibility(session.id, shown: true)
+        let split = try #require(session.splitPaneIdentity)
+        log.identities = []
+
+        store.closeSplit(session.id)
+
+        #expect(log.identities == [split])
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStorePendingCloseTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePendingCloseTests.swift
@@ -6,8 +6,17 @@ import Testing
 /// so it must stay claimed for the whole grace window.
 @MainActor
 struct AppStorePendingCloseTests {
+    private final class DropLog {
+        var identities: [UUID] = []
+    }
+
+    private let drops = DropLog()
+
     private func store() -> AppStore {
-        let store = makeStore()
+        let log = drops
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let store = AppStore(persistence: PersistenceStore(directory: dir), paneFinalizer: nil,
+                             launchPaneDrop: { log.identities += $0 })
         store.workspaces = [Workspace(name: "workspace 1", sessions: [])]
         return store
     }
@@ -76,5 +85,36 @@ struct AppStorePendingCloseTests {
         #expect(store.undoPendingClose())
         #expect(store.pendingCloseMembers().isEmpty)
         #expect(store.workspaces[0].sessions.map(\.id) == [session.id])
+    }
+    /// A soft close leaves the deck before its grace expires, so the pacer hears about it at the close, not
+    /// at finalization; undo brings the session back as a key outside the armed order.
+    @Test func softClosingASessionDropsBothItsPanesAtTheClose() throws {
+        let store = store()
+        let session = addSession(store, name: "build", split: true)
+        let split = try #require(session.splitPaneIdentity)
+
+        #expect(store.softCloseSession(session.id))
+
+        #expect(Set(drops.identities) == [session.paneIdentity, split])
+    }
+
+    @Test func batchSoftCloseDropsEveryMembersPanes() {
+        let store = store()
+        let first = addSession(store, name: "one")
+        let second = addSession(store, name: "two")
+
+        #expect(store.softCloseSessions([first.id, second.id]))
+
+        #expect(Set(drops.identities) == [first.paneIdentity, second.paneIdentity])
+    }
+
+    @Test func softRemovingAWorkspaceDropsItsSessionsPanes() {
+        let store = store()
+        let session = addSession(store, name: "build")
+        store.workspaces.append(Workspace(name: "workspace 2", sessions: []))
+
+        #expect(store.softRemoveWorkspace(store.workspaces[0].id))
+
+        #expect(drops.identities == [session.paneIdentity])
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1681,4 +1681,42 @@ extension AppStoreTests {
         #expect(store.workspaces[0].sessions.map(\.id) == [])
         #expect(store.workspaces[1].sessions.map(\.id) == [c.id, a.id, b.id, d.id])
     }
+    // MARK: - launch pane drops
+
+    private func droppingStore() -> (AppStore, DropLog) {
+        let log = DropLog()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let store = AppStore(persistence: PersistenceStore(directory: dir), paneFinalizer: nil,
+                             launchPaneDrop: { log.identities += $0 })
+        return (store, log)
+    }
+
+    private final class DropLog {
+        var identities: [UUID] = []
+    }
+
+    @Test func closingASessionDropsBothItsPanesFromTheLaunchQueue() throws {
+        let (store, log) = droppingStore()
+        let session = Session(initialCwd: "/tmp")
+        session.isSplit = true
+        session.hasSplit = true
+        session.splitPaneIdentity = UUID()
+        let split = try #require(session.splitPaneIdentity)
+        store.workspaces = [Workspace(name: "workspace 1", sessions: [session])]
+
+        store.closeSession(session.id)
+
+        #expect(Set(log.identities) == [session.paneIdentity, split])
+    }
+
+    @Test func removingAWorkspaceDropsEverySessionsPanes() {
+        let (store, log) = droppingStore()
+        let first = Session(initialCwd: "/tmp")
+        let second = Session(initialCwd: "/tmp")
+        store.workspaces = [Workspace(name: "one", sessions: [first, second]), Workspace(name: "two", sessions: [])]
+
+        store.removeWorkspace(store.workspaces[0].id)
+
+        #expect(Set(log.identities) == [first.paneIdentity, second.paneIdentity])
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/LaunchSpawnPlanTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/LaunchSpawnPlanTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct LaunchSpawnPlanTests {
+    @Test func selectedPanesLeadAsTheBurstThenTheRestInModelOrder() throws {
+        let first = restored()
+        let second = restored(split: true)
+        let third = restored()
+        let other = restored(split: true)
+        let secondSplit = try #require(second.splitPaneIdentity)
+        let otherSplit = try #require(other.splitPaneIdentity)
+
+        let plan = LaunchSpawnPlan.make(windows: [
+            LaunchSpawnWindow(selectedSessionID: second.id, sessions: [first, second, third]),
+            LaunchSpawnWindow(selectedSessionID: other.id, sessions: [other]),
+        ])
+
+        #expect(plan.order == [second.paneIdentity, secondSplit, other.paneIdentity, otherSplit,
+                               first.paneIdentity, third.paneIdentity])
+        #expect(plan.burst == [second.paneIdentity, secondSplit, other.paneIdentity, otherSplit])
+    }
+
+    @Test func hiddenSplitsAndUnrestoredSessionsAreNeverExpected() {
+        let hidden = restored()
+        hidden.splitPaneIdentity = UUID()
+        hidden.hasSplit = true
+        let fresh = Session(initialCwd: "/tmp")
+
+        let plan = LaunchSpawnPlan.make(windows: [
+            LaunchSpawnWindow(selectedSessionID: fresh.id, sessions: [hidden, fresh]),
+        ])
+
+        #expect(plan.order == [hidden.paneIdentity])
+        #expect(plan.burst.isEmpty)
+    }
+
+    @Test func aLibraryPlanReadsEveryOpenWindowsStore() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let library = WindowLibrary(directory: directory)
+        let store = try #require(library.store(for: library.windows.first?.id))
+        let session = try #require(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/tmp"))
+        session.wasRestored = true
+
+        let plan = library.launchSpawnPlan()
+
+        #expect(plan.order == [session.paneIdentity], "the bootstrap session was not restored")
+        #expect(plan.burst == [session.paneIdentity])
+    }
+
+    private func restored(split: Bool = false) -> Session {
+        let session = Session(initialCwd: "/tmp")
+        session.wasRestored = true
+        if split {
+            session.hasSplit = true
+            session.isSplit = true
+            session.splitPaneIdentity = UUID()
+        }
+        return session
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift
@@ -283,6 +283,50 @@ struct SpawnPacerTests {
         #expect(pacer.isPassthrough)
     }
 
+    @Test func drainFiresOnceWithTheTimeSinceArm() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        var drains: [Duration] = []
+        pacer.onDrain = { drains.append($0) }
+        let keys = [UUID(), UUID()]
+        pacer.arm(order: keys, burst: [keys[0]])
+
+        #expect(pacer.request(keys[0]))
+        #expect(drains.isEmpty)
+        clock.advance(interval)
+        pacer.discard(keys[1])
+
+        #expect(drains == [interval])
+        #expect(pacer.isPassthrough)
+        pacer.cancel(keys[0])
+        #expect(drains.count == 1, "a drop after the drain must not report again")
+    }
+
+    /// A second window mounting after the first drained: its selected pane is burst and spawns on request,
+    /// and its follower is spaced from that grant, never released together with it.
+    @Test func aWindowMountingAfterTheFirstDrainedStillSpacesItsFollower() throws {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let first = [UUID(), UUID()]
+        let second = [UUID(), UUID()]
+        pacer.arm(order: first + second, burst: [first[0], second[0]])
+        #expect(pacer.request(first[0]))
+        #expect(!pacer.request(first[1]))
+        clock.fireNextWake()
+        try #require(log.keys == [first[0], first[1]])
+        clock.advance(interval * 3)
+
+        #expect(pacer.request(second[0]))
+        #expect(!pacer.request(second[1]))
+        clock.fireNextWake()
+
+        try #require(log.keys == [first[0], first[1], second[0], second[1]])
+        #expect(log.instants[3] - log.instants[2] == interval)
+        #expect(pacer.isPassthrough)
+    }
+
     private func makePacer(clock: FakeSpawnClock, log: GrantLog) -> SpawnPacer {
         let pacer = SpawnPacer(interval: interval, now: { clock.now }, schedule: { clock.schedule($0, $1) })
         pacer.onGrant = { key in log.record(key, at: clock.now) }

--- a/agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift
@@ -1,0 +1,334 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct SpawnPacerTests {
+    private let interval = Duration.milliseconds(100)
+
+    @Test func unarmedPacerGrantsSynchronously() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        #expect(pacer.isPassthrough)
+        #expect(pacer.request(UUID()))
+        #expect(!clock.hasPendingWake)
+        #expect(log.keys.isEmpty)
+    }
+
+    @Test func armEmitsNothingWhileNoKeyRequests() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [keys[0]])
+        #expect(!pacer.isPassthrough)
+        #expect(!clock.hasPendingWake)
+        clock.advance(interval * 10)
+        clock.drain()
+        #expect(log.keys.isEmpty)
+    }
+
+    @Test func readyKeysGrantInExpectedOrderEachIntervalApart() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        #expect(!pacer.request(keys[2]))
+        #expect(!pacer.request(keys[0]))
+        #expect(!pacer.request(keys[1]))
+        #expect(log.keys.isEmpty)
+
+        clock.drain()
+        #expect(log.keys == keys)
+        #expect(log.instants[1] - log.instants[0] == interval)
+        #expect(log.instants[2] - log.instants[1] == interval)
+        #expect(pacer.isPassthrough)
+    }
+
+    @Test func burstKeyGrantsOnItsRequestNotOnArm() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let visible = UUID(), queued = UUID()
+        pacer.arm(order: [visible, queued], burst: [visible])
+        clock.advance(interval * 5)
+        #expect(log.keys.isEmpty)
+
+        #expect(pacer.request(visible))
+        #expect(log.keys == [visible])
+        #expect(!pacer.request(queued))
+        #expect(log.keys == [visible])
+    }
+
+    @Test func pacedGrantWaitsForAnExpectedKeyThatHasNotRequested() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        #expect(!pacer.request(keys[1]))
+        #expect(!pacer.request(keys[2]))
+        #expect(!clock.hasPendingWake)
+
+        clock.advance(interval * 10)
+        clock.drain()
+        #expect(log.keys.isEmpty)
+
+        #expect(!pacer.request(keys[0]))
+        clock.drain()
+        #expect(log.keys == keys)
+    }
+
+    @Test func lateWakeReleasesOneGrantOnly() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        for key in keys { _ = pacer.request(key) }
+
+        clock.fireNextWake()
+        #expect(log.keys == [keys[0]])
+
+        clock.advance(interval * 3)
+        clock.firePendingWake()
+        #expect(log.keys == [keys[0], keys[1]])
+
+        clock.firePendingWake()
+        #expect(log.keys == [keys[0], keys[1]])
+    }
+
+    @Test func expediteGrantsNowAndResetsTheDeadline() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        for key in keys { _ = pacer.request(key) }
+        clock.fireNextWake()
+        #expect(log.keys == [keys[0]])
+
+        pacer.expedite(keys[2])
+        #expect(log.keys == [keys[0], keys[2]])
+        #expect(log.instants[1] == log.instants[0])
+
+        clock.fireNextWake()
+        #expect(log.keys == [keys[0], keys[2], keys[1]])
+        #expect(log.instants[2] - log.instants[1] == interval)
+    }
+
+    @Test func expediteBeforeARequestGrantsOnThatRequest() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let first = UUID(), late = UUID()
+        pacer.arm(order: [first, late], burst: [])
+        pacer.expedite(late)
+        #expect(log.keys.isEmpty)
+
+        pacer.expedite(late)
+        #expect(log.keys.isEmpty)
+
+        #expect(pacer.request(late))
+        #expect(log.keys == [late])
+    }
+
+    @Test func expediteIsANoOpForGrantedAndUnknownKeys() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        for key in keys { _ = pacer.request(key) }
+        clock.fireNextWake()
+        #expect(log.keys == [keys[0]])
+
+        pacer.expedite(keys[0])
+        pacer.expedite(UUID())
+        #expect(log.keys == [keys[0]])
+    }
+
+    @Test func prioritizeReordersWithoutGranting() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        for key in keys { _ = pacer.request(key) }
+
+        pacer.prioritize([keys[2]])
+        #expect(log.keys.isEmpty)
+
+        clock.drain()
+        #expect(log.keys == [keys[2], keys[0], keys[1]])
+    }
+
+    @Test func repeatedRequestOfAQueuedKeyIsIdempotent() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        #expect(!pacer.request(keys[0]))
+        #expect(!pacer.request(keys[0]))
+        #expect(!pacer.request(keys[1]))
+
+        clock.drain()
+        #expect(log.keys == keys)
+        #expect(pacer.request(keys[0]))
+    }
+
+    @Test func cancelAndDiscardDropWithoutGrantOrCatchUp() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let keys = [UUID(), UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        for key in keys { _ = pacer.request(key) }
+        clock.fireNextWake()
+        #expect(log.keys == [keys[0]])
+
+        pacer.cancel(keys[1])
+        pacer.discard(keys[2])
+        #expect(log.keys == [keys[0]])
+        #expect(pacer.isPassthrough)
+
+        clock.drain()
+        #expect(log.keys == [keys[0]])
+    }
+
+    @Test func discardingAnExpectedKeyThatNeverRequestsDoesNotBlockDrain() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let unmounted = UUID(), queued = UUID()
+        pacer.arm(order: [unmounted, queued], burst: [])
+        #expect(!pacer.request(queued))
+        #expect(!clock.hasPendingWake)
+
+        pacer.discard(unmounted)
+        clock.drain()
+        #expect(log.keys == [queued])
+        #expect(pacer.isPassthrough)
+    }
+
+    @Test func requestAfterDrainIsSynchronous() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let armed = UUID()
+        pacer.arm(order: [armed], burst: [])
+        #expect(!pacer.request(armed))
+        clock.drain()
+        #expect(pacer.isPassthrough)
+
+        #expect(pacer.request(UUID()))
+        #expect(log.keys == [armed])
+    }
+
+    @Test func keyOutsideTheArmedOrderGrantsSynchronously() {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let armed = UUID()
+        pacer.arm(order: [armed], burst: [])
+        #expect(pacer.request(UUID()))
+        #expect(log.keys.isEmpty)
+        #expect(!pacer.isPassthrough)
+    }
+
+    @Test func burstGrantReleasesAFollowerThatRequestedFirst() throws {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let visible = UUID(), later = UUID()
+        pacer.arm(order: [visible, later], burst: [visible])
+        #expect(!pacer.request(later))
+        #expect(!clock.hasPendingWake)
+
+        clock.advance(interval * 5)
+        #expect(pacer.request(visible))
+        #expect(log.keys == [visible])
+
+        clock.advance(interval / 2)
+        clock.firePendingWake()
+        #expect(log.keys == [visible])
+
+        clock.fireNextWake()
+        try #require(log.keys == [visible, later])
+        #expect(log.instants[1] - log.instants[0] == interval)
+        #expect(pacer.isPassthrough)
+    }
+
+    @Test func deferredExpediteGrantReleasesAFollowerThatRequestedFirst() throws {
+        let clock = FakeSpawnClock()
+        let log = GrantLog()
+        let pacer = makePacer(clock: clock, log: log)
+        let head = UUID(), follower = UUID()
+        pacer.arm(order: [head, follower], burst: [])
+        #expect(!pacer.request(follower))
+        #expect(!clock.hasPendingWake)
+
+        pacer.expedite(head)
+        #expect(log.keys.isEmpty)
+
+        #expect(pacer.request(head))
+        #expect(log.keys == [head])
+
+        clock.fireNextWake()
+        try #require(log.keys == [head, follower])
+        #expect(log.instants[1] - log.instants[0] == interval)
+        #expect(pacer.isPassthrough)
+    }
+
+    private func makePacer(clock: FakeSpawnClock, log: GrantLog) -> SpawnPacer {
+        let pacer = SpawnPacer(interval: interval, now: { clock.now }, schedule: { clock.schedule($0, $1) })
+        pacer.onGrant = { key in log.record(key, at: clock.now) }
+        return pacer
+    }
+}
+
+@MainActor
+private final class FakeSpawnClock {
+    private(set) var now = ContinuousClock().now
+    private var pending: (deadline: ContinuousClock.Instant, body: @MainActor () -> Void)?
+
+    var hasPendingWake: Bool { pending != nil }
+
+    func schedule(_ delay: Duration, _ body: @escaping @MainActor () -> Void) {
+        pending = (now + delay, body)
+    }
+
+    func advance(_ amount: Duration) { now += amount }
+
+    /// Runs the pending wake where the clock stands, so a test can wake the pacer late or early.
+    @discardableResult func firePendingWake() -> Bool {
+        guard let wake = pending else { return false }
+        pending = nil
+        wake.body()
+        return true
+    }
+
+    @discardableResult func fireNextWake() -> Bool {
+        guard let wake = pending else { return false }
+        if wake.deadline > now { now = wake.deadline }
+        return firePendingWake()
+    }
+
+    func drain(limit: Int = 20) {
+        for _ in 0..<limit where hasPendingWake { fireNextWake() }
+    }
+}
+
+@MainActor
+private final class GrantLog {
+    private(set) var keys: [UUID] = []
+    private(set) var instants: [ContinuousClock.Instant] = []
+
+    func record(_ key: UUID, at instant: ContinuousClock.Instant) {
+        keys.append(key)
+        instants.append(instant)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -1475,4 +1475,36 @@ final class WindowLibraryTests {
         #expect(!library.saveAllOpenChecked())
     }
 
+    // MARK: - launch pane drops
+
+    private final class DropLog {
+        var identities: [UUID] = []
+    }
+
+    @Test func closingAWindowDropsEveryPaneItHeld() throws {
+        let log = DropLog()
+        let library = WindowLibrary(directory: directory, paneFinalizer: nil, launchPaneDrop: { log.identities += $0 })
+        let work = library.newWindow(name: "work")
+        let store = try #require(library.store(for: work.id))
+        let session = try #require(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/tmp"))
+        let expected = Set(PaneIdentityInventory.identities(in: store.workspaces.flatMap(\.sessions)))
+
+        library.closeWindow(work.id)
+
+        #expect(Set(log.identities) == expected)
+        #expect(log.identities.contains(session.paneIdentity))
+    }
+
+    @Test func removingAWindowDropsEveryPaneItHeld() throws {
+        let log = DropLog()
+        let library = WindowLibrary(directory: directory, paneFinalizer: nil, launchPaneDrop: { log.identities += $0 })
+        let work = library.newWindow(name: "work")
+        let store = try #require(library.store(for: work.id))
+        let expected = Set(PaneIdentityInventory.identities(in: store.workspaces.flatMap(\.sessions)))
+
+        library.removeWindow(work.id)
+
+        #expect(Set(log.identities) == expected)
+        #expect(!expected.isEmpty)
+    }
 }

--- a/agtermTests/AppDelegateCaptureTests.swift
+++ b/agtermTests/AppDelegateCaptureTests.swift
@@ -318,6 +318,44 @@ final class AppDelegateCaptureTests: XCTestCase {
         XCTAssertNil(session.foregroundCommand)
     }
 
+    // a paced pane mounts its surface seconds before it spawns; the argv must survive a quit landing in that
+    // window, in both replaying modes.
+    func testCleanQuitKeepsTheArgvOfAMountedButUnspawnedPane() throws {
+        let rerun = Session(initialCwd: "/tmp")
+        rerun.surface = GhosttySurfaceView(workingDirectory: "/tmp")
+        rerun.pendingForegroundCommand = ["npm", "run", "dev"]
+
+        _ = AppDelegate.captureForegroundCommands(sessions: [rerun], preserveUnconsumedPending: true)
+
+        XCTAssertFalse(try XCTUnwrap(rerun.surface).isRealized)
+        XCTAssertEqual(rerun.foregroundCommand, ["npm", "run", "dev"])
+
+        let paneID = UUID()
+        let live = Session(initialCwd: "/tmp", paneIdentity: paneID)
+        live.surface = GhosttySurfaceView(
+            workingDirectory: "/tmp", env: ["AGTERM_PANE_ID": paneID.uuidString], backedByZmx: true)
+        live.pendingForegroundCommand = ["npm", "run", "dev"]
+        // the daemon this pane would attach to does not exist yet, which is why the pane is paced at all.
+        let resolver = ZmxForegroundResolver(leaderProvider: { _ in [:] }, leaderProbe: { .foreground($0) })
+
+        _ = AppDelegate.captureForegroundCommands(
+            sessions: [live], zmxResolver: resolver, preserveUnconsumedPending: true)
+
+        XCTAssertEqual(live.foregroundCommand, ["npm", "run", "dev"])
+    }
+
+    func testOnDemandCapturePersistsNothingForAMountedButUnspawnedPane() {
+        let session = Session(initialCwd: "/tmp")
+        session.surface = GhosttySurfaceView(workingDirectory: "/tmp")
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+
+        let count = AppDelegate.captureForegroundCommands(sessions: [session])
+
+        XCTAssertEqual(count, 0)
+        XCTAssertNil(session.foregroundCommand)
+        XCTAssertEqual(session.pendingForegroundCommand, ["npm", "run", "dev"])
+    }
+
     // restore.capture persisting an unconsumed slot while it stays armed lets a later show replay it once and
     // a crash replay the persisted copy again.
     func testOnDemandCaptureLeavesAnUnconsumedPendingArgvOutOfTheSnapshot() {

--- a/agtermTests/ControlServerRestoreCaptureTests.swift
+++ b/agtermTests/ControlServerRestoreCaptureTests.swift
@@ -144,6 +144,25 @@ final class ControlServerRestoreCaptureTests: XCTestCase {
         XCTAssertTrue(library.allOpenSessions().allSatisfy { $0.foregroundCommand == nil })
     }
 
+    /// Pacing widens the gap between a pane mounting and spawning from milliseconds to seconds, so the
+    /// disarm has to reach a seed that has not resolved yet. A capture-only session, since the command
+    /// deliberately leaves the sticky pins alone.
+    func testClearBeforeTheSeedResolvesLeavesAPlainShell() throws {
+        let session = try XCTUnwrap(library.allOpenSessions().first)
+        session.wasRestored = true
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+        let provider = LaunchSeedProvider.pane(
+            session: session, pane: .left, disposition: .ordinary,
+            policy: .init(restoreEnabled: true, denylist: [], runningNames: nil))
+        XCTAssertTrue(provider.shouldPace)
+
+        XCTAssertTrue(server.clearRestoreCommands().ok)
+
+        let seed = provider.resolve(.left)
+        XCTAssertNil(seed.command)
+        XCTAssertNil(seed.initialInput)
+    }
+
     private func makeServer(launchMode: RestoreMode,
                             zmxForegroundResolver: ZmxForegroundResolver? = nil) -> ControlServer {
         ControlServer(

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -283,6 +283,104 @@ final class ControlServerSessionActionsTests: XCTestCase {
                        "an empty slot and a parked-but-unrealized view are one state to a caller")
     }
 
+    // MARK: - launch queue preemption
+
+    /// A pane parked in the launch queue: registered with an armed pacer behind a head that never asks, and
+    /// already denied once. Only an expedite can grant it, so a granted key proves the command promoted it.
+    /// The host never realizes a surface, so every command still answers `session not realized`; what is
+    /// under test is whether the pane's turn was spent before that answer.
+    @MainActor private struct QueuedPane {
+        let view: GhosttySurfaceView
+        let registry: SpawnRegistry
+        let key: UUID
+        var granted: Bool { registry.view(for: key) == nil }
+    }
+
+    private func queuePane(in session: Session, split: Bool = false) -> QueuedPane {
+        let registry = SpawnRegistry(pacer: SpawnPacer())
+        let key = UUID()
+        registry.pacer.arm(order: [UUID(), key], burst: [])
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: true) { _ in
+            LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        })
+        XCTAssertFalse(view.requestSpawnPermit(), "the fixture must start queued")
+        if split { session.splitSurface = view } else { session.surface = view }
+        return QueuedPane(view: view, registry: registry, key: key)
+    }
+
+    func testTypeExpeditesAQueuedPaneBeforeItsPoll() async throws {
+        let (store, target) = try addSession()
+        let queued = queuePane(in: target)
+
+        let response = await server.injectText("ls\n", into: target.id, store: store, select: true, pane: nil)
+
+        XCTAssertEqual(response.error, "session not realized")
+        XCTAssertTrue(queued.granted, "the pane must be granted before the poll runs, not after it")
+    }
+
+    func testTypeOnAQueuedShownSplitExpeditesItAndAnAbsentSplitFailsFast() async throws {
+        let (store, target) = try addSession()
+        store.setSplitVisibility(target.id, shown: true)
+        let queued = queuePane(in: target, split: true)
+        let (_, bare) = try addSession()
+
+        let shown = await server.injectText("ls\n", into: target.id, store: store, select: false, pane: "right")
+        let started = Date()
+        let absent = await server.injectText("ls\n", into: bare.id, store: store, select: false, pane: "right")
+
+        XCTAssertEqual(shown.error, "session not realized")
+        XCTAssertTrue(queued.granted)
+        XCTAssertEqual(absent.error, "session has no split pane")
+        XCTAssertLessThan(Date().timeIntervalSince(started), 0.1, "an absent split has nothing to wait for")
+    }
+
+    func testSearchOpenExpeditesAQueuedPane() async throws {
+        let (store, target) = try addSession()
+        let queued = queuePane(in: target)
+
+        let response = await server.searchSession(target.id, store: store, text: nil, to: nil)
+
+        XCTAssertTrue(response.ok, response.error ?? "")
+        XCTAssertTrue(queued.granted)
+    }
+
+    func testSynchronousMutatorsExpediteAQueuedPane() throws {
+        let cases: [(name: String, split: Bool, run: (Session) -> ControlResponse)] = [
+            ("session.paste", false, { self.server.pasteSession($0.id.uuidString, window: nil) }),
+            ("session.selectall", false, { self.server.selectAllSession($0.id.uuidString, window: nil) }),
+            ("font.inc left", false, { self.server.font($0.id.uuidString, window: nil, pane: nil, action: "increase_font_size:1") }),
+            ("font.inc right", true, { self.server.font($0.id.uuidString, window: nil, pane: "right", action: "increase_font_size:1") }),
+        ]
+        for testCase in cases {
+            let (store, target) = try addSession()
+            if testCase.split { store.setSplitVisibility(target.id, shown: true) }
+            let queued = queuePane(in: target, split: testCase.split)
+
+            let response = testCase.run(target)
+
+            XCTAssertEqual(response.error, "session not realized", testCase.name)
+            XCTAssertTrue(queued.granted, "\(testCase.name) must grant the pane before acting on it")
+        }
+    }
+
+    func testReadsLeaveAQueuedPaneQueued() throws {
+        let (_, target) = try addSession()
+        let queued = queuePane(in: target)
+        let id = target.id.uuidString
+
+        let text = server.readSessionText(id, window: nil,
+                                          options: ControlSessionTextOptions(pane: nil, all: false, lines: nil))
+        let copy = server.copySelection(id, window: nil)
+        let cursor = server.readSurfaceCursor("surface:\(id):left", window: nil)
+
+        XCTAssertEqual(text.error, "session not realized")
+        XCTAssertEqual(copy.error, "session not realized")
+        XCTAssertEqual(cursor.error, "surface not realized")
+        XCTAssertFalse(queued.granted, "a read must not spend the pane's turn")
+        XCTAssertTrue(queued.view.awaitingSpawnPermit)
+    }
+
     func testTextPaneIDResolvesTheLiveSlotAndOverridesPane() throws {
         let store = try XCTUnwrap(library.activeStore)
         let owner = try XCTUnwrap(store.currentWorkspaceID)

--- a/agtermTests/ControlServerZmxTests.swift
+++ b/agtermTests/ControlServerZmxTests.swift
@@ -331,6 +331,34 @@ final class ControlServerZmxTests: XCTestCase {
         XCTAssertEqual(killed, [daemon], "the identity this command killed must not be finalized again")
     }
 
+    /// A claimed pane still waiting its turn has no client yet. The kill runs the transition now, and the
+    /// teardown cancels its key, so no later grant can spawn a client that would recreate the daemon.
+    func testKillingAClaimedUnspawnedPaneRunsTheTransitionAndCancelsItsTurn() throws {
+        let store = try XCTUnwrap(library.store(for: library.windows[0].id))
+        let session = try XCTUnwrap(store.workspaces.first?.sessions.first)
+        let daemon = ZmxSupport.daemonName(for: session.paneIdentity)
+        let view = attachSurface(to: session, pane: .left)
+        let registry = SpawnRegistry(pacer: SpawnPacer())
+        let key = UUID()
+        registry.pacer.arm(order: [key], burst: [])
+        registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: true) { _ in
+            LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        })
+        XCTAssertFalse(view.requestSpawnPermit())
+        let server = makeServer(runner: { invocation in
+            guard invocation.arguments.first == "list" else { return "killed session \(invocation.arguments[1])\n" }
+            return "name=\(daemon)\tpid=1\tclients=0\tcreated=1"
+        })
+
+        let response = server.killZmxDaemon(target: session.id.uuidString, window: nil, pane: .left)
+
+        XCTAssertTrue(response.ok, response.error ?? "")
+        XCTAssertTrue(store.workspaces.first?.sessions.isEmpty ?? false, "the session closes with its pane")
+        XCTAssertTrue(registry.pacer.isPassthrough, "the teardown must cancel the pane's turn")
+        registry.pacer.expedite(key)
+        XCTAssertFalse(view.isRealized, "a cancelled key cannot be granted into a spawn")
+    }
+
     func testAFallbackPaneIsNeverClosedByKillingThePreservedDaemon() throws {
         let store = try XCTUnwrap(library.store(for: library.windows[0].id))
         let session = try XCTUnwrap(store.workspaces.first?.sessions.first)

--- a/agtermTests/DashboardViewTests.swift
+++ b/agtermTests/DashboardViewTests.swift
@@ -1,0 +1,135 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import agterm
+@testable import agtermCore
+
+/// The dashboard host moves its members' queued panes to the front of a paced launch without releasing
+/// any: the grid fills at the paced rate, in cell order, instead of in one burst.
+@MainActor
+final class DashboardViewTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-dashboard-view-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testOpeningOnQueuedMembersPromotesThemButKeepsTheRate() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let sessions = try (0..<3).map { _ in
+            try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        }
+        let interval = Duration.milliseconds(120)
+        var clock = ContinuousClock().now
+        var wakes: [@MainActor () -> Void] = []
+        let pacer = SpawnPacer(interval: interval, now: { clock }, schedule: { _, body in wakes.append(body) })
+        let registry = SpawnRegistry(pacer: pacer)
+        let keys = sessions.map { _ in UUID() }
+        pacer.arm(order: keys, burst: [])
+        for (session, key) in zip(sessions, keys) {
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: true) { _ in
+                LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+            })
+            XCTAssertFalse(view.requestSpawnPermit())
+            session.surface = view
+        }
+        let members = [DashboardMember(session: sessions[2].id, surface: .primary),
+                       DashboardMember(session: sessions[1].id, surface: .primary)]
+
+        DashboardView.prioritizeSpawns(of: members, in: store)
+
+        XCTAssertNotNil(registry.view(for: keys[2]), "prioritize reorders; it releases nothing")
+        wakes.removeFirst()()
+        XCTAssertNil(registry.view(for: keys[2]), "the first cell is granted first")
+        XCTAssertNotNil(registry.view(for: keys[1]))
+        wakes.removeFirst()()
+        XCTAssertNotNil(registry.view(for: keys[1]), "a wake before the interval elapses grants nothing")
+        clock += interval
+        wakes.removeFirst()()
+        XCTAssertNil(registry.view(for: keys[1]), "the second cell follows one interval later")
+        XCTAssertNotNil(registry.view(for: keys[0]), "the pane outside the dashboard waits its turn")
+    }
+
+    func testAMemberWithNoQueuedPaneIsSkipped() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let session = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        session.surface = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        DashboardView.prioritizeSpawns(of: [DashboardMember(session: session.id, surface: .primary),
+                                            DashboardMember(session: UUID(), surface: .split)], in: store)
+
+        XCTAssertTrue((session.surface as? GhosttySurfaceView)?.requestSpawnPermit() ?? false)
+    }
+
+    /// Mounts the real view: its `onChange(initial:)` is the only production call, so this is what goes red
+    /// when that modifier is dropped. The window is 2 points wide so every cell lays out at zero size and
+    /// the one grant fired here parks on the size guard instead of spawning a shell in the test host.
+    func testMountingTheViewPrioritizesItsMembersInCellOrder() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let sessions = try (0..<3).map { _ in
+            try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        }
+        var wakes: [@MainActor () -> Void] = []
+        let pacer = SpawnPacer(interval: .milliseconds(120), now: { ContinuousClock().now },
+                               schedule: { _, body in wakes.append(body) })
+        let registry = SpawnRegistry(pacer: pacer)
+        let keys = sessions.map { _ in UUID() }
+        pacer.arm(order: keys, burst: [])
+        var queued: [UUID: GhosttySurfaceView] = [:]
+        for (session, key) in zip(sessions, keys) {
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: true) { _ in
+                LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+            })
+            XCTAssertFalse(view.requestSpawnPermit())
+            queued[session.id] = view
+        }
+        let controller = DashboardController()
+        controller.open(members: [DashboardMember(session: sessions[2].id, surface: .primary),
+                                  DashboardMember(session: sessions[1].id, surface: .primary)])
+        var mounted = 0
+        let dashboard = DashboardView(
+            controller: controller, store: store,
+            makeSurface: { session in mounted += 1; return queued[session.id]! },
+            makeSplitSurface: { _ in XCTFail("no split member"); return GhosttySurfaceView(workingDirectory: "/tmp") },
+            highlightColor: .white, captionBackground: .black, pillColor: .gray, pillTextColor: .white,
+            focusAllowed: false, showsTopHairline: false, onClick: { _ in }, onSelect: { _ in }, onClose: {})
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 2, height: 2), styleMask: .borderless,
+                              backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        window.contentView = NSHostingView(rootView: dashboard)
+        window.layoutIfNeeded()
+        let deadline = Date().addingTimeInterval(2)
+        while mounted < 2, Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertEqual(mounted, 2, "both cells must mount their queued pane")
+        for _ in 0..<5 { RunLoop.main.run(until: Date().addingTimeInterval(0.01)) }
+
+        try XCTUnwrap(wakes.first)()
+
+        XCTAssertNil(registry.view(for: keys[2]), "the first cell must be granted ahead of the model order")
+        XCTAssertNotNil(registry.view(for: keys[0]), "the model head waits behind the dashboard's members")
+        XCTAssertTrue(queued.values.allSatisfy { !$0.isRealized }, "nothing may spawn in the test host")
+    }
+}

--- a/agtermTests/GhosttySurfaceViewTrackingTests.swift
+++ b/agtermTests/GhosttySurfaceViewTrackingTests.swift
@@ -491,4 +491,85 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
 
         try await waitUntil("deinit cancels the permit") { pacer.isPassthrough }
     }
+
+    // MARK: - selection preemption
+
+    private func queuedPair() -> (pacer: SpawnPacer, keys: [UUID], views: [GhosttySurfaceView]) {
+        let pacer = SpawnPacer()
+        let keys = [UUID(), UUID()]
+        pacer.arm(order: keys, burst: [])
+        let views = keys.map { key -> GhosttySurfaceView in
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            view.useSpawnPacer(pacer, key: key)
+            XCTAssertFalse(view.requestSpawnPermit())
+            return view
+        }
+        return (pacer, keys, views)
+    }
+
+    func testSelectingAQueuedPaneGrantsItBeforeTheQueueReachesIt() {
+        let pair = queuedPair()
+
+        pair.views[1].deckActive = true
+
+        XCTAssertTrue(pair.views[1].requestSpawnPermit(), "the selected pane jumps the queue")
+        XCTAssertFalse(pair.views[0].requestSpawnPermit(), "the head of the queue still waits its interval")
+    }
+
+    /// The deck and the zoom host both set `deckActive` before the first `createSurface`, so a selected pane
+    /// is granted on that first request rather than one interval later.
+    func testAPaneActiveBeforeItsFirstRequestIsGrantedOnThatRequest() {
+        let pacer = SpawnPacer()
+        let key = UUID()
+        pacer.arm(order: [UUID(), key], burst: [])
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        view.useSpawnPacer(pacer, key: key)
+
+        view.deckActive = true
+
+        XCTAssertTrue(view.requestSpawnPermit())
+        XCTAssertFalse(view.awaitingSpawnPermit)
+    }
+
+    func testSelectingAPaneTwiceMintsOneToken() {
+        let pair = queuedPair()
+        var granted: [UUID] = []
+        pair.pacer.onGrant = { granted.append($0) }
+
+        pair.views[0].deckActive = true
+        pair.views[0].deckActive = true
+
+        XCTAssertEqual(granted, [pair.keys[0]])
+        XCTAssertFalse(pair.views[1].requestSpawnPermit(), "a repeated selection must not release the next pane")
+    }
+
+    func testAnUnpacedPaneIgnoresSelection() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        view.deckActive = true
+
+        XCTAssertTrue(view.requestSpawnPermit())
+    }
+
+    func testPrioritizeReleasesNothing() {
+        let pair = queuedPair()
+        var granted: [UUID] = []
+        pair.pacer.onGrant = { granted.append($0) }
+
+        GhosttySurfaceView.prioritizeSpawn([pair.views[1], pair.views[0]])
+
+        XCTAssertTrue(granted.isEmpty, "prioritize reorders; only the timer or an expedite grants")
+        XCTAssertFalse(pair.views[1].requestSpawnPermit())
+    }
+
+    func testPrioritizeSkipsUnpacedViews() {
+        let pair = queuedPair()
+        let plain = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        GhosttySurfaceView.prioritizeSpawn([plain])
+        GhosttySurfaceView.prioritizeSpawn([plain, pair.views[1]])
+
+        XCTAssertTrue(plain.requestSpawnPermit())
+        XCTAssertFalse(pair.views[1].requestSpawnPermit(), "an unpaced view never picks a pacer for the rest")
+    }
 }

--- a/agtermTests/GhosttySurfaceViewTrackingTests.swift
+++ b/agtermTests/GhosttySurfaceViewTrackingTests.swift
@@ -286,4 +286,77 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
         XCTAssertFalse(view.layer === stale, "a torn-down surface must not keep the layer libghostty installed")
         XCTAssertEqual(view.layer?.contentsScale, 3, "the replacement carries the last frame, so nothing blanks")
     }
+
+    // MARK: - launch seed
+
+    func testResolvingTheDeferredSeedRunsOnceAndLatchesTheValues() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        var resolves = 0
+        view.launchSeed = LaunchSeedProvider(shouldPace: true) { _ in
+            resolves += 1
+            return LaunchSeed(command: nil, initialInput: "npm run dev\n", waitAfterCommand: false)
+        }
+
+        let first = view.resolveLaunchSeed()
+        let second = view.resolveLaunchSeed()
+
+        XCTAssertEqual(resolves, 1, "a retried creation must not consume the pending slots a second time")
+        XCTAssertEqual(first, LaunchSeed(command: nil, initialInput: "npm run dev\n", waitAfterCommand: false))
+        XCTAssertEqual(second, first)
+        XCTAssertNil(view.launchSeed)
+    }
+
+    func testResolvingPassesTheSurfacesLivePaneRole() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        view.setPaneRole(.split)
+        var asked: StatusPane?
+        view.launchSeed = LaunchSeedProvider(shouldPace: true) { pane in
+            asked = pane
+            return LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        }
+
+        view.resolveLaunchSeed()
+
+        XCTAssertEqual(asked, .right)
+    }
+
+    func testAViewWithoutAProviderKeepsItsConstructorValues() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory(),
+                                      command: "revdiff", waitAfterCommand: true)
+
+        XCTAssertEqual(view.resolveLaunchSeed(),
+                       LaunchSeed(command: "revdiff", initialInput: nil, waitAfterCommand: true))
+        XCTAssertNil(view.launchSeed)
+    }
+
+    func testTeardownDropsTheUnresolvedProvider() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        view.launchSeed = LaunchSeedProvider(shouldPace: true) { _ in
+            XCTFail("a torn-down surface must not consume its pending slots")
+            return LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        }
+
+        view.destroySurface()
+
+        XCTAssertNil(view.launchSeed)
+    }
+
+    /// A provider holding its session strongly would close the `Session -> surface -> provider -> Session`
+    /// cycle and leak every pane destroyed before it spawned.
+    func testAViewDestroyedBeforeResolutionDeallocates() {
+        let session = Session(initialCwd: "/tmp")
+        weak var released: GhosttySurfaceView?
+        autoreleasepool {
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            view.session = session
+            view.launchSeed = LaunchSeedProvider.pane(
+                session: session, pane: .left, disposition: .ordinary,
+                policy: .init(restoreEnabled: true, denylist: [], runningNames: nil))
+            session.surface = view
+            released = view
+            session.surface = nil
+        }
+
+        XCTAssertNil(released)
+    }
 }

--- a/agtermTests/GhosttySurfaceViewTrackingTests.swift
+++ b/agtermTests/GhosttySurfaceViewTrackingTests.swift
@@ -510,13 +510,13 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
     func testSelectingAQueuedPaneGrantsItBeforeTheQueueReachesIt() {
         let pair = queuedPair()
 
-        pair.views[1].deckActive = true
+        pair.views[1].deckVisible = true
 
         XCTAssertTrue(pair.views[1].requestSpawnPermit(), "the selected pane jumps the queue")
         XCTAssertFalse(pair.views[0].requestSpawnPermit(), "the head of the queue still waits its interval")
     }
 
-    /// The deck and the zoom host both set `deckActive` before the first `createSurface`, so a selected pane
+    /// The deck and the zoom host both set `deckVisible` before the first `createSurface`, so a selected pane
     /// is granted on that first request rather than one interval later.
     func testAPaneActiveBeforeItsFirstRequestIsGrantedOnThatRequest() {
         let pacer = SpawnPacer()
@@ -525,7 +525,7 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
         let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
         view.useSpawnPacer(pacer, key: key)
 
-        view.deckActive = true
+        view.deckVisible = true
 
         XCTAssertTrue(view.requestSpawnPermit())
         XCTAssertFalse(view.awaitingSpawnPermit)
@@ -536,17 +536,37 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
         var granted: [UUID] = []
         pair.pacer.onGrant = { granted.append($0) }
 
-        pair.views[0].deckActive = true
-        pair.views[0].deckActive = true
+        pair.views[0].deckVisible = true
+        pair.views[0].deckVisible = true
 
         XCTAssertEqual(granted, [pair.keys[0]])
         XCTAssertFalse(pair.views[1].requestSpawnPermit(), "a repeated selection must not release the next pane")
     }
 
+    /// Both panes of a shown split are on screen, so selecting the session brings both up, whichever half
+    /// holds split focus.
+    func testSelectingAShownSplitBringsUpBothPanes() {
+        let pair = queuedPair()
+
+        pair.views[0].deckVisible = true
+        pair.views[1].deckVisible = true
+
+        XCTAssertTrue(pair.views[0].requestSpawnPermit())
+        XCTAssertTrue(pair.views[1].requestSpawnPermit())
+    }
+
+    func testFocusAloneExpeditesNothing() {
+        let pair = queuedPair()
+
+        pair.views[1].deckActive = true
+
+        XCTAssertFalse(pair.views[1].requestSpawnPermit(), "focus is not visibility")
+    }
+
     func testAnUnpacedPaneIgnoresSelection() {
         let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
 
-        view.deckActive = true
+        view.deckVisible = true
 
         XCTAssertTrue(view.requestSpawnPermit())
     }

--- a/agtermTests/GhosttySurfaceViewTrackingTests.swift
+++ b/agtermTests/GhosttySurfaceViewTrackingTests.swift
@@ -359,4 +359,136 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
 
         XCTAssertNil(released)
     }
+
+    // MARK: - spawn permit
+
+    /// Every paced pane in these tests is DENIED its permit: a granted one at a real size would spawn the
+    /// user's login shell inside the test host, which is why the granted side is driven through
+    /// `requestSpawnPermit()` rather than through `createSurface()`.
+    private func makeQueuedPane(size: NSSize = NSSize(width: 240, height: 160))
+        -> (view: GhosttySurfaceView, pacer: SpawnPacer, key: UUID) {
+        let pacer = SpawnPacer()
+        let key = UUID()
+        pacer.arm(order: [key], burst: [])
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        view.useSpawnPacer(pacer, key: key)
+        view.launchSeed = LaunchSeedProvider(shouldPace: true) { _ in
+            XCTFail("a queued pane must not consume its seed before the permit")
+            return LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        }
+        view.setFrameSize(size)
+        return (view, pacer, key)
+    }
+
+    private func assertStillQueued(_ view: GhosttySurfaceView, _ path: String,
+                                   file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertFalse(view.isRealized, "\(path) spawned a surface without a permit", file: file, line: line)
+        XCTAssertTrue(view.awaitingSpawnPermit, "\(path) never reached the gate", file: file, line: line)
+        XCTAssertNotNil(view.launchSeed, "\(path) consumed the pending slots before the permit",
+                        file: file, line: line)
+    }
+
+    func testADeniedPaneCreatesNoSurfaceAndKeepsItsSeedArmed() {
+        let paned = makeQueuedPane()
+
+        paned.view.createSurface()
+
+        assertStillQueued(paned.view, "updateNSView")
+    }
+
+    func testTheWindowAttachEntryPathReachesTheGate() {
+        let paned = makeQueuedPane()
+
+        content.addSubview(paned.view)
+
+        assertStillQueued(paned.view, "viewDidMoveToWindow")
+        paned.view.removeFromSuperview()
+    }
+
+    func testTheDeferredSizeRetryEntryPathReachesTheGate() {
+        let paned = makeQueuedPane(size: .zero)
+
+        paned.view.createSurface()
+        XCTAssertFalse(paned.view.awaitingSpawnPermit, "a zero-size pane asks for nothing")
+        paned.view.setFrameSize(NSSize(width: 240, height: 160))
+
+        assertStillQueued(paned.view, "setFrameSize")
+    }
+
+    func testTheDisplayWakeRetryEntryPathReachesTheGate() async throws {
+        let paned = makeQueuedPane()
+
+        NotificationCenter.default.post(name: .agtermScreensDidWake, object: nil)
+
+        try await waitUntil("the wake retry reaches the gate") { paned.view.awaitingSpawnPermit }
+        assertStillQueued(paned.view, "retryCreationAfterWake")
+    }
+
+    /// A pane deferred on a zero size must not hold a token: the queue would spend an interval on a view
+    /// that still cannot spawn, and the token would be waiting for it when a later layout burst arrives.
+    func testAZeroSizedPaneAsksForNoPermit() {
+        let paned = makeQueuedPane(size: .zero)
+        var granted: [UUID] = []
+        paned.pacer.onGrant = { granted.append($0) }
+
+        paned.view.createSurface()
+        paned.pacer.expedite(paned.key)
+
+        XCTAssertFalse(paned.view.awaitingSpawnPermit)
+        XCTAssertTrue(granted.isEmpty, "expedite grants a READY key, so a token means the view had requested")
+    }
+
+    func testAGrantedKeyPassesTheGate() {
+        let paned = makeQueuedPane()
+
+        XCTAssertFalse(paned.view.requestSpawnPermit())
+        XCTAssertTrue(paned.view.awaitingSpawnPermit)
+        paned.pacer.expedite(paned.key)
+
+        XCTAssertTrue(paned.view.requestSpawnPermit())
+        XCTAssertFalse(paned.view.awaitingSpawnPermit)
+    }
+
+    func testAnUnarmedPacerGrantsOnRequest() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        view.useSpawnPacer(SpawnPacer(), key: UUID())
+
+        XCTAssertTrue(view.requestSpawnPermit())
+        XCTAssertFalse(view.awaitingSpawnPermit)
+    }
+
+    func testAPaneOutsideTheLaunchQueueNeedsNoPermit() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        XCTAssertTrue(view.requestSpawnPermit())
+    }
+
+    func testTeardownLeavesTheQueueAndTheLaterGrantDoesNothing() {
+        let paned = makeQueuedPane()
+        paned.view.createSurface()
+
+        paned.view.destroySurface()
+
+        XCTAssertTrue(paned.pacer.isPassthrough, "a torn-down pane must not hold the rest of the queue")
+        paned.view.unregisterDraggedTypes()
+        paned.view.createSurface()
+        XCTAssertTrue(paned.view.registeredDraggedTypes.isEmpty,
+                      "a grant reaching a torn-down pane must not re-enter creation")
+    }
+
+    /// The safety net for a queued pane dropped without a teardown: `deinit` is nonisolated, so it schedules
+    /// a key-only cancellation instead of touching the pacer inline.
+    func testDeinitCancelsTheQueuedPermit() async throws {
+        let pacer = SpawnPacer()
+        let key = UUID()
+        pacer.arm(order: [key], burst: [])
+        autoreleasepool {
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            view.useSpawnPacer(pacer, key: key)
+            _ = view.requestSpawnPermit()
+        }
+        XCTAssertFalse(pacer.isPassthrough)
+
+        try await waitUntil("deinit cancels the permit") { pacer.isPassthrough }
+    }
 }

--- a/agtermTests/LaunchSeedTests.swift
+++ b/agtermTests/LaunchSeedTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// The deferred launch seed: which panes are classified as paceable without consuming anything, and what
+/// each disposition consumes when the seed finally resolves.
+@MainActor
+final class LaunchSeedTests: XCTestCase {
+    private let configuration = ZmxSupport.Configuration(
+        command: "'/bin/zmx' 'attach' 'agterm-pane'",
+        environment: ["SHELL": "/bin/zsh", "ZDOTDIR": "/bundle/zsh"],
+        daemonName: "agterm-pane",
+        socketDirectory: "/tmp/zmx",
+        paneID: "pane"
+    )
+
+    // MARK: - ordinary
+
+    func testOrdinaryPacesACaptureTheDenylistAccepts() {
+        let session = restoredSession()
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+
+        let provider = ordinaryProvider(session: session, pane: .left)
+
+        XCTAssertTrue(provider.shouldPace)
+        XCTAssertEqual(provider.resolve(.left).initialInput, "'npm' 'run' 'dev'\n")
+    }
+
+    func testOrdinaryPacesANonEmptyPinAndARestoredDurableCommand() {
+        let pinned = restoredSession()
+        pinned.pendingRestoreCommand = "tail -f /tmp/log"
+        let pinnedProvider = ordinaryProvider(session: pinned, pane: .left)
+        XCTAssertTrue(pinnedProvider.shouldPace)
+        XCTAssertEqual(pinnedProvider.resolve(.left).initialInput, "tail -f /tmp/log\n")
+
+        let durable = restoredSession()
+        durable.splitInitialCommand = "htop"
+        let durableProvider = ordinaryProvider(session: durable, pane: .right)
+        XCTAssertTrue(durableProvider.shouldPace)
+        XCTAssertEqual(durableProvider.resolve(.right).command, "htop")
+    }
+
+    func testOrdinaryDoesNotPaceAPinNoneADeniedCaptureOrAPlainShell() {
+        let pinNone = restoredSession()
+        pinNone.initialCommand = "htop"
+        pinNone.pendingRestoreCommand = ""
+        XCTAssertFalse(ordinaryProvider(session: pinNone, pane: .left).shouldPace)
+
+        let denied = restoredSession()
+        denied.initialCommand = "htop"
+        denied.pendingForegroundCommand = ["tmux", "attach"]
+        let deniedProvider = ordinaryProvider(session: denied, pane: .left, denylist: ["tmux"])
+        XCTAssertFalse(deniedProvider.shouldPace)
+        let deniedSeed = deniedProvider.resolve(.left)
+        XCTAssertNil(deniedSeed.command, "a denied capture suppresses the durable command too")
+        XCTAssertNil(deniedSeed.initialInput)
+
+        XCTAssertFalse(ordinaryProvider(session: restoredSession(), pane: .left).shouldPace)
+    }
+
+    func testOrdinaryConsumesEachPendingSlotOnce() {
+        let session = restoredSession()
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+        session.pendingRestoreCommand = "tail -f /tmp/log"
+        session.restoreCommand = "tail -f /tmp/log"
+
+        _ = ordinaryProvider(session: session, pane: .left).resolve(.left)
+
+        XCTAssertNil(session.pendingForegroundCommand)
+        XCTAssertNil(session.pendingRestoreCommand)
+        XCTAssertEqual(session.restoreCommand, "tail -f /tmp/log", "the sticky pin outlives the launch")
+    }
+
+    /// Preserving the slots under `none` would let a mode change to rerun before the next clean quit replay
+    /// a command the user launched a plain shell under.
+    func testExplicitNoneDropsBothPendingSlotsAndSpawnsAPlainShell() {
+        let session = restoredSession()
+        session.initialCommand = "htop"
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+        session.pendingRestoreCommand = "tail -f /tmp/log"
+
+        let provider = ordinaryProvider(session: session, pane: .left, restoreEnabled: false)
+
+        XCTAssertFalse(provider.shouldPace)
+        let seed = provider.resolve(.left)
+        XCTAssertNil(seed.command)
+        XCTAssertNil(seed.initialInput)
+        XCTAssertNil(session.pendingForegroundCommand)
+        XCTAssertNil(session.pendingRestoreCommand)
+    }
+
+    // MARK: - wrapped
+
+    func testWrappedPacesAnEligibleCaptureAndARestoredDurableCommand() {
+        let captured = restoredSession()
+        captured.pendingForegroundCommand = ["npm", "run", "dev"]
+        let capturedProvider = wrappedProvider(session: captured, pane: .left)
+        XCTAssertTrue(capturedProvider.shouldPace)
+        XCTAssertEqual(capturedProvider.resolve(.left).command, ZmxSupport.attachCommand(
+            configuration, replaying: ["npm", "run", "dev"], denylist: []))
+
+        let durable = restoredSession()
+        durable.splitInitialCommand = "htop"
+        let durableProvider = wrappedProvider(session: durable, pane: .right)
+        XCTAssertTrue(durableProvider.shouldPace)
+        XCTAssertNotEqual(durableProvider.resolve(.right).command, configuration.command)
+    }
+
+    func testWrappedDoesNotPaceAPaneCarryingOnlyAStickyPin() {
+        let session = restoredSession()
+        session.restoreCommand = "tail -f /tmp/log"
+        session.pendingRestoreCommand = "tail -f /tmp/log"
+
+        let provider = wrappedProvider(session: session, pane: .left)
+
+        XCTAssertFalse(provider.shouldPace)
+        XCTAssertEqual(provider.resolve(.left).command, configuration.command)
+        XCTAssertEqual(session.pendingRestoreCommand, "tail -f /tmp/log",
+                       "a live pane never reads the pin, so it stays armed for the next rerun launch")
+    }
+
+    func testWrappedDoesNotPaceADeniedCaptureOrARunningDaemon() {
+        let denied = restoredSession()
+        denied.pendingForegroundCommand = ["tmux", "attach"]
+        XCTAssertFalse(wrappedProvider(session: denied, pane: .left, denylist: ["tmux"]).shouldPace)
+
+        let survivor = restoredSession()
+        survivor.pendingForegroundCommand = ["npm", "run", "dev"]
+        XCTAssertFalse(wrappedProvider(session: survivor, pane: .left,
+                                       runningNames: [configuration.daemonName]).shouldPace,
+                       "attaching a surviving daemon runs no program")
+        XCTAssertTrue(wrappedProvider(session: survivor, pane: .left, runningNames: ["agterm-other"]).shouldPace)
+        XCTAssertTrue(wrappedProvider(session: survivor, pane: .left, runningNames: nil).shouldPace,
+                      "a failed list must pace every replaying pane")
+    }
+
+    // MARK: - fallback
+
+    func testFallbackIsNeverPacedAndLeavesThePinAndCapturePending() {
+        let session = restoredSession()
+        session.initialCommand = "htop"
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+        session.pendingRestoreCommand = "tail -f /tmp/log"
+
+        let provider = LaunchSeedProvider.pane(
+            session: session, pane: .left, disposition: .fallback,
+            policy: .init(restoreEnabled: true, denylist: [], runningNames: nil))
+
+        XCTAssertFalse(provider.shouldPace)
+        XCTAssertNil(provider.resolve(.left).command, "a restored fallback pane runs no durable command")
+        XCTAssertEqual(session.pendingForegroundCommand, ["npm", "run", "dev"])
+        XCTAssertEqual(session.pendingRestoreCommand, "tail -f /tmp/log")
+    }
+
+    /// `session.swap` moves a mounted surface into the other slot and swaps the pending payloads with it,
+    /// so the seed must read the slot the pane occupies at spawn time.
+    func testResolvingReadsTheLivePaneNotTheOneItWasBuiltIn() {
+        let session = restoredSession()
+        session.pendingForegroundCommand = ["npm", "run", "dev"]
+        session.pendingSplitForegroundCommand = ["htop"]
+
+        let seed = ordinaryProvider(session: session, pane: .left).resolve(.right)
+
+        XCTAssertEqual(seed.initialInput, "'htop'\n")
+        XCTAssertNil(session.pendingSplitForegroundCommand)
+        XCTAssertEqual(session.pendingForegroundCommand, ["npm", "run", "dev"])
+    }
+
+    // MARK: - classification
+
+    func testClassifyingAPaneConsumesNoSlot() {
+        for disposition in [ZmxLaunch.Disposition.ordinary, .wrapped(configuration), .fallback] {
+            let session = restoredSession()
+            session.pendingForegroundCommand = ["npm", "run", "dev"]
+            session.pendingSplitForegroundCommand = ["htop"]
+            session.pendingRestoreCommand = "tail -f /tmp/log"
+            session.pendingSplitRestoreCommand = "less /tmp/log"
+
+            for pane in [StatusPane.left, .right] {
+                _ = LaunchSeedProvider.pane(
+                    session: session, pane: pane, disposition: disposition,
+                    policy: .init(restoreEnabled: true, denylist: [], runningNames: nil)).shouldPace
+            }
+
+            XCTAssertEqual(session.pendingForegroundCommand, ["npm", "run", "dev"])
+            XCTAssertEqual(session.pendingSplitForegroundCommand, ["htop"])
+            XCTAssertEqual(session.pendingRestoreCommand, "tail -f /tmp/log")
+            XCTAssertEqual(session.pendingSplitRestoreCommand, "less /tmp/log")
+        }
+    }
+
+    func testAFreshPaneIsNeverPaced() {
+        let session = Session(initialCwd: "/tmp")
+        session.initialCommand = "htop"
+
+        XCTAssertFalse(ordinaryProvider(session: session, pane: .left).shouldPace)
+        XCTAssertFalse(wrappedProvider(session: session, pane: .left).shouldPace)
+        XCTAssertEqual(ordinaryProvider(session: session, pane: .left).resolve(.left).command, "htop")
+    }
+
+    private func restoredSession() -> Session {
+        let session = Session(initialCwd: "/tmp")
+        session.wasRestored = true
+        return session
+    }
+
+    private func ordinaryProvider(session: Session, pane: StatusPane, denylist: Set<String> = [],
+                                  restoreEnabled: Bool = true) -> LaunchSeedProvider {
+        LaunchSeedProvider.pane(
+            session: session, pane: pane, disposition: .ordinary,
+            policy: .init(restoreEnabled: restoreEnabled, denylist: denylist, runningNames: nil))
+    }
+
+    private func wrappedProvider(session: Session, pane: StatusPane, denylist: Set<String> = [],
+                                 runningNames: Set<String>? = nil) -> LaunchSeedProvider {
+        LaunchSeedProvider.pane(
+            session: session, pane: pane, disposition: .wrapped(configuration),
+            policy: .init(restoreEnabled: true, denylist: denylist, runningNames: runningNames))
+    }
+}

--- a/agtermTests/SpawnRegistryTests.swift
+++ b/agtermTests/SpawnRegistryTests.swift
@@ -102,6 +102,78 @@ final class SpawnRegistryTests: XCTestCase {
         XCTAssertNil(registry.view(for: key))
     }
 
+    // MARK: - launch pipeline
+
+    /// The launch as the app runs it, minus the factories: arm from the plan, queue each pane, request as
+    /// each mounts. The selected pane spawns on its request; the rest follow one interval apart, in model
+    /// order; a session created after the drain never waits.
+    func testALaunchSpawnsTheSelectedPaneNowAndTheRestOneIntervalApart() throws {
+        let sessions = (0..<3).map { _ in restoredSession() }
+        let plan = LaunchSpawnPlan.make(windows: [
+            LaunchSpawnWindow(selectedSessionID: sessions[1].id, sessions: sessions),
+        ])
+        let interval = Duration.milliseconds(120)
+        var clock = ContinuousClock().now
+        var wakes: [@MainActor () -> Void] = []
+        let pacer = SpawnPacer(interval: interval, now: { clock }, schedule: { _, body in wakes.append(body) })
+        let paced = SpawnRegistry(pacer: pacer)
+        var grants: [(key: UUID, at: ContinuousClock.Instant)] = []
+        let route = pacer.onGrant
+        pacer.onGrant = { grants.append(($0, clock)); route?($0) }
+        pacer.arm(order: plan.order, burst: plan.burst)
+        let views = sessions.map { session -> GhosttySurfaceView in
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            paced.enqueue(view, key: session.paneIdentity, provider: replaying())
+            return view
+        }
+
+        XCTAssertFalse(views[0].requestSpawnPermit())
+        XCTAssertTrue(views[1].requestSpawnPermit(), "the selected pane spawns as soon as it asks")
+        XCTAssertFalse(views[2].requestSpawnPermit())
+        var fired = 0
+        while !wakes.isEmpty, fired < 10 {
+            clock += interval
+            wakes.removeFirst()()
+            fired += 1
+        }
+
+        XCTAssertEqual(grants.map(\.key),
+                       [sessions[1].paneIdentity, sessions[0].paneIdentity, sessions[2].paneIdentity])
+        let times = try XCTUnwrap(grants.count == 3 ? grants.map(\.at) : nil, "every pane must be granted")
+        XCTAssertEqual(times[1] - times[0], interval)
+        XCTAssertEqual(times[2] - times[1], interval)
+        XCTAssertTrue(pacer.isPassthrough)
+        let late = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        paced.enqueue(late, key: UUID(), provider: replaying())
+        XCTAssertTrue(late.requestSpawnPermit(), "after the drain a new session never waits")
+    }
+
+    func testAOneSessionLaunchSpawnsSynchronously() {
+        let session = restoredSession()
+        let plan = LaunchSpawnPlan.make(windows: [
+            LaunchSpawnWindow(selectedSessionID: session.id, sessions: [session]),
+        ])
+        let paced = SpawnRegistry(pacer: SpawnPacer())
+        paced.pacer.arm(order: plan.order, burst: plan.burst)
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        paced.enqueue(view, key: session.paneIdentity, provider: replaying())
+
+        XCTAssertTrue(view.requestSpawnPermit())
+        XCTAssertTrue(paced.pacer.isPassthrough)
+    }
+
+    private func restoredSession() -> Session {
+        let session = Session(initialCwd: "/tmp")
+        session.wasRestored = true
+        return session
+    }
+
+    private func replaying() -> LaunchSeedProvider {
+        LaunchSeedProvider(shouldPace: true) { _ in
+            LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        }
+    }
+
     private func enqueue(_ view: GhosttySurfaceView) {
         registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: true) { _ in
             LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)

--- a/agtermTests/SpawnRegistryTests.swift
+++ b/agtermTests/SpawnRegistryTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import agterm
+@testable import agtermCore
+
+/// The pacer knows only keys, so the registry is what turns a grant into a spawn. Its weak entries are the
+/// contract that matters: a queued pane the user closed must not be resurrected by its own grant.
+@MainActor
+final class SpawnRegistryTests: XCTestCase {
+    private var registry: SpawnRegistry!
+    private var key: UUID!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            registry = SpawnRegistry(pacer: SpawnPacer())
+            key = UUID()
+            registry.pacer.arm(order: [key], burst: [])
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run { registry = nil; key = nil }
+        try await super.tearDown()
+    }
+
+    /// The view stays at its zero init size, so the re-entered `createSurface` parks on the size guard
+    /// instead of spawning a shell; the drop registration it runs first is the proof it was re-entered.
+    func testAGrantSpawnsTheRegisteredPane() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        enqueue(view)
+        XCTAssertFalse(view.requestSpawnPermit())
+        view.unregisterDraggedTypes()
+
+        registry.pacer.expedite(key)
+
+        XCTAssertFalse(view.registeredDraggedTypes.isEmpty, "the grant never reached createSurface")
+    }
+
+    func testARegisteredPaneIsForgottenOnceGranted() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        enqueue(view)
+        _ = registry.pacer.request(key)
+        XCTAssertTrue(registry.view(for: key) === view)
+
+        registry.pacer.expedite(key)
+
+        XCTAssertNil(registry.view(for: key), "a key is granted once")
+    }
+
+    func testQueueingPointsThePaneAtThePacer() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        enqueue(view)
+
+        XCTAssertFalse(view.requestSpawnPermit(), "a queued pane must ask the armed pacer")
+        XCTAssertTrue(view.awaitingSpawnPermit)
+    }
+
+    func testAPaneThatReplaysNothingIsDiscardedRatherThanQueued() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: false) { _ in
+            LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        })
+
+        XCTAssertNil(registry.view(for: key))
+        XCTAssertTrue(registry.pacer.isPassthrough, "a discarded key must not hold the queue open")
+        XCTAssertTrue(view.requestSpawnPermit())
+    }
+
+    func testAPaneWithNoKeyIsNeverQueued() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+
+        registry.enqueue(view, key: nil, provider: LaunchSeedProvider(shouldPace: true) { _ in
+            LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        })
+
+        XCTAssertTrue(view.requestSpawnPermit(), "a fresh or runtime split was never expected")
+    }
+
+    func testABurstGrantIsConsumedByTheRequesterNotReplayedThroughTheRegistry() {
+        registry.pacer.arm(order: [key], burst: [key])
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        enqueue(view)
+        view.unregisterDraggedTypes()
+
+        XCTAssertTrue(view.requestSpawnPermit(), "a burst key is granted on request")
+
+        XCTAssertTrue(view.registeredDraggedTypes.isEmpty, "the grant re-entered createSurface under the requester")
+        XCTAssertNil(registry.view(for: key))
+    }
+
+    func testAPreExpeditedGrantIsConsumedByTheRequesterNotReplayedThroughTheRegistry() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        enqueue(view)
+        registry.pacer.expedite(key)
+        view.unregisterDraggedTypes()
+
+        XCTAssertTrue(view.requestSpawnPermit(), "an expedited key is granted on request")
+
+        XCTAssertTrue(view.registeredDraggedTypes.isEmpty, "the grant re-entered createSurface under the requester")
+        XCTAssertNil(registry.view(for: key))
+    }
+
+    private func enqueue(_ view: GhosttySurfaceView) {
+        registry.enqueue(view, key: key, provider: LaunchSeedProvider(shouldPace: true) { _ in
+            LaunchSeed(command: nil, initialInput: nil, waitAfterCommand: false)
+        })
+    }
+
+    func testTheRegistryHoldsThePaneWeakly() {
+        weak var released: GhosttySurfaceView?
+        autoreleasepool {
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            enqueue(view)
+            released = view
+        }
+
+        XCTAssertNil(released, "a registry entry must not keep a closed pane alive")
+        XCTAssertNil(registry.view(for: key))
+    }
+
+    func testAGrantForADeallocatedPaneIsDropped() {
+        autoreleasepool {
+            let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            enqueue(view)
+        }
+        _ = registry.pacer.request(key)
+
+        registry.pacer.expedite(key)
+
+        XCTAssertNil(registry.view(for: key))
+    }
+
+    func testAGrantForAnUnknownKeyIsIgnored() {
+        let stray = UUID()
+
+        registry.grant(stray)
+
+        XCTAssertNil(registry.view(for: stray))
+    }
+}

--- a/agtermTests/SurfaceFactorySeedTests.swift
+++ b/agtermTests/SurfaceFactorySeedTests.swift
@@ -4,6 +4,29 @@ import agtermCore
 
 @MainActor
 final class SurfaceFactorySeedTests: XCTestCase {
+    private var stateDir: URL!
+    private var store: AppStore!
+    private var library: WindowLibrary!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-surface-factory-seed-tests-\(UUID().uuidString)", isDirectory: true)
+            store = AppStore(persistence: PersistenceStore(directory: stateDir))
+            library = WindowLibrary(directory: stateDir)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            store = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+        }
+        try await super.tearDown()
+    }
+
     private let configuration = ZmxSupport.Configuration(
         command: "'/bin/zmx' 'attach' 'agterm-pane'",
         environment: ["SHELL": "/bin/zsh", "ZDOTDIR": "/bundle/zsh"],
@@ -116,6 +139,64 @@ final class SurfaceFactorySeedTests: XCTestCase {
 
         XCTAssertEqual(seed.command, configuration.command)
         XCTAssertEqual(seed.initialInput, "ssh example\n")
+    }
+
+    // MARK: - factory wiring
+
+    // the hosted scheme's isolated state dir latches restore mode `.none`, so both factories build an
+    // ordinary disposition and a fresh pane's durable command is the seed in force.
+    func testPrimaryFactoryDefersItsSeedAndResolvesOnlyTheLeftSlot() {
+        let restored = restoredSession()
+        setPendingCapture(["primary"], on: .left, session: restored)
+        setPendingCapture(["split"], on: .right, session: restored)
+
+        let view = primarySurface(for: restored)
+
+        XCTAssertNotNil(view.launchSeed)
+        XCTAssertEqual(pendingCapture(on: .left, session: restored), ["primary"])
+        XCTAssertEqual(pendingCapture(on: .right, session: restored), ["split"])
+
+        view.resolveLaunchSeed()
+
+        XCTAssertNil(pendingCapture(on: .left, session: restored))
+        XCTAssertEqual(pendingCapture(on: .right, session: restored), ["split"])
+
+        let fresh = Session(initialCwd: "/tmp")
+        fresh.initialCommand = "echo primary"
+        XCTAssertEqual(primarySurface(for: fresh).resolveLaunchSeed(),
+                       LaunchSeed(command: "echo primary", initialInput: nil, waitAfterCommand: false))
+    }
+
+    func testSplitFactoryDefersItsSeedAndResolvesOnlyTheRightSlot() {
+        let restored = restoredSession()
+        setPendingCapture(["primary"], on: .left, session: restored)
+        setPendingCapture(["split"], on: .right, session: restored)
+
+        let view = splitSurface(for: restored)
+
+        XCTAssertNotNil(view.launchSeed)
+        XCTAssertEqual(pendingCapture(on: .left, session: restored), ["primary"])
+        XCTAssertEqual(pendingCapture(on: .right, session: restored), ["split"])
+
+        view.resolveLaunchSeed()
+
+        XCTAssertEqual(pendingCapture(on: .left, session: restored), ["primary"])
+        XCTAssertNil(pendingCapture(on: .right, session: restored))
+
+        let fresh = Session(initialCwd: "/tmp")
+        fresh.splitInitialCommand = "echo split"
+        XCTAssertEqual(splitSurface(for: fresh).resolveLaunchSeed(),
+                       LaunchSeed(command: "echo split", initialInput: nil, waitAfterCommand: false))
+    }
+
+    private func primarySurface(for session: Session) -> GhosttySurfaceView {
+        agtermApp.makeSurface(for: session, store: store, env: [:], library: library,
+                              zmxForegroundResolver: nil)
+    }
+
+    private func splitSurface(for session: Session) -> GhosttySurfaceView {
+        agtermApp.makeSplitSurface(for: session, store: store, env: [:], library: library,
+                                   zmxForegroundResolver: nil)
     }
 
     private func restoredSession() -> Session {

--- a/agtermTests/SurfaceFactorySeedTests.swift
+++ b/agtermTests/SurfaceFactorySeedTests.swift
@@ -226,8 +226,36 @@ final class SurfaceFactorySeedTests: XCTestCase {
         agtermApp.makeSplitSurface(for: session, store: store, env: [:], services: services(registry))
     }
 
+    /// A restored split hidden at quit is not armed: shown later it attaches through the unarmed path,
+    /// its capture still waiting for that spawn, and the queue drains without it.
+    func testAHiddenSplitShownLaterAttachesUnarmedWithItsCaptureIntact() {
+        let session = restoredSession()
+        session.splitPaneIdentity = UUID()
+        session.hasSplit = true
+        setPendingCapture(["split"], on: .right, session: session)
+        let registry = SpawnRegistry(pacer: SpawnPacer())
+        registry.pacer.arm(order: [session.paneIdentity], burst: [])
+
+        let view = splitSurface(for: session, registry: registry)
+
+        XCTAssertTrue(view.requestSpawnPermit(), "a key outside the armed order never waits")
+        XCTAssertNotNil(view.launchSeed)
+        XCTAssertEqual(pendingCapture(on: .right, session: session), ["split"])
+        XCTAssertFalse(registry.pacer.isPassthrough, "the armed primary still waits its turn")
+    }
+
+    func testThePolicyCarriesTheReapsRunningNames() {
+        let context = agtermApp.LaunchSpawnContext()
+        context.runningNames = ["agterm-alive"]
+
+        XCTAssertEqual(agtermApp.launchSeedPolicy(GhosttyApp.shared, context: context).runningNames, ["agterm-alive"])
+        XCTAssertNil(agtermApp.launchSeedPolicy(GhosttyApp.shared, context: agtermApp.LaunchSpawnContext()).runningNames,
+                     "a skipped or failed list paces every replaying live pane")
+    }
+
     private func services(_ registry: SpawnRegistry?) -> agtermApp.SurfaceServices {
-        agtermApp.SurfaceServices(library: library, zmxForegroundResolver: nil, spawnRegistry: registry)
+        agtermApp.SurfaceServices(library: library, zmxForegroundResolver: nil, spawnRegistry: registry,
+                                  launchContext: agtermApp.LaunchSpawnContext())
     }
 
     private func restoredSession() -> Session {

--- a/agtermTests/SurfaceFactorySeedTests.swift
+++ b/agtermTests/SurfaceFactorySeedTests.swift
@@ -189,14 +189,45 @@ final class SurfaceFactorySeedTests: XCTestCase {
                        LaunchSeed(command: "echo split", initialInput: nil, waitAfterCommand: false))
     }
 
-    private func primarySurface(for session: Session) -> GhosttySurfaceView {
-        agtermApp.makeSurface(for: session, store: store, env: [:], library: library,
-                              zmxForegroundResolver: nil)
+    /// Arming expects every restored primary and shown right pane, before any provider exists to say which
+    /// of them replays a program. A pane that turns out to replay nothing must leave the queue at
+    /// construction, or the drain waits forever on a permit it never asks for.
+    func testAPrimaryThatReplaysNothingLeavesTheLaunchQueue() {
+        let session = restoredSession()
+        let registry = SpawnRegistry(pacer: SpawnPacer())
+        registry.pacer.arm(order: [session.paneIdentity], burst: [])
+
+        let view = primarySurface(for: session, registry: registry)
+
+        XCTAssertNil(registry.view(for: session.paneIdentity))
+        XCTAssertTrue(registry.pacer.isPassthrough)
+        XCTAssertTrue(view.requestSpawnPermit(), "an unpaced pane must not wait on a permit")
     }
 
-    private func splitSurface(for session: Session) -> GhosttySurfaceView {
-        agtermApp.makeSplitSurface(for: session, store: store, env: [:], library: library,
-                                   zmxForegroundResolver: nil)
+    func testASplitThatReplaysNothingLeavesTheLaunchQueue() throws {
+        let session = restoredSession()
+        session.splitPaneIdentity = UUID()
+        let splitKey = try XCTUnwrap(session.splitPaneIdentity)
+        let registry = SpawnRegistry(pacer: SpawnPacer())
+        registry.pacer.arm(order: [splitKey], burst: [])
+
+        let view = splitSurface(for: session, registry: registry)
+
+        XCTAssertNil(registry.view(for: splitKey))
+        XCTAssertTrue(registry.pacer.isPassthrough)
+        XCTAssertTrue(view.requestSpawnPermit(), "an unpaced pane must not wait on a permit")
+    }
+
+    private func primarySurface(for session: Session, registry: SpawnRegistry? = nil) -> GhosttySurfaceView {
+        agtermApp.makeSurface(for: session, store: store, env: [:], services: services(registry))
+    }
+
+    private func splitSurface(for session: Session, registry: SpawnRegistry? = nil) -> GhosttySurfaceView {
+        agtermApp.makeSplitSurface(for: session, store: store, env: [:], services: services(registry))
+    }
+
+    private func services(_ registry: SpawnRegistry?) -> agtermApp.SurfaceServices {
+        agtermApp.SurfaceServices(library: library, zmxForegroundResolver: nil, spawnRegistry: registry)
     }
 
     private func restoredSession() -> Session {

--- a/agtermTests/ZmxClientTests.swift
+++ b/agtermTests/ZmxClientTests.swift
@@ -102,7 +102,7 @@ final class ZmxClientTests: XCTestCase {
 
         XCTAssertTrue(client.reap(
             knownPaneIdentities: [known],
-            launchDecision: RestoreMode.live.launchDecision(liveUnavailableReason: nil)))
+            launchDecision: RestoreMode.live.launchDecision(liveUnavailableReason: nil)).killedAll)
         XCTAssertEqual(invocations.map(\.arguments), [["list"], ["kill", orphan, "--force"]])
         XCTAssertEqual(invocations.map(\.timeout), [1.5, 1.5])
         XCTAssertEqual(invocations[0].environment["ZMX_DIR"], "/tmp/zmx-dir")
@@ -118,7 +118,7 @@ final class ZmxClientTests: XCTestCase {
 
         XCTAssertTrue(client.reap(
             knownPaneIdentities: nil,
-            launchDecision: RestoreMode.live.launchDecision(liveUnavailableReason: nil)))
+            launchDecision: RestoreMode.live.launchDecision(liveUnavailableReason: nil)).killedAll)
         XCTAssertEqual(calls, 0)
     }
 
@@ -132,8 +132,58 @@ final class ZmxClientTests: XCTestCase {
 
         let fallback = RestoreMode.live.launchDecision(liveUnavailableReason: "login shell is not zsh")
         XCTAssertEqual(fallback.active, .none)
-        XCTAssertTrue(client.reap(knownPaneIdentities: [known], launchDecision: fallback))
+        XCTAssertTrue(client.reap(knownPaneIdentities: [known], launchDecision: fallback).killedAll)
         XCTAssertEqual(invocations, [["list"]])
+    }
+
+    func testReapReportsEveryReadableDaemonAsRunning() {
+        let known = UUID()
+        let client = ZmxClient(executablePath: "/tmp/zmx", socketDirectory: "/tmp/zmx-dir") { _ in
+            """
+            name=\(ZmxSupport.daemonName(for: known))\tpid=1\tclients=0\tcreated=1
+            name=agterm-attached\tpid=3\tclients=1\tcreated=1
+            name=agterm-stale\terr=Timeout\tstatus=unreachable
+            """
+        }
+
+        let outcome = client.reap(knownPaneIdentities: [known],
+                                  launchDecision: RestoreMode.live.launchDecision(liveUnavailableReason: nil))
+
+        XCTAssertTrue(outcome.killedAll)
+        XCTAssertEqual(outcome.runningNames, [ZmxSupport.daemonName(for: known), "agterm-attached"],
+                       "an err= row is unreadable, so its pane must pace like a missing daemon")
+    }
+
+    func testReapReportsNoRunningNamesWhenTheListIsSkippedOrFails() {
+        let failing = ZmxClient(executablePath: "/tmp/zmx", socketDirectory: "/tmp/zmx-dir") { _ in
+            throw ZmxClient.CommandError.timedOut
+        }
+        let live = RestoreMode.live.launchDecision(liveUnavailableReason: nil)
+
+        let failed = failing.reap(knownPaneIdentities: [UUID()], launchDecision: live)
+        let skipped = failing.reap(knownPaneIdentities: nil, launchDecision: live)
+
+        XCTAssertEqual(failed, ZmxClient.ReapOutcome(runningNames: nil, killedAll: false))
+        XCTAssertEqual(skipped, ZmxClient.ReapOutcome(runningNames: nil, killedAll: true))
+    }
+
+    func testAFailedOrphanKillKeepsTheRunningNames() {
+        let known = UUID()
+        let orphan = ZmxSupport.daemonName(for: UUID())
+        let client = ZmxClient(executablePath: "/tmp/zmx", socketDirectory: "/tmp/zmx-dir") { invocation in
+            guard invocation.arguments == ["list"] else { throw ZmxClient.CommandError.timedOut }
+            return """
+            name=\(ZmxSupport.daemonName(for: known))\tpid=1\tclients=0\tcreated=1
+            name=\(orphan)\tpid=2\tclients=0\tcreated=1
+            """
+        }
+
+        let outcome = client.reap(knownPaneIdentities: [known],
+                                  launchDecision: RestoreMode.live.launchDecision(liveUnavailableReason: nil))
+
+        XCTAssertFalse(outcome.killedAll)
+        XCTAssertEqual(outcome.runningNames, [ZmxSupport.daemonName(for: known), orphan],
+                       "a good list stands even when the orphan kill fails")
     }
 
     func testSemanticKillUsesFullPaneDaemonNames() {

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -258,20 +258,20 @@ does not apply.
 - Create: `agtermCore/Sources/agtermCore/SpawnPacer.swift`
 - Create: `agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift`
 
-- [ ] write tests first: arm with no requests emits nothing even after the clock advances; N keys requested
+- [x] write tests first: arm with no requests emits nothing even after the clock advances; N keys requested
       late, in any order, yield N grants each `interval` apart in expected order, timed from the actual
       grants; a burst key grants synchronously on its request, not on arm; the timer waits when the next
       expected key has not requested yet; a clock that wakes late by 3 intervals releases ONE grant;
       expedite grants one key now, consumes the token and resets the deadline; prioritize reorders and
       releases nothing; discarding an expected key that never requests cannot block drain
-- [ ] write tests first: double request is idempotent; expedite of a granted, unknown or already-expedited
+- [x] write tests first: double request is idempotent; expedite of a granted, unknown or already-expedited
       key is a no-op; cancel and discard drop without a grant and without catch-up; request after
       passthrough is synchronous; unarmed pacer grants synchronously
-- [ ] add `SpawnKey`, `SpawnPacer` with `request` (marks ready), `expedite`, `prioritize`, `cancel`,
+- [x] add `SpawnKey`, `SpawnPacer` with `request` (marks ready), `expedite`, `prioritize`, `cancel`,
       `discard`, `arm(order:burst:)` (records expectations only), `isPassthrough`, `interval`, injected
       clock/timer, and `onGrant`
-- [ ] leaky-bucket deadline computed from the actual previous grant; no catch-up
-- [ ] run `cd agtermCore && swift test --filter SpawnPacerTests` - must pass before Task 2
+- [x] leaky-bucket deadline computed from the actual previous grant; no catch-up
+- [x] run `cd agtermCore && swift test --filter SpawnPacerTests` - must pass before Task 2
 
 ### Task 2: Late seed: `LaunchSeedProvider` on the view, consumed at spawn
 

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -429,17 +429,19 @@ signal. No command sets this state, so the read-back rule for state-setting comm
       (a queued right pane shows nothing on either)
 
 ### Task 7: Update documentation
-- [ ] `.claude/rules/libghostty.md`: the permit and the late seed inside `createSurface()`, and why the
+- [x] `.claude/rules/libghostty.md`: the permit and the late seed inside `createSurface()`, and why the
       deferral does not race layout
-- [ ] `.claude/rules/settings.md` (owns restore capture and the pending slots): seed consumption at
+- [x] `.claude/rules/settings.md` (owns restore capture and the pending slots): seed consumption at
       spawn time; `restore.clear` and clean-quit preservation now cover the paced window; hard reset
       boundary unchanged
-- [ ] `.claude/rules/control-api.md`: which commands expedite a queued pane and which reads never do
-- [ ] `site/docs.html` restore section: one sentence that a launch which replays commands brings panes up
+- [x] `.claude/rules/control-api.md`: which commands expedite a queued pane and which reads never do
+- [x] `site/docs.html` restore section: one sentence that a launch which replays commands brings panes up
       over several seconds, the visible panes first
-- [ ] `plugins/agterm/skills/agterm/troubleshooting.md`: `(not realized)` right after a replaying launch
+- [x] `plugins/agterm/skills/agterm/troubleshooting.md`: `(not realized)` right after a replaying launch
       is pacing, not a fault
-- [ ] move this plan to `docs/plans/completed/`
+- [ ] move this plan to `docs/plans/completed/` (left in place: this run does not move the plan; do it when the PR merges)
+- [x] ➕ `plugins/agterm/skills/agterm/reference.md` and `SKILL.md`: their `realized` sentences said `session type`
+      answers `session not realized` for an unrealized pane, which the expedite makes untrue for a paced one
 
 ## Post-Completion
 

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -341,29 +341,30 @@ does not apply.
 
 **Files:**
 - Modify: `agterm/Ghostty/GhosttySurfaceView.swift` (`deckActive` didSet)
-- Modify: `agterm/Views/TerminalZoom*.swift`, `agterm/Views/Dashboard*.swift` (host attach points)
+- Modify: `agterm/Views/DashboardView.swift` (the zoom host already sets `deckActive`, so it needs no change)
+- Create: `agtermTests/DashboardViewTests.swift`
 - Modify: `agterm/Control/ControlServer+SurfaceIO.swift` (`injectText` for `session.type`, `searchSession`,
   `pasteSession`, `selectAllSession`, `font`)
-- Modify: `agterm/Control/ControlServer+Zmx.swift` only if `applyKilledPaneExit` needs a `discard`
+- `agterm/Control/ControlServer+Zmx.swift` unchanged: teardown cancels the key, so `applyKilledPaneExit` needs no `discard`
 - Modify: the corresponding `agtermTests` files and the dispatcher/protocol tests those commands own
 
-- [ ] write tests first: with a paced launch the selected pane of each window is granted synchronously on
+- [x] write tests first: with a paced launch the selected pane of each window is granted synchronously on
       its first request after arm; selecting a queued session grants it before the queue reaches it;
       selecting it twice mints one token
-- [ ] write tests first: `session.type --select` on a queued pane succeeds within the existing 12 x 30 ms
+- [x] write tests first: `session.type --select` on a queued pane succeeds within the existing 12 x 30 ms
       poll; `session.type --pane right` on a queued shown split succeeds and on an absent split fails fast
       as today; `session.search` open on a queued pane realizes it; `session.paste`, `session.selectall`
       and `font.inc` on a queued left pane and on a queued shown right pane succeed synchronously
-- [ ] write tests first: on a queued pane `session.text` and `session.copy` answer `session not realized`
+- [x] write tests first: on a queued pane `session.text` and `session.copy` answer `session not realized`
       and `surface.cursor` answers `surface not realized`, all leaving it queued; a dashboard opened on
       queued members promotes them but records spawns still `interval` apart
-- [ ] write tests first: `zmx kill` on a claimed, mounted, unspawned pane performs the model transition
+- [x] write tests first: `zmx kill` on a claimed, mounted, unspawned pane performs the model transition
       (`handlePaneExit`) and the later grant does not recreate the daemon
-- [ ] keep the expedite set to exactly `session.type`, `session.search`, `session.paste`, `session.selectall`
+- [x] keep the expedite set to exactly `session.type`, `session.search`, `session.paste`, `session.selectall`
       and `font.inc/dec/reset`: the last four resolve a surface and answer `session not realized` when it
       has none (`ControlServer+SurfaceIO.swift:32-62`); the scratch pane is runtime-only and never queued
-- [ ] wire `deckActive`, zoom host and dashboard host; wire the control expedites before each bounded poll
-- [ ] run the touched test classes - must pass before Task 5
+- [x] wire `deckActive`, zoom host and dashboard host; wire the control expedites before each bounded poll
+- [x] run the touched test classes - must pass before Task 5
 
 ### Task 5: Arm from the launch inventory with the survivor hint; drain to passthrough
 

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -276,6 +276,10 @@ does not apply.
 ### Task 2: Late seed: `LaunchSeedProvider` on the view, consumed at spawn
 
 **Files:**
+- Create: `agterm/Ghostty/LaunchSeed.swift` (`LaunchSeed`, `LaunchSeedProvider`, `LaunchSeedPolicy` and the
+  classifier live here, not in `GhosttySurfaceView.swift`, which sits at 996 of the 1000-line cap and
+  Task 3 must still grow)
+- Create: `agtermTests/LaunchSeedTests.swift`
 - Modify: `agterm/Ghostty/GhosttySurfaceView.swift`
 - Modify: `agterm/agtermApp.swift` (both factories)
 - Modify: `agterm/AppDelegate.swift` (`captureForegroundCommands`, if the unconsumed-pending path needs a
@@ -283,29 +287,29 @@ does not apply.
 - Modify: `agtermTests/AppDelegateCaptureTests.swift`
 - Modify: `agtermTests/GhosttySurfaceViewTrackingTests.swift` (or the file owning surface lifecycle tests)
 
-- [ ] write tests first: a mounted-but-unspawned restored pane leaves `pendingForegroundCommand` and
+- [x] write tests first: a mounted-but-unspawned restored pane leaves `pendingForegroundCommand` and
       `pendingRestoreOverride` on the `Session`; a clean quit at that point persists the same argv for
       rerun AND live; `restore.clear` at that point on a CAPTURE-ONLY session (no `initialCommand`, no
       sticky pin, which the command deliberately leaves alone) makes the later spawn run a plain shell; an
       on-demand `restore.capture` at that point persists nothing for that pane
-- [ ] write tests first: spawning consumes each slot exactly once; a second `createSurface` after a failed
+- [x] write tests first: spawning consumes each slot exactly once; a second `createSurface` after a failed
       first attempt reuses the cached seed; a view without a provider keeps its constructor values; a view
       destroyed before its provider resolves deallocates and leaves the `Session` with no strong path back
       to it; the closure is nil after resolution and after `destroySurface`
-- [ ] write tests first, per disposition: `.ordinary` is true for a captured argv the denylist accepts,
+- [x] write tests first, per disposition: `.ordinary` is true for a captured argv the denylist accepts,
       a nonempty pending override and a restored durable `initialCommand`, false for pin-none, a
       denylist-refused capture and no command; `.wrapped` is true for an eligible capture and for a
       durable `initialCommand`, false for a pane carrying ONLY a sticky pin (which stays pending), and
       false when its daemon name is running; `.fallback` is false and resolving it leaves pin and capture
       pending; explicit `none` is false and resolving it consumes and drops both slots, spawning a plain
       shell, so a later mode change to rerun replays nothing; computing `shouldPace` consumes no slot
-- [ ] add `LaunchSeed`, `LaunchSeedProvider { shouldPace, resolve }`, the provider property and its one-shot
+- [x] add `LaunchSeed`, `LaunchSeedProvider { shouldPace, resolve }`, the provider property and its one-shot
       cache to `GhosttySurfaceView`; `createSurface()` resolves it immediately before
       `ghostty_surface_config_new`; the closure captures the session weakly and is nilled after resolution
       and in `destroySurface`
-- [ ] move each factory's `.wrapped` / `.ordinary` / `.fallback` seed computation into the provider it
+- [x] move each factory's `.wrapped` / `.ordinary` / `.fallback` seed computation into the provider it
       passes to the view; construction no longer calls `takePending*`
-- [ ] run the touched test classes with `-only-testing:` - must pass before Task 3
+- [x] run the touched test classes with `-only-testing:` - must pass before Task 3
 
 ### Task 3: Gate `createSurface()` on the pacer with weak grant routing
 

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -316,24 +316,26 @@ does not apply.
 **Files:**
 - Modify: `agterm/Ghostty/GhosttySurfaceView.swift`
 - Create: `agterm/Ghostty/SpawnRegistry.swift`
+- Create: `agterm/Ghostty/GhosttySurfaceView+FirstResponder.swift` (first-responder overrides moved verbatim to keep the view file under the 1000-line limit)
 - Modify: `agterm/agtermApp.swift` (owns the pacer and registry; injects them into every factory)
 - Create: `agtermTests/SpawnRegistryTests.swift`
 - Modify: `agtermTests/GhosttySurfaceViewTrackingTests.swift`
+- Modify: `agtermTests/SurfaceFactorySeedTests.swift`
 
-- [ ] write tests first: a denied view creates no surface and creates one on grant against current bounds;
+- [x] write tests first: a denied view creates no surface and creates one on grant against current bounds;
       every entry path reaches the same gate and a denied one creates nothing (`TerminalView.updateNSView`,
       `viewDidMoveToWindow`, the `setFrameSize` retry, the 1 s retry); a zero-size view consumes no token
       until it has a size
-- [ ] write tests first: destroy before grant cancels and the grant is a no-op; a deallocated view leaves
+- [x] write tests first: destroy before grant cancels and the grant is a no-op; a deallocated view leaves
       no strong reference in the registry and no callback fires; unarmed pacer keeps today's synchronous
       behavior (surface exists on return from `updateNSView`)
-- [ ] add `spawnKey`, `awaitingSpawnPermit` and the registry hookup to `GhosttySurfaceView`; request the
+- [x] add `spawnKey`, `awaitingSpawnPermit` and the registry hookup to `GhosttySurfaceView`; request the
       permit after the size guard and before the provider resolves the seed, and only when the provider's
       `shouldPace` is true; a `false` provider calls `discard` for its expected key at construction and the
       view spawns synchronously exactly as today
-- [ ] `SpawnRegistry` with weak views keyed by `SpawnKey`; `onGrant` routes through it
-- [ ] `destroySurface` cancels on the main actor; `deinit` schedules a key-only cancellation without `self`
-- [ ] run the touched test classes - must pass before Task 4
+- [x] `SpawnRegistry` with weak views keyed by `SpawnKey`; `onGrant` routes through it
+- [x] `destroySurface` cancels on the main actor; `deinit` schedules a key-only cancellation without `self`
+- [x] run the touched test classes - must pass before Task 4
 
 ### Task 4: Expedite and prioritize from selection, hosts and control
 

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -86,6 +86,22 @@ Code startup issues 3 `ps` of which one is full-table; 69 sessions, 14 split, 83
   destroyed before its provider resolves deallocates; the `restore.clear` case uses a capture-only session;
   arm emits nothing until a key requests; late-mounting views still spawn `interval` apart from actual
   grants; a live pin-only pane is unpaced and keeps its pin pending
+- **owners** (verified in Task 6): Task 1 `SpawnPacerTests` - late wake, expedite resets the deadline, arm emits
+  nothing, an expected key that has not requested holds the timer. Task 2 `LaunchSeedTests` - rerun replay
+  paced, live survivor unpaced with missing/unknown/nil paced, plain shell/pin-none/denied capture unpaced,
+  live pin-only pane unpaced; `AppDelegateCaptureTests` - rerun and live unspawned clean quit keep the
+  capture, on-demand capture persists no armed copy; `ControlServerRestoreCaptureTests` - `restore.clear`
+  before the permit on a capture-only session; `GhosttySurfaceViewTrackingTests` - a view destroyed before
+  resolution deallocates. Task 3 `GhosttySurfaceViewTrackingTests` - every entry path reaches the gate (red
+  when the gate is deleted), zero-size retry holds no token, teardown and deinit leave no stale callback.
+  Task 4 `GhosttySurfaceViewTrackingTests` - repeated selection expedites once; `ControlServerSessionActionsTests`
+  - reads never realize, `session.type` left and right and `session.search` do, mutators expedite;
+  `ControlServerZmxTests` - `zmx kill` before the permit; `DashboardViewTests` - promotion keeps the rate.
+  Task 5 `SpawnRegistryTests` - N panes `interval` apart after the burst; `LaunchSpawnPlanTests` and
+  `SurfaceFactorySeedTests` - a hidden split is never armed; `ZmxClientTests` - an `err=` row is not a
+  survivor; `SpawnPacerTests` - a window mounting after the first drained spaces its follower. Claim and
+  reap before any grant has no unit test: the sink runs inside `WindowLibrary.init` and arm follows it in
+  `agtermApp.init`, verified by reading.
 
 ## Progress Tracking
 
@@ -242,8 +258,9 @@ after `WindowLibrary` returns, when model order is available, and hands the cont
 which set `shouldPace` when building each provider.
 
 **Read-back:** none new. `realized == false` and `agtermctl tree`'s `(not realized)` already describe a
-pane awaiting its permit; no command sets this state, so the read-back rule for state-setting commands
-does not apply.
+session whose MAIN pane awaits its permit; both read `session.surface` only, so a queued right pane shows
+nothing and an empty tree is no proof the queue drained. The pacer's `onDrain` debug log is the drain
+signal. No command sets this state, so the read-back rule for state-setting commands does not apply.
 
 ## What Goes Where
 
@@ -406,9 +423,10 @@ does not apply.
 - [x] run the touched test classes - must pass before Task 6
 
 ### Task 6: Verify acceptance criteria
-- [ ] verify every required regression in Testing Strategy exists and names the task that owns it
-- [ ] run full gates once: `cd agtermCore && swift test`, `make test-app`, `make lint`
-- [ ] confirm `realized` read-back and `agtermctl tree` `(not realized)` describe a queued pane correctly
+- [x] verify every required regression in Testing Strategy exists and names the task that owns it
+- [x] run full gates once: `cd agtermCore && swift test`, `make test-app`, `make lint`
+- [x] confirm `realized` read-back and `agtermctl tree` `(not realized)` describe a queued MAIN pane correctly
+      (a queued right pane shows nothing on either)
 
 ### Task 7: Update documentation
 - [ ] `.claude/rules/libghostty.md`: the permit and the late seed inside `createSurface()`, and why the
@@ -433,8 +451,9 @@ carrying a cheap captured command, at 80, 120 and 200 ms, recording peak CPU, ti
 the selected pane and time to full drain; record the numbers in the commit that changes the constant.
 
 **Manual verification, next NATURAL replaying launch only:** no simultaneous `ps` burst and no CPU pin
-(each paced Claude startup still runs its own `ps`), selected panes usable immediately, and
-`agtermctl tree` `(not realized)` shrinking to zero over the drain.
+(each paced Claude startup still runs its own `ps`), selected panes usable immediately, `agtermctl tree`
+`(not realized)` clearing from the queued main panes over the drain, and the `onDrain` debug log line as
+the proof the whole queue drained, since the tag never covers a right pane.
 
 **External:** none. Claude Code's own `ps aux` at startup is upstream behavior and out of scope.
 

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -1,0 +1,429 @@
+# Launch spawn pacing
+
+## Overview
+
+A launch that replays captured commands spawns every pane's program at the same instant. With 83 panes
+whose captured commands replay, every `claude`/`codex`/`pi` the user had running boots together; each
+Claude Code startup alone forks a full-table `ps aux` plus two targeted `ps`, and N bun runtimes booting
+concurrently pin the CPU for seconds. This is not one-time and not live-only: rerun mode replays every
+captured command on every launch, and live mode does so on the first launch after a rerun quit and on
+every launch after a reboot, because a clean quit captures every pane and the reboot kills every daemon.
+
+The fix paces the spawn, not the replay. Every pane's host view and `Session` wiring stay eager exactly
+as today; only the moment `ghostty_surface_new` runs is rate-limited, app-wide, with the on-screen panes
+of every window and any pane a user or control command reaches spawning at once. Replay semantics,
+capture semantics, `restore.clear`, and the deck's constant shape are unchanged.
+
+## Context (from discovery)
+
+- `agterm/Views/WindowContentView+Detail.swift:29` mounts EVERY session's detail in one `ZStack`; switching
+  is a visibility flip, so all panes realize at launch by design. Constant-shape rule at `:41-50`.
+- `agterm/Views/TerminalView.swift:46-68`: `makeNSView` calls the factory and `updateNSView` calls
+  `createSurface()` synchronously ("a deferred next-tick create races the layout").
+- `agterm/Ghostty/GhosttySurfaceView.swift:569`: `createSurface()` is the single choke point behind four
+  entry paths (`TerminalView.updateNSView`, `viewDidMoveToWindow` at `:857`, the `setFrameSize` retry via
+  `pendingSurfaceCreation` at `:876`, the 1 s retry at `:369`). It already defers itself on a zero size.
+  `deinit` is nonisolated and cannot call main-actor methods (`:162-165`).
+- `agterm/agtermApp.swift:294` and `:500`: the factories take `session.takePendingForegroundCommand` and
+  `takePendingRestoreOverride` at CONSTRUCTION, for `.wrapped` inside `ZmxLaunch.surfaceSeed` and for
+  `.ordinary` through `CommandRestore.restorePlan`, and bake the result into immutable `view.command` /
+  `view.initialInput`. `RestoredRuntime` (`:230`) already carries the library, resolver and zmx client.
+- `agterm/Control/ControlServer.swift:512-526` `clearRestoreCommands`: disarms the PENDING slots because the
+  socket binds before later windows' decks mount; a clear in that gap must stop the command from running.
+  Pacing widens that gap from milliseconds to seconds.
+- `agterm/AppDelegate.swift:368` `captureForegroundCommands(preserveUnconsumedPending:)`: a clean quit keeps
+  an UNCONSUMED pending seed; an on-demand `restore.capture` must never persist an armed copy.
+- `agterm/Control/ControlServer+Zmx.swift:155` `applyKilledPaneExit` needs the wrapper (`surface as?
+  GhosttySurfaceView`, `backedByZmx`, `claimProcessExit()`); `backedByZmx` is set in `init` (`:340`) and
+  `claimProcessExit` is a pure latch, so an eager unspawned wrapper satisfies it.
+- `agterm/Ghostty/ZmxClient.swift:42` `reap` runs one synchronous `zmx list`, parses it, and returns a
+  bare `Bool`, discarding the observed session set.
+- `agtermCore/Sources/agtermCore/WindowLibrary.swift:141` `prepareLaunchPaneInventory()` claims/reaps
+  before SwiftUI mounts and never reads `session.surface`; pacing cannot change which daemons are claimed.
+- A restored HIDDEN split keeps its identity and pin with no right host until shown
+  (`.claude/rules/control-api.md`, Restore commands). `session.type` on an unrealized main pane
+  bounded-polls 12 x 30 ms; `session.text` never selects or realizes; `session.search` "selects and
+  realizes the target".
+- `ControlSessionNode.realized` already reports an unspawned main pane as `false`.
+
+Measured on the user's machine (1420 processes): targeted `ps -p` 4.1 ms, `ps -axww` 76 ms, one Claude
+Code startup issues 3 `ps` of which one is full-table; 69 sessions, 14 split, 83 panes, 166 zmx processes.
+
+## Development Approach
+
+- **testing approach**: TDD - write the task's tests first against the injected clock and spawn
+  recorder, watch them fail, then implement
+- complete each task fully before moving to the next; small focused changes
+- **CRITICAL: every task includes new/updated tests** as separate checklist items; success and error paths
+- **CRITICAL: all tests pass before the next task**: `cd agtermCore && swift test`, `make test-app`, `make lint`
+- run each full gate ONCE at the end; scope in-task runs with `--filter` / `-only-testing:`
+- **CRITICAL: update this plan when scope changes**
+- no user-facing setting: pacing constants are code; a preference needs separate approval
+- `agtermCore` is a published library consumed by agterm-linux: no public signature changes there beyond
+  the new `SpawnPacer` type; `ControlActions` signatures stay synchronous
+
+## Testing Strategy
+
+- **unit tests**: host-free scheduler model in `agtermCore` (`swift test`); hosted `GhosttySurfaceView`,
+  factory, capture and launch behavior in `agtermTests` (`make test-app`), following
+  `GhosttySurfaceViewTrackingTests` and `AppDelegateCaptureTests` structure
+- **e2e**: no XCUITest additions; `ControlAPIUITests` is not re-run for this change
+- one test file per source file; Swift Testing in `agtermCore`, XCTest in `agtermTests`
+- every timing assertion uses an injected clock and a spawn recorder; nothing sleeps
+- **required regressions** (each lives in the task that makes it pass):
+  N replaying panes record N spawns each `interval` apart and go red when the gate is deleted; a late
+  wake releases one grant, not several; expedite consumes a token and resets the deadline; repeated
+  selection of one pane expedites once; zero-size retry consumes no token; every `createSurface` entry
+  path reaches the gate; deinit/cancel leaves no stale callback; rerun unspawned clean quit preserves the
+  capture; live unspawned clean quit preserves the capture; `restore.clear` before permit prevents the
+  command from running; on-demand `restore.capture` persists no armed copy; `zmx kill` before permit
+  performs the model transition and the later grant cannot recreate the daemon; a hidden split does not
+  block drain; live survivor unpaced, missing and unknown paced, nil observed set paces all; rerun replay
+  paced; `session.text`/`session.copy`/`surface.cursor` do not realize; `session.type` left and right and
+  `session.search` do; synchronous mutators follow the expedite contract; dashboard promotion preserves
+  rate; claim and reap run before any grant; a plain restored shell, a pin-none pane and a
+  denylist-refused capture spawn unpaced; an `err=` list row is paced, not treated as a survivor; a view
+  destroyed before its provider resolves deallocates; the `restore.clear` case uses a capture-only session;
+  arm emits nothing until a key requests; late-mounting views still spawn `interval` apart from actual
+  grants; a live pin-only pane is unpaced and keeps its pin pending
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix; blockers with ⚠️ prefix
+- keep this plan in sync with actual work
+
+## Solution Overview
+
+"Eager host, paced spawn, late seed." Nothing before `createSurface()` changes: bootstrap, claim, reap,
+factory and view mounting run as today, so the launch inventory, `zmx kill`, `session.swap` and split
+controls see exactly the objects they see now. Two things move later, both to the instant immediately
+before `ghostty_surface_new`:
+
+1. **The permit.** `createSurface()` asks an app-global `SpawnPacer` for a grant after its existing
+   app/nonzero-size guards. Denied means the view records itself as awaiting and returns; the pacer later
+   grants and the same idempotent `createSurface()` runs against then-current bounds, so the "synchronous
+   on purpose" site keeps its guarantee: the deferral is the pacer's, not a next-tick hop racing layout.
+   Gating the sink covers all four entry paths and stops a zero-size view from holding a permit into a
+   later same-layout burst.
+2. **The seed.** The factories no longer take the pending slots at construction. Each view carries a
+   `LaunchSeedProvider` closure that consumes `pendingForegroundCommand`, `pendingRestoreOverride` and
+   the restore-plan precedence atomically when the permit is granted. Until then the slots stay on the
+   `Session`, so a clean quit before the permit preserves them through today's
+   `preserveUnconsumedPending`, `restore.clear` disarms them exactly as it does in the pre-mount gap,
+   and an on-demand `restore.capture` finds nothing armed on the view. This covers primary and split,
+   `.ordinary` and `.wrapped`, captured argv and `initialCommand`; `backedByZmx` is still decided at
+   construction because the disposition is.
+
+Pacing is start-rate limiting, not a concurrency cap. `createSurface()` returns when
+`ghostty_surface_new` has only begun the child's lifecycle; no callback marks a replayed program's startup
+finished (PWD/title/output are optional program behavior, exit is far too late), so an in-flight cap has
+no truthful release edge. The pacer is a leaky bucket: at most one paced grant per `interval`, the next
+deadline computed from the ACTUAL previous grant on a monotonic clock, never catching up missed ticks
+after a main-thread stall. The one bounded exemption is the launch burst: every open window's selected
+session's on-screen panes are granted synchronously when each one requests, since the user is looking
+at them.
+
+Two promotion verbs, because one cannot serve both callers: `expedite(key)` grants ONE key immediately
+and resets the deadline (selection, zoom, control commands that must realize now); `prioritize(keys)`
+reorders without releasing (a dashboard opening on many queued members). Once granted a key stays
+granted; a second expedite of a granted or already-expedited key is a no-op, so repeated
+`deckActive = true` writes cannot mint tokens.
+
+Scope: every launch that replays is paced, whichever mode replays it. In rerun mode every restored pane
+carrying a replay is queued. In live mode a `.wrapped` pane is queued only when its daemon is absent or
+unknown; a pane whose daemon the launch reap observed alive attaches immediately, because attaching a
+survivor runs no program. The reap's parsed `zmx list` becomes a SCHEDULING HINT carried on an
+app-local launch context, never on `GhosttyApp`, whose `restoreLaunchDecision` is immutable process
+policy. A list-to-attach race can still miss a daemon that died in between, so nothing about correctness
+depends on the hint: a mis-hinted survivor merely spawns unpaced, exactly today's behavior. When the
+list fails, every replay-bearing live pane is paced; an unrelated orphan-kill failure does not count as
+"list failed".
+
+Expected set: every restored primary pane and every restored SHOWN right pane is expected at arm, in
+deterministic model order, because providers do not exist yet. The factory later computes `shouldPace`
+without consuming: false calls `discard` for the expected key before any spawn, so a plain shell or a
+running-daemon attach spawns synchronously and cannot block drain; true registers the weak view, and
+`createSurface()` calls `request` only once the view is sized. Pacing therefore touches only panes that
+would start a program.
+A hidden restored split has no right host until shown and stays outside the queue with its pending state
+intact. Fresh and runtime-created splits, scratch, overlays and the quick terminal are never armed; their
+host attachment bypasses the bootstrap queue. The pacer is armed only by a launch restore and becomes
+passthrough once its queue drains, so a session created later never waits.
+
+Rejected: delaying the factory (widens the on-disk loss window, breaks `zmx kill` and `--pane right`
+before mount); baking the seed at construction and re-arming it at exit (cannot honor `restore.clear`
+once `view.command` holds the payload, and excludes rerun's `.ordinary` path); making zmx daemons lazy on
+first selection (breaks the instant-flip promise and every control caller); per-window pacing (four
+windows releasing one each per tick recreate a smaller synchronized burst); making the survivor decision
+a correctness input; an in-flight concurrency cap (no truthful child-ready edge).
+
+## Technical Details
+
+**`SpawnKey`**: the pane identity UUID (`paneIdentity` / `splitPaneIdentity`), stable across the
+wrapper's lifetime and already the daemon-name input.
+
+**`SpawnPacer` (agtermCore, host-free, `@MainActor`, injected monotonic clock and timer):**
+- `request(_ key: SpawnKey) -> Bool`: true = granted now; false = queued
+- `expedite(_ key: SpawnKey)`: grant one queued key immediately, consume the next token, reset the
+  deadline; no-op for a granted, unknown or already-expedited key
+- `prioritize(_ keys: [SpawnKey])`: move to the front in the given order, release nothing
+- `cancel(_ key: SpawnKey)`: drop a queued key (pane removed or view destroyed)
+- `discard(_ key: SpawnKey)`: a key realized elsewhere leaves the queue without a grant and without
+  releasing catch-up tokens
+- `arm(order: [SpawnKey], burst: Set<SpawnKey>)`: records the EXPECTED deterministic model order and
+  the burst membership. It emits no grant and starts no timer: at arm time no factory, provider or view
+  exists yet, so a grant issued then would be a logical grant with no spawn, and the real
+  `ghostty_surface_new` calls of several such keys would later collapse into one SwiftUI pass while every
+  pacer timestamp still looked correct
+- `request(_ key:)` marks the key READY. A ready burst key is granted synchronously on its request. The
+  paced timer grants only a READY key, in expected order; when the next expected key is not yet ready or
+  classified it waits rather than granting into an empty registry. The deadline runs from the ACTUAL
+  grant. A missing registry entry at grant time is stale-state handling, never the bootstrap path
+- `isPassthrough` once every expected key is granted, cancelled or discarded; unarmed or drained means
+  `request` returns true synchronously
+- `interval` (constant; starting value 120 ms, selected as described under Post-Completion) and the
+  grant sink `onGrant: (SpawnKey) -> Void`; pure model, no AppKit
+
+**Grant routing:** the app owns a `SpawnRegistry` mapping `SpawnKey` to a weak `GhosttySurfaceView`;
+`onGrant` looks the key up and calls `createSurface()`; a missing or destroyed view is dropped. The view
+never holds the pacer strongly. `destroySurface` cancels its key on the main actor; the nonisolated
+`deinit` safety net schedules a key-only cancellation without capturing `self`.
+
+**`LaunchSeedProvider`:** a value `{ shouldPace: Bool, resolve: @MainActor () -> LaunchSeed }` where
+`LaunchSeed` is `(command: String?, initialInput: String?, waitAfterCommand: Bool)`. `shouldPace` is
+decided at construction WITHOUT consuming anything, by peeking the inputs the pane's OWN disposition
+will read, since the three dispositions honor different slots:
+- `.ordinary` (rerun): a nonempty pending `session.restore` override, else a captured argv that
+  `CommandRestore.shouldRestore` accepts, else a restored durable `initialCommand` paces; a pin-none
+  override, a denylist-refused capture (which still suppresses `initialCommand`, matching the
+  `hadForeground` precedence) or no command spawns a plain shell and does not
+- `.wrapped` (live): an eligible captured argv, else a restored durable `initialCommand` paces; the
+  pending restore override is IGNORED because `ZmxLaunch.surfaceSeed` never reads it (live pins are
+  future-rerun policy, not a live opt-out) and it stays pending; a daemon name in `runningNames` forces
+  unpaced because attaching runs no program
+- `.fallback` (live requested, unavailable): never paced; the factories pass `restoreOverride: nil`
+  (`agtermApp.swift:349`, `:546`), take no pending slot, and the provider resolves WITHOUT consuming,
+  so pin and capture stay pending exactly as today
+- explicit `none` mode: never paced, but it is the `.ordinary` disposition with
+  `restoreEnabled == false`, which takes BOTH pending slots and drops them; the provider keeps that
+  consume-and-drop path. Preserving them instead would let an old capture resurrect: exit capture keeps
+  unconsumed pending state, so a mode change to rerun before the next clean quit would replay a
+  command the user launched under none
+`resolve` is the factory's existing `.wrapped` / `.ordinary` / `.fallback` seed computation moved into a
+closure, so `surfaceSeed` and `restorePlan` precedence are untouched; only WHEN it runs changes.
+`createSurface()` calls it once, immediately before `ghostty_surface_config_new`, caches the result for
+the surface's lifetime so a retry after an unrelated failure does not consume a second time, and sets
+the closure to nil. Lifetime: the closure captures the session only through the view's existing weak
+`session` (never strongly, or `Session -> view -> provider -> Session` cycles when a view is destroyed
+before spawning); `destroySurface` also nils it. A view built without a provider (overlay, scratch,
+quick, HUD, dashboard host) keeps its constructor values and never queues.
+
+**Preemption sources:** `deckActive = true` expedites the view's key; zoom host attach expedites; the
+dashboard host prioritizes its members; the quick terminal and overlays are unarmed. Control commands
+that must realize their pane expedite before their existing bounded poll: `session.type` (left AND right;
+right keeps failing fast when there is no shown split), `session.search` open/update/next/prev, and the
+synchronous mutators that need a live libghostty surface (`session.paste`, `session.selectall`, and
+`font.inc/dec/reset` for the left and right panes: `ControlDispatcher.swift:679-687` routes them to
+`actions.font`, which resolves a per-pane surface at `ControlServer+SurfaceIO.swift:32-62` and answers
+`session not realized`), so `ControlActions` stays synchronous. Reads keep their contract:
+`session.text` and `session.copy` report `session not realized`, `surface.cursor` reports
+`surface not realized` (`ControlServer+SurfaceIO.swift:337`), and the overlay reads address their own
+overlay surface (`no overlay` / `overlay not realized`), never the base pane; none of them realizes
+anything. `session.swap` needs eager wrapper slots, not a spawned surface, and is unchanged.
+
+**Launch context:** `ZmxClient.reap` returns `ReapOutcome { runningNames: Set<String>?, killedAll: Bool }`.
+`runningNames` holds only records with `clients != nil`: `ZmxListParser` emits `clients == nil` for an
+`err=` row and `ZmxInventory` classifies that `.unreadable`, so a stale or unreadable socket must be
+paced like an absent daemon, not attached unpaced as a survivor. It is nil only when `zmx list` failed
+or did not parse; an orphan-kill failure with a good list leaves it populated. The existing synchronous
+inventory sink captures it into a `LaunchSpawnContext` on `RestoredRuntime`; `agtermApp` arms the pacer
+after `WindowLibrary` returns, when model order is available, and hands the context to the factories,
+which set `shouldPace` when building each provider.
+
+**Read-back:** none new. `realized == false` and `agtermctl tree`'s `(not realized)` already describe a
+pane awaiting its permit; no command sets this state, so the read-back rule for state-setting commands
+does not apply.
+
+## What Goes Where
+
+- **Implementation Steps**: code, tests, rule and doc updates inside this repo
+- **Post-Completion**: interval selection and the manual replaying-launch check on the user's setup
+
+## Implementation Steps
+
+### Task 1: Host-free `SpawnPacer` model
+
+**Files:**
+- Create: `agtermCore/Sources/agtermCore/SpawnPacer.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift`
+
+- [ ] write tests first: arm with no requests emits nothing even after the clock advances; N keys requested
+      late, in any order, yield N grants each `interval` apart in expected order, timed from the actual
+      grants; a burst key grants synchronously on its request, not on arm; the timer waits when the next
+      expected key has not requested yet; a clock that wakes late by 3 intervals releases ONE grant;
+      expedite grants one key now, consumes the token and resets the deadline; prioritize reorders and
+      releases nothing; discarding an expected key that never requests cannot block drain
+- [ ] write tests first: double request is idempotent; expedite of a granted, unknown or already-expedited
+      key is a no-op; cancel and discard drop without a grant and without catch-up; request after
+      passthrough is synchronous; unarmed pacer grants synchronously
+- [ ] add `SpawnKey`, `SpawnPacer` with `request` (marks ready), `expedite`, `prioritize`, `cancel`,
+      `discard`, `arm(order:burst:)` (records expectations only), `isPassthrough`, `interval`, injected
+      clock/timer, and `onGrant`
+- [ ] leaky-bucket deadline computed from the actual previous grant; no catch-up
+- [ ] run `cd agtermCore && swift test --filter SpawnPacerTests` - must pass before Task 2
+
+### Task 2: Late seed: `LaunchSeedProvider` on the view, consumed at spawn
+
+**Files:**
+- Modify: `agterm/Ghostty/GhosttySurfaceView.swift`
+- Modify: `agterm/agtermApp.swift` (both factories)
+- Modify: `agterm/AppDelegate.swift` (`captureForegroundCommands`, if the unconsumed-pending path needs a
+  wrapper-aware read)
+- Modify: `agtermTests/AppDelegateCaptureTests.swift`
+- Modify: `agtermTests/GhosttySurfaceViewTrackingTests.swift` (or the file owning surface lifecycle tests)
+
+- [ ] write tests first: a mounted-but-unspawned restored pane leaves `pendingForegroundCommand` and
+      `pendingRestoreOverride` on the `Session`; a clean quit at that point persists the same argv for
+      rerun AND live; `restore.clear` at that point on a CAPTURE-ONLY session (no `initialCommand`, no
+      sticky pin, which the command deliberately leaves alone) makes the later spawn run a plain shell; an
+      on-demand `restore.capture` at that point persists nothing for that pane
+- [ ] write tests first: spawning consumes each slot exactly once; a second `createSurface` after a failed
+      first attempt reuses the cached seed; a view without a provider keeps its constructor values; a view
+      destroyed before its provider resolves deallocates and leaves the `Session` with no strong path back
+      to it; the closure is nil after resolution and after `destroySurface`
+- [ ] write tests first, per disposition: `.ordinary` is true for a captured argv the denylist accepts,
+      a nonempty pending override and a restored durable `initialCommand`, false for pin-none, a
+      denylist-refused capture and no command; `.wrapped` is true for an eligible capture and for a
+      durable `initialCommand`, false for a pane carrying ONLY a sticky pin (which stays pending), and
+      false when its daemon name is running; `.fallback` is false and resolving it leaves pin and capture
+      pending; explicit `none` is false and resolving it consumes and drops both slots, spawning a plain
+      shell, so a later mode change to rerun replays nothing; computing `shouldPace` consumes no slot
+- [ ] add `LaunchSeed`, `LaunchSeedProvider { shouldPace, resolve }`, the provider property and its one-shot
+      cache to `GhosttySurfaceView`; `createSurface()` resolves it immediately before
+      `ghostty_surface_config_new`; the closure captures the session weakly and is nilled after resolution
+      and in `destroySurface`
+- [ ] move each factory's `.wrapped` / `.ordinary` / `.fallback` seed computation into the provider it
+      passes to the view; construction no longer calls `takePending*`
+- [ ] run the touched test classes with `-only-testing:` - must pass before Task 3
+
+### Task 3: Gate `createSurface()` on the pacer with weak grant routing
+
+**Files:**
+- Modify: `agterm/Ghostty/GhosttySurfaceView.swift`
+- Create: `agterm/Ghostty/SpawnRegistry.swift`
+- Modify: `agterm/agtermApp.swift` (owns the pacer and registry; injects them into every factory)
+- Create: `agtermTests/SpawnRegistryTests.swift`
+- Modify: `agtermTests/GhosttySurfaceViewTrackingTests.swift`
+
+- [ ] write tests first: a denied view creates no surface and creates one on grant against current bounds;
+      every entry path reaches the same gate and a denied one creates nothing (`TerminalView.updateNSView`,
+      `viewDidMoveToWindow`, the `setFrameSize` retry, the 1 s retry); a zero-size view consumes no token
+      until it has a size
+- [ ] write tests first: destroy before grant cancels and the grant is a no-op; a deallocated view leaves
+      no strong reference in the registry and no callback fires; unarmed pacer keeps today's synchronous
+      behavior (surface exists on return from `updateNSView`)
+- [ ] add `spawnKey`, `awaitingSpawnPermit` and the registry hookup to `GhosttySurfaceView`; request the
+      permit after the size guard and before the provider resolves the seed, and only when the provider's
+      `shouldPace` is true; a `false` provider calls `discard` for its expected key at construction and the
+      view spawns synchronously exactly as today
+- [ ] `SpawnRegistry` with weak views keyed by `SpawnKey`; `onGrant` routes through it
+- [ ] `destroySurface` cancels on the main actor; `deinit` schedules a key-only cancellation without `self`
+- [ ] run the touched test classes - must pass before Task 4
+
+### Task 4: Expedite and prioritize from selection, hosts and control
+
+**Files:**
+- Modify: `agterm/Ghostty/GhosttySurfaceView.swift` (`deckActive` didSet)
+- Modify: `agterm/Views/TerminalZoom*.swift`, `agterm/Views/Dashboard*.swift` (host attach points)
+- Modify: `agterm/Control/ControlServer+SurfaceIO.swift` (`injectText` for `session.type`, `searchSession`,
+  `pasteSession`, `selectAllSession`, `font`)
+- Modify: `agterm/Control/ControlServer+Zmx.swift` only if `applyKilledPaneExit` needs a `discard`
+- Modify: the corresponding `agtermTests` files and the dispatcher/protocol tests those commands own
+
+- [ ] write tests first: with a paced launch the selected pane of each window is granted synchronously on
+      its first request after arm; selecting a queued session grants it before the queue reaches it;
+      selecting it twice mints one token
+- [ ] write tests first: `session.type --select` on a queued pane succeeds within the existing 12 x 30 ms
+      poll; `session.type --pane right` on a queued shown split succeeds and on an absent split fails fast
+      as today; `session.search` open on a queued pane realizes it; `session.paste`, `session.selectall`
+      and `font.inc` on a queued left pane and on a queued shown right pane succeed synchronously
+- [ ] write tests first: on a queued pane `session.text` and `session.copy` answer `session not realized`
+      and `surface.cursor` answers `surface not realized`, all leaving it queued; a dashboard opened on
+      queued members promotes them but records spawns still `interval` apart
+- [ ] write tests first: `zmx kill` on a claimed, mounted, unspawned pane performs the model transition
+      (`handlePaneExit`) and the later grant does not recreate the daemon
+- [ ] keep the expedite set to exactly `session.type`, `session.search`, `session.paste`, `session.selectall`
+      and `font.inc/dec/reset`: the last four resolve a surface and answer `session not realized` when it
+      has none (`ControlServer+SurfaceIO.swift:32-62`); the scratch pane is runtime-only and never queued
+- [ ] wire `deckActive`, zoom host and dashboard host; wire the control expedites before each bounded poll
+- [ ] run the touched test classes - must pass before Task 5
+
+### Task 5: Arm from the launch inventory with the survivor hint; drain to passthrough
+
+**Files:**
+- Modify: `agterm/Ghostty/ZmxClient.swift` (`reap` returns `ReapOutcome`)
+- Modify: `agterm/agtermApp.swift` (`LaunchSpawnContext` on `RestoredRuntime`; arm after `WindowLibrary`
+  returns; classification in the factories' providers)
+- Modify: `agtermTests/ZmxClientTests.swift` (owns `reap`: the `ReapOutcome` `err=` row and kill-result
+  cases live here)
+- Modify: `agtermTests/ZmxLaunchTests.swift` (disposition classification) and the launch/restore test file
+  that owns bootstrap
+
+- [ ] write tests first (injected clock, spawn recorder): a launch restore of N replaying sessions records
+      N spawns each `interval` apart and goes red when the gate is removed; a session created after drain
+      spawns synchronously; a one-session launch spawns synchronously
+- [ ] write tests first: live survivor (name running) spawns unpaced while missing and unknown names are
+      paced; an `err=` list row is paced; a nil running set paces every replay-bearing live pane; an
+      orphan-kill failure with a good list does not pace survivors; rerun-mode replay is paced
+- [ ] write tests first: a plain restored shell, a pin-none pane and a denylist-refused capture are never
+      queued and spawn synchronously; a restored durable `initialCommand` is paced
+- [ ] write tests first: a restored hidden split is not armed and drain completes without it; showing it
+      later attaches through the normal unarmed path with its pending state intact; reap and claim run
+      before any grant
+- [ ] `reap` returns `ReapOutcome { runningNames: Set<String>?, killedAll: Bool }` built from records with
+      `clients != nil`; the inventory sink stores it on `LaunchSpawnContext`
+- [ ] arm from the model BEFORE any window mounts, recording expectations only: every open window's
+      selected session's on-screen panes as the burst set, then remaining windows, sessions, primaries and
+      shown right panes; never expect fresh or runtime splits, scratch, overlays or quick
+- [ ] write tests first: with arm done and no view mounted, advancing the clock records no spawn; views
+      that mount one tick late still record spawns `interval` apart from the first actual grant; a
+      multi-window launch whose second window mounts after every ready key of the first has been granted
+      (not pacer passthrough, which waits on every expected key) records no simultaneous spawns
+- [ ] passthrough once every armed key is granted, cancelled or discarded; log the drain duration at debug
+- [ ] run the touched test classes - must pass before Task 6
+
+### Task 6: Verify acceptance criteria
+- [ ] verify every required regression in Testing Strategy exists and names the task that owns it
+- [ ] run full gates once: `cd agtermCore && swift test`, `make test-app`, `make lint`
+- [ ] confirm `realized` read-back and `agtermctl tree` `(not realized)` describe a queued pane correctly
+
+### Task 7: Update documentation
+- [ ] `.claude/rules/libghostty.md`: the permit and the late seed inside `createSurface()`, and why the
+      deferral does not race layout
+- [ ] `.claude/rules/settings.md` (owns restore capture and the pending slots): seed consumption at
+      spawn time; `restore.clear` and clean-quit preservation now cover the paced window; hard reset
+      boundary unchanged
+- [ ] `.claude/rules/control-api.md`: which commands expedite a queued pane and which reads never do
+- [ ] `site/docs.html` restore section: one sentence that a launch which replays commands brings panes up
+      over several seconds, the visible panes first
+- [ ] `plugins/agterm/skills/agterm/troubleshooting.md`: `(not realized)` right after a replaying launch
+      is pacing, not a fault
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Interval selection:** 120 ms ships as the explicit product starting value. It is NOT tuned on the
+user's live setup: producing samples at several intervals would mean repeatedly killing his daemons and
+agents to force replaying launches, which nothing authorizes, and a natural reboot yields one sample. If
+tuning is wanted, do it in an isolated instance (`AGTERM_STATE_DIR`, own socket) seeded with N sessions
+carrying a cheap captured command, at 80, 120 and 200 ms, recording peak CPU, time to first prompt in
+the selected pane and time to full drain; record the numbers in the commit that changes the constant.
+
+**Manual verification, next NATURAL replaying launch only:** no simultaneous `ps` burst and no CPU pin
+(each paced Claude startup still runs its own `ps`), selected panes usable immediately, and
+`agtermctl tree` `(not realized)` shrinking to zero over the drain.
+
+**External:** none. Claude Code's own `ps aux` at startup is upstream behavior and out of scope.
+
+Smells pre-check: skipped — non-Go project

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -144,7 +144,7 @@ Two promotion verbs, because one cannot serve both callers: `expedite(key)` gran
 and resets the deadline (selection, zoom, control commands that must realize now); `prioritize(keys)`
 reorders without releasing (a dashboard opening on many queued members). Once granted a key stays
 granted; a second expedite of a granted or already-expedited key is a no-op, so repeated
-`deckActive = true` writes cannot mint tokens.
+`deckVisible = true` writes cannot mint tokens.
 
 Scope: every launch that replays is paced, whichever mode replays it. In rerun mode every restored pane
 carrying a replay is queued. In live mode a `.wrapped` pane is queued only when its daemon is absent or
@@ -235,7 +235,8 @@ the closure to nil. Lifetime: the closure captures the session only through the 
 before spawning); `destroySurface` also nils it. A view built without a provider (overlay, scratch,
 quick, HUD, dashboard host) keeps its constructor values and never queues.
 
-**Preemption sources:** `deckActive = true` expedites the view's key; zoom host attach expedites; the
+**Preemption sources:** `deckVisible = true` expedites the view's key (not `deckActive`, which is
+split-focus-gated and would leave the other half of a shown split queued); zoom host attach expedites; the
 dashboard host prioritizes its members; the quick terminal and overlays are unarmed. Control commands
 that must realize their pane expedite before their existing bounded poll: `session.type` (left AND right;
 right keeps failing fast when there is no shown split), `session.search` open/update/next/prev, and the
@@ -256,6 +257,15 @@ or did not parse; an orphan-kill failure with a good list leaves it populated. T
 inventory sink captures it into a `LaunchSpawnContext` on `RestoredRuntime`; `agtermApp` arms the pacer
 after `WindowLibrary` returns, when model order is available, and hands the context to the factories,
 which set `shouldPace` when building each provider.
+
+**Model removal drops (revmux round 01):** the pacer grants only a ready head and never jumps an
+expected key, so a pane leaving the visible model before its window mounts would hold the queue forever.
+`AppStore` and `WindowLibrary` take a default-nil `launchPaneDrop` closure and call it with the pane
+identities on hard and soft session close, hard and soft workspace removal, a shown split hidden or
+closed, and a loaded window's close or delete; the app wires it to `SpawnPacer.discard`. A hidden split's
+identity rides along and is ignored as a key outside the order; a view torn down later drops again,
+harmlessly; undo or re-show returns as a key outside the order and spawns synchronously. Owners:
+`AppStoreTests`, `AppStorePendingCloseTests`, `AppStorePaneTests`, `WindowLibraryTests`.
 
 **Read-back:** none new. `realized == false` and `agtermctl tree`'s `(not realized)` already describe a
 session whose MAIN pane awaits its permit; both read `session.surface` only, so a queued right pane shows
@@ -357,8 +367,8 @@ signal. No command sets this state, so the read-back rule for state-setting comm
 ### Task 4: Expedite and prioritize from selection, hosts and control
 
 **Files:**
-- Modify: `agterm/Ghostty/GhosttySurfaceView.swift` (`deckActive` didSet)
-- Modify: `agterm/Views/DashboardView.swift` (the zoom host already sets `deckActive`, so it needs no change)
+- Modify: `agterm/Ghostty/GhosttySurfaceView.swift` (`deckVisible` didSet)
+- Modify: `agterm/Views/DashboardView.swift` (the zoom host already sets `deckVisible`, so it needs no change)
 - Create: `agtermTests/DashboardViewTests.swift`
 - Modify: `agterm/Control/ControlServer+SurfaceIO.swift` (`injectText` for `session.type`, `searchSession`,
   `pasteSession`, `selectAllSession`, `font`)
@@ -380,7 +390,7 @@ signal. No command sets this state, so the read-back rule for state-setting comm
 - [x] keep the expedite set to exactly `session.type`, `session.search`, `session.paste`, `session.selectall`
       and `font.inc/dec/reset`: the last four resolve a surface and answer `session not realized` when it
       has none (`ControlServer+SurfaceIO.swift:32-62`); the scratch pane is runtime-only and never queued
-- [x] wire `deckActive`, zoom host and dashboard host; wire the control expedites before each bounded poll
+- [x] wire `deckVisible`, zoom host and dashboard host; wire the control expedites before each bounded poll
 - [x] run the touched test classes - must pass before Task 5
 
 ### Task 5: Arm from the launch inventory with the survivor hint; drain to passthrough

--- a/docs/plans/20260901-launch-spawn-pacing.md
+++ b/docs/plans/20260901-launch-spawn-pacing.md
@@ -374,31 +374,36 @@ does not apply.
   returns; classification in the factories' providers)
 - Modify: `agtermTests/ZmxClientTests.swift` (owns `reap`: the `ReapOutcome` `err=` row and kill-result
   cases live here)
-- Modify: `agtermTests/ZmxLaunchTests.swift` (disposition classification) and the launch/restore test file
-  that owns bootstrap
+- Create: `agtermCore/Sources/agtermCore/LaunchSpawnPlan.swift` (model order and burst)
+- Create: `agtermCore/Tests/agtermCoreTests/LaunchSpawnPlanTests.swift`
+- Modify: `agtermCore/Sources/agtermCore/SpawnPacer.swift` (`onDrain`)
+- Modify: `agtermCore/Tests/agtermCoreTests/SpawnPacerTests.swift` (drain; late second window)
+- Modify: `agtermTests/SpawnRegistryTests.swift` (launch pipeline with injected clock)
+- Modify: `agtermTests/SurfaceFactorySeedTests.swift` (hidden split; policy carries the reap's names)
+- Disposition classification was pinned by `LaunchSeedTests` in Task 2
 
-- [ ] write tests first (injected clock, spawn recorder): a launch restore of N replaying sessions records
+- [x] write tests first (injected clock, spawn recorder): a launch restore of N replaying sessions records
       N spawns each `interval` apart and goes red when the gate is removed; a session created after drain
       spawns synchronously; a one-session launch spawns synchronously
-- [ ] write tests first: live survivor (name running) spawns unpaced while missing and unknown names are
+- [x] write tests first: live survivor (name running) spawns unpaced while missing and unknown names are
       paced; an `err=` list row is paced; a nil running set paces every replay-bearing live pane; an
       orphan-kill failure with a good list does not pace survivors; rerun-mode replay is paced
-- [ ] write tests first: a plain restored shell, a pin-none pane and a denylist-refused capture are never
+- [x] write tests first: a plain restored shell, a pin-none pane and a denylist-refused capture are never
       queued and spawn synchronously; a restored durable `initialCommand` is paced
-- [ ] write tests first: a restored hidden split is not armed and drain completes without it; showing it
+- [x] write tests first: a restored hidden split is not armed and drain completes without it; showing it
       later attaches through the normal unarmed path with its pending state intact; reap and claim run
       before any grant
-- [ ] `reap` returns `ReapOutcome { runningNames: Set<String>?, killedAll: Bool }` built from records with
+- [x] `reap` returns `ReapOutcome { runningNames: Set<String>?, killedAll: Bool }` built from records with
       `clients != nil`; the inventory sink stores it on `LaunchSpawnContext`
-- [ ] arm from the model BEFORE any window mounts, recording expectations only: every open window's
+- [x] arm from the model BEFORE any window mounts, recording expectations only: every open window's
       selected session's on-screen panes as the burst set, then remaining windows, sessions, primaries and
       shown right panes; never expect fresh or runtime splits, scratch, overlays or quick
-- [ ] write tests first: with arm done and no view mounted, advancing the clock records no spawn; views
+- [x] write tests first: with arm done and no view mounted, advancing the clock records no spawn; views
       that mount one tick late still record spawns `interval` apart from the first actual grant; a
       multi-window launch whose second window mounts after every ready key of the first has been granted
       (not pacer passthrough, which waits on every expected key) records no simultaneous spawns
-- [ ] passthrough once every armed key is granted, cancelled or discarded; log the drain duration at debug
-- [ ] run the touched test classes - must pass before Task 6
+- [x] passthrough once every armed key is granted, cancelled or discarded; log the drain duration at debug
+- [x] run the touched test classes - must pass before Task 6
 
 ### Task 6: Verify acceptance criteria
 - [ ] verify every required regression in Testing Strategy exists and names the task that owns it

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -230,8 +230,10 @@ them never has to know the defaults; `spinner` names the STYLE, so `none` is wha
 turn one off. While a HUD is up the node's `overlay` reads `false` and `overlaySizePercent` is omitted, so a
 poll for "is a program covering this session" cannot mistake a message for one; HUD state is poll-only,
 no event announces it),
-`realized` (whether the session's MAIN pane has a live terminal; `false` means no shell was spawned and
-`session type`/`session text` will answer `session not realized`. `session new` returns `ok` for a model
+`realized` (whether the session's MAIN pane has a live terminal; `false` means no shell was spawned.
+`session text` then answers `session not realized` without realizing anything; `session type` brings up a
+restored main pane still waiting its turn in a launch that replays commands, while any other unrealized
+cause can still exhaust its poll and fail the same way. `session new` returns `ok` for a model
 entry, which is weaker — libghostty will not create a surface while the display is asleep, so a session
 created by a scheduled job overnight stays unrealized until the displays wake and then recovers itself.
 Poll this after an unattended create),

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -108,12 +108,16 @@ SIGTERM use normal process behavior.
 `id`, `name`, `cwd`, `title` (the raw OSC terminal title — e.g. a remote host over SSH — omitted
 when none reported; distinct from `name`, the derived sidebar label), `active` (selected),
 `split` (split SHOWN side by side, the read side of `session split on|off`),
-`realized` (whether the session's MAIN pane has a live terminal — `false` means no shell was spawned, a
-`--command` has not run, and `session type`/`session text` will answer `session not realized`. `session
-new` returns `ok` for a session that exists in the model, which is not the same thing: libghostty refuses
-to create a surface while the DISPLAY is asleep, so a session a scheduled job creates overnight stays
-unrealized until the displays wake, at which point it recovers on its own. Poll this after creating a
-session unattended; `agtermctl tree` also tags the row `(not realized)`),
+`realized` (whether the session's MAIN pane has a live terminal — `false` means no shell was spawned and a
+`--command` has not run. `session text` then answers `session not realized` without realizing anything;
+`session type` brings up a restored main pane still waiting its turn in a launch that replays commands,
+while any other unrealized cause can still exhaust its poll and fail the same way; `session search`
+expedites such a pane too.
+`session new` returns `ok` for a session that exists in the model, which is not the same thing: libghostty
+refuses to create a surface while the DISPLAY is asleep, so a session a scheduled job creates overnight
+stays unrealized until the displays wake, at which point it recovers on its own. A queued right pane shows
+nothing here. Poll this after creating a session unattended; `agtermctl tree` also tags the row
+`(not realized)`),
 `backedByZmx` (true only when every existing primary/split pane is currently zmx-backed; older servers omit
 it),
 `hasSplit` (whether a second pane exists at all, shown or hidden with ⌘D; omitted when there is none —

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -143,6 +143,20 @@ and hyperlink metadata already attached to cells do not. New output behaves norm
 Saving settings with this version removes the legacy `restoreRunningCommand` key. If an older agterm opens
 the same state directory later, it sees no restore setting and defaults to fresh shells.
 
+### "`tree` shows `(not realized)` right after a launch that replays commands"
+
+That is pacing, not a fault. A launch that replays commands starts each window's visible panes at once,
+then the remaining replaying panes one at a time, a short interval apart, so tens of programs do not boot
+in the same instant. A session whose MAIN
+pane is waiting its turn reads `(not realized)` in `tree` and `realized: false` in `tree --json` until its
+turn comes; a queued right pane shows no tag, since `realized` describes the main pane only, so a tree with
+no tags is not proof the launch has finished. While a pane waits for its permit, its captured command stays
+on the session.
+Selecting it, or a command that must act on it (`session type`, `session search`, `session paste`,
+`session selectall`, `font inc`/`dec`/`reset`), brings it up at once; reads such as `session text` and
+`session copy` answer `session not realized` and leave it queued. A main pane still `(not realized)` long
+after its neighbours came up is a different fault, not pacing.
+
 ### "My session restore override didn't fire"
 
 You set `session restore` but the pane came back as a plain shell (or re-ran the old captured command).

--- a/site/docs.html
+++ b/site/docs.html
@@ -3131,6 +3131,7 @@ command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' stop"
                   >›</span
                 ><strong style="color: #e6e1d7">Re-run mode starts commands again.</strong> Fresh shells is the default. Re-run
                 commands starts the command each pane had in the foreground at the last clean quit; it does not reattach that process.
+                A launch that replays commands starts its panes at a paced rate rather than all at once, with visible panes first.
                 Only a single-process command restores faithfully; a command whose name or arguments carry a control character
                 starts a plain shell instead, since the restored line is typed and the line editor would read that byte as an
                 editing key rather than text, and so does one carrying bytes that were not valid UTF-8, which are captured


### PR DESCRIPTION
a launch that replays commands used to start every restored pane's program at once. Several restored Claude Code processes then synchronized their startup `ps` calls, one of them a full-table `ps aux`, and pinned the CPU for seconds. That happened on the first live launch after a rerun quit, and live mode repeats it after an orderly reboot or any other clean capture followed by daemon loss. Replay-bearing panes now start at a paced rate: each window's selected replay-bearing panes at once, then the rest one interval apart in model order, initially 120 ms. Plain restored shells and live survivor attaches stay unpaced.

**host-free pacer** (`88c2a533`). `SpawnPacer` in `agtermCore` is a leaky bucket: one grant per interval from the actual previous grant, no catch-up after a stall, `arm` records expectations only and `request` marks a key ready. A burst or pre-expedited key is granted inside the request; `expedite` grants one key now and resets the deadline, `prioritize` reorders without releasing.

**seed at spawn time** (`71e61296`). `LaunchSeedProvider` resolves a pane's command, initial input and wait flag on the first permitted creation attempt instead of at view construction, so the captured argv and the `session.restore` pin stay on the session while the pane waits. `restore.clear` and a clean quit's capture cover that window.

**permit gate** (`e20220bb`). `createSurface()` asks for its permit after the size guard and before the seed resolves, so a zero-size pane holds no token. `SpawnRegistry` maps a granted key to its view through a weak entry and re-enters `createSurface()` against current bounds. It resumes only a pane already denied, since a synchronous grant re-entered under the requester spawned the surface twice.

**preemption** (`211e7225`, corrected in `145250d9`). Selecting a session expedites its visible panes, and the dashboard host prioritizes its members without releasing any. `session.type`, `session.search`, `session.paste`, `session.selectall` and `font.inc/dec/reset` expedite a queued pane before acting. `session.text` and `session.copy` answer `session not realized`, `surface.cursor` answers `surface not realized`, and all three leave the pane queued.

**arming and drain** (`0aad658e`). The plan comes from the model before any window mounts. `reap` returns the daemon names it saw alive, so a live pane whose daemon survived attaches unpaced, and an unreadable `err=` row paces like a missing daemon. `onDrain` logs the drain once at debug.

**revmux loop fixes** (`145250d9`). The pacer never jumps an expected key, so a session or window closed through the socket before its window mounted held the queue forever. `AppStore` and `WindowLibrary` now report every pane leaving the visible model, hard or soft, and the app discards its key. The same commit moves the selection expedite from `deckActive`, which is split-focus-gated and left the other half of a shown split queued, to `deckVisible`, and makes the pacer's interval private.

**docs** (`ee18591c`, `ede33bca`, `ddf580e3`). The plan, its acceptance map with every required regression's owning test, and the rules, site and bundled skill. Read-back is unchanged: `realized` and the tree's `(not realized)` describe the main pane only, and the drain log is the whole-queue signal. The plan at `docs/plans/20260901-launch-spawn-pacing.md` moves to completed at merge.

gates on the pushed tip: `swift test` 2882 tests in 117 suites, `make test-app` 441 tests, `swiftlint --strict` clean. Manual check on the next natural replaying launch: no launch-wide `ps` burst and no CPU pin, selected panes usable at once, the drain log line in Console.

https://claude.ai/code/session_01YEnN5AXxfm6m8tdjd2E9q8
