### PR TITLE
fix(cookbook): make peer chat delivery reliable

### DIFF
--- a/cookbook/two-agent-chat/README.md
+++ b/cookbook/two-agent-chat/README.md
@@ -8,7 +8,7 @@ Let Claude Code and Codex hold a conversation with each other in one agterm spli
 
 Two coding agents run side by side in a split session, one per pane, and talk to each other directly. Each sends a single line into the other's composer with `peer-chat.py`, and the reply arrives in its own pane as an ordinary prompt. You watch both halves of the exchange without relaying anything by hand.
 
-The value is disagreement. An agent working alone accepts its own reasoning; a second one with its own context attacks it first, and what comes back is a located disagreement or a checked fact rather than agreement.
+The value is disagreement. An agent working alone accepts its own reasoning; a second one with its own context attacks it first, and what comes back is a located disagreement or a checked fact instead of agreement.
 
 That is not only for planning. It works on the code itself: two agents reviewing the same diff find different defects, and each can refute the other's finding before it reaches anyone. It works on a bug, where one traces the failure and the other tries to prove the diagnosis wrong. It works on a long investigation, where splitting the reading keeps them off the same files. Design discussion is one use among those, not the point.
 
@@ -23,7 +23,7 @@ agterm 0.24.0 or later, which added `surface cursor`. The recipe refuses to type
 1. Copy `peer-chat.py` somewhere on your `PATH`, keeping the executable bit.
 2. Copy `SKILL-claude.md` to `~/.claude/skills/peer-chat/SKILL.md` and `SKILL-codex.md` to `~/.codex/skills/peer-chat/SKILL.md`. Both loaders require the installed file to be named exactly `SKILL.md`, so the suffix here only says which agent the file is for. Each one tells its own agent how to send, how to recognise an incoming message, and what it may not do to the other pane.
 3. Edit both copies so the path they name for `peer-chat.py` matches where you put it.
-4. If you start either agent through a wrapper script rather than as `claude` or `codex`, put that wrapper's name in the same file, as the `--target-command` value the agent should pass when sending to it. Without this the first send refuses, saying the target pane is not running the expected command.
+4. If you start either agent through a wrapper script instead of as `claude` or `codex`, put that wrapper's name in the same file, as the `--target-command` value the agent should pass when sending to it. Without this the first send refuses, saying the target pane is not running the expected command.
 5. To let Codex reserve and send file-backed messages without separate approvals, add these two entries to `~/.codex/rules/default.rules`, creating the file if needed and using the command name or path from step 1:
 
    ```python
@@ -47,7 +47,15 @@ your message as one paragraph
 MSG
 ```
 
-`--to claude` sends the other way. `--session` names a session explicitly; without it the script uses `AGTERM_SESSION_ID` when the caller has one, and otherwise looks for a single session whose target pane is running the expected agent.
+`--to claude` sends the other way. `--session` names a session explicitly; without it the script uses `AGTERM_SESSION_ID` when the caller has one, and otherwise looks for a single session whose target pane is running the expected agent. An explicit session is found across open windows, while `--window` constrains the lookup. The resolved window id stays pinned for the full send.
+
+Claude Code normally sends to Codex with Return, the key Codex uses for steering an active turn. Codex can still queue it when its current state cannot accept a steer. Add `--queue` only for an informational note that can wait until the turn ends:
+
+```sh
+peer-chat.py --to codex --queue --stdin <<'MSG'
+the background check finished; no action is needed in this turn
+MSG
+```
 
 Codex can keep the send as plain command arguments by using a private one-shot message file. Reserve a fresh name first:
 
@@ -77,13 +85,15 @@ On success it prints `{"sent": N}` and exits 0. Any refusal or failure exits 1 w
 
 ## How it works
 
-The message is typed into the other pane's composer through `agtermctl session type`, which is real typing rather than a paste, so a newline would submit a half-written line. The script collapses the message to one paragraph before sending, which is why the examples above are written as one.
+The message is typed into the other pane's composer through `agtermctl session type --stdin`, which treats a newline as Return. The script collapses the message to one paragraph and packs words into UTF-8-safe events. Each body event ends with a short marker absent from the message, and the complete event stays within 197 bytes. A live boundary test accepted a 1,627-byte event and began losing 1,022-byte windows at 1,663 bytes; the smaller cap also keeps one event visible in a narrow Claude composer. After every event the script waits for the marked composer to settle, checks the newly visible tail against that event and an overlap from the preceding text, backspaces the marker, and confirms its removal. The comparison permits a source space to become a terminal wrap, so it still works after the opening text has scrolled out of view. If a clipped periodic tail could represent either complete input or a truncated current event, the script refuses the send. The final unmarked body must stay settled for 500 ms before the script sends the submit key separately and confirms that the body cleared.
 
-Three checks guard every send. The script first confirms that the pane contains a recognisable composer prompt, then `agtermctl surface cursor` must report the caret at column 2, where it rests in an empty composer. The caret read is the final pre-write check. Pane text cannot prove the composer is empty: both agents draw a placeholder hint in an empty box, so a hint and something you half-typed read alike, while the caret sits past the chevron whenever real text is present. A pre-write refusal means nothing was written. After typing, the script confirms that the line is visible where a message goes before it sends the submit key, so a dialog can receive text but cannot be answered. A refusal there means the text may still be sitting in the composer, which is why the script stops instead of retrying.
+Before the body request, the script confirms that the target pane runs the expected agent and contains its known empty input: a blank Claude prompt, either shipped Claude queue hint, or Codex's `Ask Codex to do anything` placeholder. `agtermctl surface cursor` must also report the caret at column 2. Both checks are required because a full-width Codex draft can wrap its caret onto a reserved empty row at column 2. It checks the target process once more immediately before each write. The agterm window is fixed before these checks, so changing the frontmost window during a send cannot redirect or strand later pieces. A changed placeholder fails closed until the recipe is updated.
 
-The two agents need different submit keys. Codex takes Tab, which queues the line as a follow-up when it is mid-turn and submits on an idle composer; Return would steer a running turn instead. Claude Code takes Return. Getting this backwards is the single easiest way to break the exchange.
+**Why the body is split and submit is separate:** Claude Code can lose the middle of an oversized text event, and it may absorb Return when that key reaches its parser in the same burst as the body. Bounded, separately observed events avoid the reproduced loss; the temporary marker makes each event change observable; the visible-tail comparison rejects visible mismatches and ambiguous clipped periodic alignments. The final settled-state interval makes the following Return distinct even when rendering is slow.
 
-Messages carry a label, `Chat from Claude:` or `Chat from Codex:`, which is what lets the receiving agent read an arriving prompt as the next line of a conversation rather than as a fresh instruction from you. The script adds the label, so the skills tell each agent not to write one.
+Return is the normal submit key in both agents. In Codex it requests steering of the running turn; `--queue` uses Tab for a note that should wait until the turn ends. The script confirms that the composer cleared, but cannot distinguish an accepted steer from Codex queueing the message because the current state cannot be steered. Claude Code accepts Return and manages its own busy queue.
+
+Messages carry a label, `Chat from Claude:` or `Chat from Codex:`, which lets the receiving agent read an arriving prompt as the next line of a conversation instead of as a fresh instruction from you. The script adds the label, so the skills tell each agent not to write one.
 
 Sending requires exactly one of `--stdin` and `--message-file NAME`. Both keep the message text out of the process list and protect its punctuation from the shell. `--prepare-message NAME` creates the named file with mode 0600 in a per-user directory with mode 0700. A file-backed send resolves and checks the target session before opening the file. It accepts only a reserved basename, rejects links, non-regular files, files accessible to other users, and bodies over 64 KiB, then removes the directory entry before reading the message.
 
@@ -91,30 +101,34 @@ The recipe deliberately does not start agents. Deciding that a pane is safe to t
 
 ## Limits
 
-**The script types into another pane's composer, and it can submit text you did not write.** The caret check is one-way evidence: a caret at column 2 rules out a draft whose cursor sits after the text, but it cannot tell an empty composer from a draft whose cursor was moved back to the start. In that state the message is inserted in front of your draft and both are submitted together. The check made after typing cannot rule that out either: only the composer's first rendered row is identifiable, so once a message wraps, anything left on a continuation row is invisible to it, in both directions. Do not leave half-written input in a pane you are about to receive a message in.
+**The script types into another pane's composer.** It accepts only the agent's known empty prompt together with a caret at column 2, which rejects ordinary drafts even when their caret is at the start or wraps onto an empty row. A draft whose complete text equals one of the recognised placeholders can still imitate that state. Do not leave half-written input in a pane you are about to receive a message in.
 
-**In practice it does not type into dialogs, but a short window exists where it could.** A dialog already on screen stops the send: the pane must contain a recognisable composer prompt and the caret must be at rest before a single character goes anywhere. The window is only the moment between the caret check and the typing, which are separate `agtermctl` calls, so a chooser or trust prompt appearing inside it would receive the message text. Even then the post-write check fails and the submit key is withheld, so nothing is answered and no choice is confirmed, though characters reaching a picker can move its selection.
+**Short dialog races remain.** A dialog already on screen stops the send: the pane must contain a recognisable empty composer before a single character goes anywhere. A chooser or trust prompt that appears during a body write could receive text; the next composer check withholds submit, but cleanup backspaces could still affect the dialog. The visible composer state must remain unchanged from the final settled chunk immediately before Return. A chooser that appears after that check and before the separate Return request can still receive the key because agterm has no conditional type operation.
 
-**The first exchange may stop and wait for you.** An agent asked to run this script may put up its own approval request before running anything, and neither skill will answer it: a permission prompt carries your authority, so both are told to leave it alone. Until you approve it in that pane, the exchange simply sits there, which looks like a hang rather than a question.
+**Do not type in the receiving pane during a send.** Recovery progressively checks that every visible row is one contiguous part of the script's attempted body before each bounded backspace batch. This permits cleanup after the opening has scrolled away and stops when newly revealed or appended text is foreign. A keystroke arriving after that ownership check but before its backspaces can still be erased.
 
-**A busy composer is waited out, but only for about forty seconds.** If the other pane's composer is not confirmably empty, the script retries five times at ten-second intervals, printing each attempt to stderr, then gives up with exit 1 and types nothing. A pane left sitting on a dialog therefore costs about forty seconds before the send fails rather than blocking forever.
+**The first exchange may stop and wait for you.** An agent asked to run this script may put up its own approval request before running anything, and neither skill will answer it: a permission prompt carries your authority, so both are told to leave it alone. Until you approve it in that pane, the exchange simply sits there and looks like a hang, not a question.
+
+**A busy composer is waited out, but only for about forty seconds.** If the other pane's composer is not confirmably empty, the script retries five times at ten-second intervals, printing each attempt to stderr, then gives up with exit 1 and types nothing. A pane left sitting on a dialog therefore costs about forty seconds before the send fails instead of blocking forever.
 
 **A multi-row Codex shortcut overlay is treated as busy.** The parser ignores one trailing status row. It does not strip a whole indented region because shortcut rows and modal choices have the same shape; the send therefore retries and refuses until a multi-row overlay closes.
 
-**Only the pre-write refusal is retried.** Nothing has been typed at that point, so trying again is safe. Every failure after the text has gone in stops on the first occurrence and is never retried, because retrying there would duplicate a message that is already sitting in the composer.
+**Highly repetitive input can be refused after the opening scrolls away.** A rendered suffix such as a long run of one character can align with both the complete message and one missing part of the current event. The script stops and cleans up when it cannot distinguish those states.
 
-**A failed send can strand the message in the composer.** When the script types successfully but cannot verify the result, it stops with the text still sitting there. Read the pane before doing anything else: retrying blind either duplicates the message or leaves the old line to be submitted later by hand.
+**Rendered text cannot prove every source character.** Agterm exposes the terminal's plain screen text, which omits an ASCII space consumed at a visual line wrap. A correctly wrapped space and a missing space at that exact boundary therefore look identical to the script. The 197-byte event cap avoids the reproduced oversized-event loss, but the read-back is not a byte-level receipt from the agent's editor.
 
-The two directions are not symmetric. Codex is sent Tab, which queues the line while it is busy and costs a running turn nothing. Claude Code has no queue-only key and is sent Return, so a message arriving while it works injects into the turn in progress and can interrupt it. Send to Claude when you have finished, not mid-thought.
+**Only a confirmed pre-body refusal is retried.** Nothing has been typed at that point, so trying again is safe. Once the body request starts, any failure stops on the first occurrence. Before submission, the script backspaces the text it owns and reports whether the empty composer was restored; it never sends an interrupt key to clear a busy agent. A failure during or after the submit request is ambiguous and retrying could duplicate the message.
+
+The two directions are not symmetric. Codex exposes both steering Return and queued Tab, while Claude Code exposes only its normal Return submission and manages busy input itself. Use `--queue` only for a Codex-bound note that needs no action during the current turn.
 
 It assumes Claude Code on the left and Codex on the right. Each agent's pane is fixed in the script's profiles, so a split arranged the other way sends every message to the wrong pane. A session with no split is refused outright, before any pane is read: without that check a send to the left pane would still pass after the right one had closed, which is no longer a two-agent layout at all.
 
-**Codex cannot see which pane it is in unless you tell it at launch.** It strips `AGTERM_SESSION_ID` from every tool subprocess, and nothing inside its sandbox recovers the value: reading a parent process is blocked outright. Without the launch injection in *Setup*, the script falls back to matching the git checkout, and every worktree of one repository maps to the same checkout, so two sessions open on the same repository are indistinguishable and the send refuses. That refusal is the correct outcome, not a bug, but it is why the injection is worth doing once in your Codex launcher rather than remembering per session.
+**Codex cannot see which pane it is in unless you tell it at launch.** It strips `AGTERM_SESSION_ID` from every tool subprocess, and nothing inside its sandbox recovers the value: reading a parent process is blocked outright. Without the launch injection in *Setup*, the script falls back to matching the git checkout, and every worktree of one repository maps to the same checkout, so two sessions open on the same repository are indistinguishable and the send refuses. That refusal is the correct outcome, not a bug, but it is why the injection is worth doing once in your Codex launcher instead of remembering per session.
 
-Session resolution never guesses. With `AGTERM_SESSION_ID` or `--session` it uses that session after checking the target pane. Without either, it matches only sessions in the same checkout as the caller, and refuses on none or several rather than picking a session elsewhere that happens to have the right shape. `--session` takes a full id or any unique prefix of one.
+Session resolution never guesses. With `AGTERM_SESSION_ID` or `--session` it searches open windows for that session, pins its owning window and checks the target pane; `--window` restricts this to one window. Without a session id, it matches only sessions in the same checkout as the caller, and refuses on none or several instead of picking a session elsewhere that happens to have the right shape. `--session` takes a full id or any unique prefix of one.
 
 An agent whose launcher leaves no stable name in the pane's command line cannot be targeted at all. `--target-command` matches a name that agterm can actually see, so a wrapper that execs through something anonymous stays unsupported and every send to it refuses.
 
-A reply is not promised. An agent's model can decline to answer a message that arrived perfectly well, and nothing on either side reports that. If an exchange goes quiet, read the other pane rather than waiting.
+A reply is not promised. An agent's model can decline to answer a message that arrived perfectly well, and nothing on either side reports that. If an exchange goes quiet, read the other pane instead of waiting.
 
 No transcript is kept. A one-shot message file remains untouched until the target session resolves. Once its identity, ownership and link checks pass, its directory entry is removed before mode, size and body validation, so those validation failures and every later send failure consume it. A prepared file that never reaches that point remains in the private spool. The conversation lives in the two panes and is gone when the session ends.

--- a/cookbook/two-agent-chat/SKILL-claude.md
+++ b/cookbook/two-agent-chat/SKILL-claude.md
@@ -10,8 +10,9 @@ Talk with Codex in the split pane. The user reads both panes, so the conversatio
 result even when code comes out of it.
 
 Everything that touches the pane goes through `peer-chat.py`. Do not drive `agtermctl` directly:
-the script carries the checks that keep a message out of a dialog, and a raw `session type` bypasses
-all of them.
+the script checks the target agent, window, composer and cursor, sends the body as bounded, separately
+observed pieces through `session type --stdin`, then sends the submit key after the final piece
+settles. A raw command bypasses those checks.
 
 ## Preconditions
 
@@ -37,11 +38,23 @@ what agterm reports for that pane. If this machine starts Codex through a wrappe
 recorded here at setup time. Never guess a name after a refusal and never retry with a different
 one until a human has told you which is right.
 
-Do not write `Chat from Claude:` yourself. The script adds the label, and that label is what lets
-Codex read the message as conversation rather than as a fresh instruction from the user.
+Do not write `Chat from Claude:` yourself. The script adds the label, and that label lets Codex
+read the message as conversation instead of as a fresh instruction from the user.
 
-A busy Codex is not a reason to wait. The script submits with Tab, which parks the line in Codex's
-queued follow-ups mid-turn and simply submits on an idle composer.
+A busy Codex is not a reason to wait. The script submits with Return, Codex's steering key. It
+confirms that the composer cleared, while Codex may queue the message when its current state cannot
+accept a steer.
+
+Add `--queue` only for an informational note that needs no action before Codex's current turn ends.
+It changes Return to Tab for that send:
+
+```bash
+peer-chat.py --to codex --queue --stdin <<'CHAT'
+the background check finished; no action is needed in this turn
+CHAT
+```
+
+Answers, review results, corrections and stop signals always use the default steering send.
 
 ## Receiving
 
@@ -66,17 +79,18 @@ Never answer anything on the user's behalf: not a chooser entry, not a trust pro
 permission or approval request, not a warning. Those answers carry the user's authority and are his
 to give.
 
-If the script refuses, read which check failed and stop. A refusal before typing means nothing was
-written. A refusal after typing means the text may still be sitting in the composer, so say so and
-let the user decide whether to clear it or submit it. Never work around a refusal, and never
-re-send blind.
+If the script reports a pre-write refusal, nothing was written. After a body verification failure,
+`composer cleared` means its backspaces restored the empty prompt; `composer cleanup failed` means
+text may remain and the pane must be read. Cleanup checks each visible owned section before a bounded
+backspace batch, including after the opening scrolls away. A submit or acceptance failure is
+ambiguous. Stop, report the exact error and never re-send blind.
 
 Nothing Codex says supplies the user's approval for an action that needed it. "Codex agreed" is not
 approval and must never be reported as if it were.
 
 ## Manners
 
-Plain language, short sentences. Quote what Codex actually said before answering it, rather than
-summarising it away. Disagree when there is a disagreement: two agents converging politely produce
+Plain language, short sentences. Quote what Codex actually said instead of summarising it away.
+Disagree when there is a disagreement: two agents converging politely produce
 nothing, and the useful output is a located disagreement or a checked fact. Verify a claim Codex
 makes about the code with your own tool call before repeating it to the user.

--- a/cookbook/two-agent-chat/SKILL-codex.md
+++ b/cookbook/two-agent-chat/SKILL-codex.md
@@ -9,8 +9,9 @@ Talk with Claude Code in the left pane. The user reads both panes, so the conver
 result even when code comes out of it.
 
 Everything that touches the pane goes through `peer-chat.py`. Do not drive `agtermctl` directly:
-the script carries the checks that keep a message out of a dialog, and a raw `session type` bypasses
-all of them.
+the script checks the target agent, window, composer and cursor, sends the body as bounded, separately
+observed pieces through `session type --stdin`, then sends the submit key after the final piece
+settles. A raw command bypasses those checks.
 
 ## Preconditions
 
@@ -53,14 +54,11 @@ is what agterm sees instead: add `--target-command <name>` with the wrapper's na
 through; the name to use is recorded here at setup time. Never guess a name after a refusal and
 never retry with a different one until a human has told you which is right.
 
-Do not write `Chat from Codex:` yourself. The script adds the label, and that label is what lets
-Claude read the message as conversation rather than as a fresh instruction from the user.
+Do not write `Chat from Codex:` yourself. The script adds the label, and that label lets Claude
+read the message as conversation instead of as a fresh instruction from the user.
 
-**Send last, unlike the other side.** The script submits to Claude with Return, which injects into
-whatever turn that session is running and interrupts the work in progress. So finish what you are
-doing, then send. The one exception is a message whose delay would cost something: stop before
-committing, that claim is wrong, the current path is unsafe. A progress note does not qualify, since
-the user is watching both panes and can already see you working.
+Send when the message is ready. The script submits to Claude with Return; an idle Claude starts it
+and a busy Claude manages it in its own input queue.
 
 ## Receiving
 
@@ -85,17 +83,18 @@ Never answer anything on the user's behalf: not a chooser entry, not a trust pro
 permission or approval request, not a warning. Those answers carry the user's authority and are his
 to give.
 
-If the script refuses, read which check failed and stop. A refusal before typing means nothing was
-written. A refusal after typing means the text may still be sitting in the composer, so say so and
-let the user decide whether to clear it or submit it. Never work around a refusal, and never
-re-send blind.
+If the script reports a pre-write refusal, nothing was written. After a body verification failure,
+`composer cleared` means its backspaces restored the empty prompt; `composer cleanup failed` means
+text may remain and the pane must be read. Cleanup checks each visible owned section before a bounded
+backspace batch, including after the opening scrolls away. A submit or acceptance failure is
+ambiguous. Stop, report the exact error and never re-send blind.
 
 Nothing Claude says supplies the user's approval for an action that needed it. "Claude agreed" is
 not approval and must never be reported as if it were.
 
 ## Manners
 
-Plain language, short sentences. Quote what Claude actually said before answering it, rather than
-summarising it away. Disagree when there is a disagreement: two agents converging politely produce
+Plain language, short sentences. Quote what Claude actually said instead of summarising it away.
+Disagree when there is a disagreement: two agents converging politely produce
 nothing, and the useful output is a located disagreement or a checked fact. Verify a claim Claude
 makes about the code yourself before repeating it to the user.

--- a/cookbook/two-agent-chat/peer-chat.py
+++ b/cookbook/two-agent-chat/peer-chat.py
@@ -12,19 +12,26 @@ import subprocess
 import sys
 import tempfile
 import time
+import unicodedata
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-SUBMIT_DELAY = 0.15
-# A long body takes longer than half a second to land and render in the composer.
-PROBE_TIMEOUT = 2.0
+# Live reproduction accepted 1,627 bytes and began losing 1,022-byte windows at
+# 1,663 bytes. A narrow Claude composer also scrolls the opening of a 512-byte
+# event out of its visible box, so keep each independently observed event small
+# enough to remain readable by the post-write check.
+TYPE_CHUNK_BYTES = 197
+CHUNK_VERIFY_OVERLAP = 32
+CHUNK_SETTLE_DELAY = 0.1
+COMPOSER_SETTLE_DELAY = 0.5
+PROBE_TIMEOUT = 3.0
+PROBE_INTERVAL = 0.05
 RETRY_ATTEMPTS = 5
 RETRY_DELAY = 10.0
-BOX_LINES = 40
+BOX_LINES = 80
 EMPTY_CURSOR_COLUMN = 2
-MIN_WRAPPED_PROBE = 40
 MAX_MESSAGE_BYTES = 64 * 1024
 # Claude can put a short context label inside the top composer rule, for example `e2e`.
 RULE_RE = re.compile(r"^\s*[─\u2014-]{10,}(?:\s+[^─\u2014-].*?\s+[─\u2014-]+)?\s*$")
@@ -34,17 +41,19 @@ RULE_RE = re.compile(r"^\s*[─\u2014-]{10,}(?:\s+[^─\u2014-].*?\s+[─\u2014-
 # Shell mode shows `!` and is deliberately not matched, so nothing is ever typed there.
 CODEX_PROMPT_RE = re.compile(r"^[›»][\s ]*(.*?)\s*$")
 CODEX_SHELL_PROMPT_RE = re.compile(r"^![\s ]*(.*?)\s*$")
+CODEX_CHOICE_RE = re.compile(r"^\d+\.\s")
+CODEX_EMPTY_PROMPT = "Ask Codex to do anything"
 # Codex prefixes footer rows with two spaces. Only the final row is stripped: a
 # multi-row shortcut overlay is indistinguishable from indented modal choices and
 # therefore fails closed instead of weakening the live-prompt guard.
 CODEX_FOOTER_RE = re.compile(r"^ {2}\S.*$")
 CLAUDE_PROMPT_RE = re.compile(r"^\s*❯[\s ]*(.*?)\s*$")
-PASTED_RE = re.compile(r"\[Pasted Content \d+ chars?\]")
-# loose on purpose: Claude draws "[Pasted text #16]" and "[Pasted text #1 +12 lines]", and a
-# precise pattern would refuse an unseen variant. The body fragment below is what proves
-# whose content the box holds.
-PASTED_TEXT_RE = re.compile(r"^\[Pasted text #\d+[^\]]*\]")
-MESSAGE_FRAGMENT = 20
+CLAUDE_FOOTER_RE = re.compile(r"^ {2}\S.*$")
+CLAUDE_EMPTY_PROMPTS = {
+    "",
+    "Press up to edit queued messages",
+    "Press up to edit queued messages, Enter to send them immediately",
+}
 MESSAGE_NAME_RE = re.compile(r"peer-chat-[a-z0-9][a-z0-9-]{2,48}\.txt")
 MESSAGE_SPOOL = Path(tempfile.gettempdir()) / f"agterm-peer-chat-{os.getuid()}"
 
@@ -58,9 +67,23 @@ class Profile:
     submit: str
 
 
+@dataclass
+class BodyProgress:
+    """Exact composer text owned at the latest body transaction boundary."""
+
+    owned_text: str = ""
+
+
+@dataclass
+class DeliveryProgress:
+    """Conservative delivery state shared with the outer CLI boundary."""
+
+    phase: str = "not_started"
+
+
 PROFILES = {
     "claude": Profile("left", "claude", "claude", "Chat from Codex: ", "\n"),
-    "codex": Profile("right", "codex", "codex", "Chat from Claude: ", "\t"),
+    "codex": Profile("right", "codex", "codex", "Chat from Claude: ", "\n"),
 }
 
 
@@ -68,12 +91,28 @@ class PromptBlocked(RuntimeError):
     """The target prompt is occupied before any text was written."""
 
 
-def ctl(*args: str) -> str:
+class ComposerDirty(RuntimeError):
+    """A body write started but could not be verified before submission."""
+
+    def __init__(
+        self, message: str, owned_text: str, interrupted: bool = False
+    ) -> None:
+        super().__init__(message)
+        self.owned_text = owned_text
+        self.interrupted = interrupted
+
+
+class DeliveryAmbiguous(RuntimeError):
+    """Submission may have started, so the caller must not resend."""
+
+
+def ctl(*args: str, input_text: str | None = None) -> str:
     command = os.environ.get("AGTERMCTL", "agtermctl")
     result = subprocess.run(
         [command, *args],
         capture_output=True,
         check=False,
+        input=input_text,
         text=True,
         timeout=30,
     )
@@ -83,8 +122,66 @@ def ctl(*args: str) -> str:
     return result.stdout
 
 
-def tree() -> Any:
-    return json.loads(ctl("tree", "--json"))
+def window_option(window: str | None) -> tuple[str, ...]:
+    return ("--window", window) if window else ()
+
+
+def configured_selector(
+    explicit: str | None,
+    environment: str,
+    label: str,
+    default: str | None = None,
+) -> str | None:
+    """Resolve one explicit or environment selector without blank fallback."""
+    raw = explicit if explicit is not None else os.environ.get(environment)
+    if raw is None:
+        return default
+    value = raw.strip()
+    if not value:
+        raise RuntimeError(f"{label} selector is empty")
+    return value
+
+
+def tree(window: str | None = None) -> Any:
+    return json.loads(ctl("tree", "--json", *window_option(window)))
+
+
+def resolve_window(explicit: str | None) -> str:
+    target = configured_selector(
+        explicit, "AGTERM_WINDOW_ID", "window", "active"
+    )
+    assert target is not None
+    payload = json.loads(ctl("window", "list", "--json"))
+    windows = payload.get("result", {}).get("windows", [])
+    if target.lower() == "active":
+        matches = [item for item in windows if item.get("active")]
+    else:
+        exact = [
+            item
+            for item in windows
+            if str(item.get("id", "")).lower() == target.lower()
+        ]
+        matches = exact or [
+            item
+            for item in windows
+            if str(item.get("id", "")).lower().startswith(target.lower())
+        ]
+    if len(matches) != 1 or not matches[0].get("id"):
+        detail = "ambiguous" if len(matches) > 1 else "not found"
+        raise RuntimeError(f"agterm window {target!r} is {detail}")
+    if not matches[0].get("open"):
+        raise RuntimeError(f"agterm window {target!r} is not open")
+    return str(matches[0]["id"])
+
+
+def open_window_ids() -> list[str]:
+    """Return every open window id for an explicit-session lookup."""
+    payload = json.loads(ctl("window", "list", "--json"))
+    return [
+        str(item["id"])
+        for item in payload.get("result", {}).get("windows", [])
+        if item.get("open") and item.get("id")
+    ]
 
 
 def checkout_key(path: str) -> str:
@@ -124,11 +221,14 @@ def command_name(value: str) -> str:
     return name
 
 
-def target_profile(target: str, explicit_command: str | None) -> Profile:
+def target_profile(
+    target: str, explicit_command: str | None, queue: bool = False
+) -> Profile:
     profile = PROFILES[target]
     env_name = f"PEER_CHAT_{profile.agent.upper()}_COMMAND"
     configured = explicit_command or os.environ.get(env_name) or profile.command
-    return replace(profile, command=command_name(configured))
+    submit = "\t" if queue else profile.submit
+    return replace(profile, command=command_name(configured), submit=submit)
 
 
 def runs(foreground: Any, command: str) -> bool:
@@ -145,11 +245,11 @@ def has_target(info: dict[str, Any], profile: Profile) -> bool:
     return runs(info.get(field), profile.command)
 
 
-def find_node(sid: str) -> dict[str, Any]:
+def find_node(sid: str, window: str | None = None) -> dict[str, Any]:
     needle = sid.lower()
     matches = [
         info
-        for info in walk(tree())
+        for info in walk(tree(window))
         if str(info.get("id", "")).lower().startswith(needle)
     ]
     if len(matches) == 1:
@@ -159,8 +259,10 @@ def find_node(sid: str) -> dict[str, Any]:
     raise RuntimeError(f"ambiguous session prefix {sid!r}")
 
 
-def require_target(sid: str, profile: Profile) -> str:
-    info = find_node(sid)
+def require_target(
+    sid: str, profile: Profile, window: str | None = None
+) -> str:
+    info = find_node(sid, window)
     if not info.get("hasSplit"):
         raise RuntimeError(f"session {sid} has no split")
     if not has_target(info, profile):
@@ -171,14 +273,16 @@ def require_target(sid: str, profile: Profile) -> str:
     return str(info["id"])
 
 
-def resolve_session(explicit: str | None, profile: Profile) -> str:
-    sid = explicit or os.environ.get("AGTERM_SESSION_ID")
+def resolve_session(
+    explicit: str | None, profile: Profile, window: str | None = None
+) -> str:
+    sid = configured_selector(explicit, "AGTERM_SESSION_ID", "session")
     if sid:
-        return require_target(sid, profile)
+        return require_target(sid, profile, window)
     wanted = checkout_key(os.getcwd())
     matches = [
         str(info["id"])
-        for info in walk(tree())
+        for info in walk(tree(window))
         if has_target(info, profile)
         and info.get("cwd")
         and checkout_key(str(info["cwd"])) == wanted
@@ -197,8 +301,61 @@ def resolve_session(explicit: str | None, profile: Profile) -> str:
     )
 
 
-def pane_text(sid: str, profile: Profile) -> str:
-    require_target(sid, profile)
+def resolve_target(
+    explicit_session: str | None,
+    explicit_window: str | None,
+    profile: Profile,
+) -> tuple[str, str]:
+    """Resolve one session and pin its owning window before any pane read."""
+    session = configured_selector(
+        explicit_session, "AGTERM_SESSION_ID", "session"
+    )
+    window_selector = (
+        configured_selector(explicit_window, "AGTERM_WINDOW_ID", "window")
+        if explicit_window is not None or explicit_session is None
+        else None
+    )
+    if window_selector is not None:
+        window = resolve_window(window_selector)
+        return window, resolve_session(explicit_session, profile, window)
+    if not session:
+        window = resolve_window(None)
+        return window, resolve_session(None, profile, window)
+
+    needle = session.lower()
+    matches: list[tuple[str, dict[str, Any]]] = []
+    for window in open_window_ids():
+        matches.extend(
+            (window, info)
+            for info in walk(tree(window))
+            if str(info.get("id", "")).lower().startswith(needle)
+        )
+    if len(matches) > 1:
+        raise RuntimeError(f"ambiguous session prefix {session!r}")
+    if not matches:
+        raise RuntimeError(f"no such session: {session}")
+    window, info = matches[0]
+    sid = str(info["id"])
+    if not info.get("hasSplit"):
+        raise RuntimeError(f"session {sid} has no split")
+    if not has_target(info, profile):
+        raise RuntimeError(
+            f"{profile.agent} target pane is not running {profile.command!r}; "
+            "for a wrapper, pass --target-command NAME"
+        )
+    return window, sid
+
+
+def pane_text(
+    sid: str, profile: Profile, window: str | None = None
+) -> str:
+    require_target(sid, profile, window)
+    return _pane_text_unchecked(sid, profile, window)
+
+
+def _pane_text_unchecked(
+    sid: str, profile: Profile, window: str | None = None
+) -> str:
     return ctl(
         "session",
         "text",
@@ -208,16 +365,26 @@ def pane_text(sid: str, profile: Profile) -> str:
         sid,
         "--lines",
         str(BOX_LINES),
+        *window_option(window),
     )
 
 
-def cursor_column(sid: str, profile: Profile) -> int:
-    require_target(sid, profile)
+def cursor_column(
+    sid: str, profile: Profile, window: str | None = None
+) -> int:
+    require_target(sid, profile, window)
+    return _cursor_column_unchecked(sid, profile, window)
+
+
+def _cursor_column_unchecked(
+    sid: str, profile: Profile, window: str | None = None
+) -> int:
     value = ctl(
         "surface",
         "cursor",
         "--target",
         f"surface:{sid}:{profile.pane}",
+        *window_option(window),
     ).strip()
     try:
         return int(value)
@@ -225,17 +392,65 @@ def cursor_column(sid: str, profile: Profile) -> int:
         raise RuntimeError(f"surface cursor returned {value!r}") from err
 
 
-def type_text(sid: str, profile: Profile, text: str) -> None:
-    require_target(sid, profile)
+def type_text(
+    sid: str, profile: Profile, text: str, window: str | None = None
+) -> None:
+    require_target(sid, profile, window)
     ctl(
         "session",
         "type",
-        text,
+        "--stdin",
         "--pane",
         profile.pane,
         "--target",
         sid,
+        *window_option(window),
+        input_text=text,
     )
+
+
+def text_chunks(text: str, max_bytes: int = TYPE_CHUNK_BYTES) -> list[str]:
+    """Split normalised text into independently observable input events."""
+    max_bytes = max(4, min(TYPE_CHUNK_BYTES, max_bytes))
+    chunks: list[str] = []
+    current = ""
+    tokens = re.findall(r" ?[^ ]+", text)
+    for token in tokens:
+        if len((current + token).encode("utf-8")) <= max_bytes:
+            current += token
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        if len(token.encode("utf-8")) <= max_bytes:
+            current = token
+            continue
+
+        piece: list[str] = []
+        piece_bytes = 0
+        for char in token:
+            char_bytes = len(char.encode("utf-8"))
+            if piece and piece_bytes + char_bytes > max_bytes:
+                chunks.append("".join(piece))
+                piece = []
+                piece_bytes = 0
+            piece.append(char)
+            piece_bytes += char_bytes
+        if piece:
+            chunks.append("".join(piece))
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def composer_probe_marker(text: str) -> str:
+    """Choose a short visible marker that cannot occur in this message."""
+    index = 0
+    while True:
+        marker = f" [peer-check:{index:x}]"
+        if marker not in text:
+            return marker
+        index += 1
 
 
 def trailing_input_block(text: str) -> list[str]:
@@ -252,37 +467,19 @@ def trailing_input_block(text: str) -> list[str]:
     return lines[start:]
 
 
-def codex_prompt_text(text: str) -> str | None:
-    content = None
-    for line in trailing_input_block(text):
-        if CODEX_SHELL_PROMPT_RE.match(line):
-            content = None
-        if match := CODEX_PROMPT_RE.match(line):
-            content = match.group(1)
-    return content
-
-
 def codex_live_prompt_text(text: str) -> str | None:
     block = trailing_input_block(text)
     if not block or any(CODEX_SHELL_PROMPT_RE.match(line) for line in block):
         return None
-    match = CODEX_PROMPT_RE.match(block[-1])
-    return match.group(1) if match else None
-
-
-def claude_prompt_text(text: str) -> str | None:
-    lines = text.splitlines()[-BOX_LINES:]
-    for index in range(len(lines) - 1, -1, -1):
-        match = CLAUDE_PROMPT_RE.match(lines[index])
-        if not match:
-            continue
-        content = [match.group(1)]
-        for line in lines[index + 1 :]:
-            if RULE_RE.match(line):
-                break
-            content.append(line.strip())
-        return " ".join(part for part in content if part)
-    return None
+    match = CODEX_PROMPT_RE.match(block[0])
+    if (
+        not match
+        or CODEX_CHOICE_RE.match(match.group(1))
+        or any(not line[:1].isspace() for line in block[1:])
+    ):
+        return None
+    content = [match.group(1), *(line.strip() for line in block[1:])]
+    return "\n".join(part for part in content if part)
 
 
 def claude_live_prompt_text(text: str) -> str | None:
@@ -292,20 +489,21 @@ def claude_live_prompt_text(text: str) -> str | None:
         if not match:
             continue
         content = [match.group(1)]
-        for line in lines[index + 1 :]:
+        for offset, line in enumerate(lines[index + 1 :], start=index + 1):
             if RULE_RE.match(line):
-                return " ".join(part for part in content if part)
+                trailing = [item for item in lines[offset + 1 :] if item.strip()]
+                if any(
+                    not CLAUDE_FOOTER_RE.match(item)
+                    or CODEX_CHOICE_RE.match(item.strip())
+                    for item in trailing
+                ):
+                    return None
+                return "\n".join(part for part in content if part)
             content.append(line.strip())
         if index == len(lines) - 1:
             return match.group(1)
         return None
     return None
-
-
-def prompt_text(profile: Profile, text: str) -> str | None:
-    if profile.agent == "codex":
-        return codex_prompt_text(text)
-    return claude_prompt_text(text)
 
 
 def live_prompt_text(profile: Profile, text: str) -> str | None:
@@ -314,8 +512,383 @@ def live_prompt_text(profile: Profile, text: str) -> str | None:
     return claude_live_prompt_text(text)
 
 
+def composer_is_empty(profile: Profile, content: str) -> bool:
+    """Recognise the empty input content instead of inferring it from the caret."""
+    if profile.agent == "codex":
+        return " ".join(content.splitlines()) == CODEX_EMPTY_PROMPT
+    return " ".join(content.splitlines()) in CLAUDE_EMPTY_PROMPTS
+
+
+def composer_state(
+    sid: str, profile: Profile, window: str | None = None
+) -> tuple[str, int] | None:
+    resolved = require_target(sid, profile, window)
+    content = live_prompt_text(
+        profile, _pane_text_unchecked(resolved, profile, window)
+    )
+    if content is None:
+        return None
+    return content, _cursor_column_unchecked(resolved, profile, window)
+
+
+def wait_for_composer_change(
+    sid: str,
+    profile: Profile,
+    previous: tuple[str, int],
+    settle_delay: float,
+    window: str | None = None,
+) -> tuple[str, int] | None:
+    """Wait for a changed composer state to remain stable."""
+    deadline = time.monotonic() + PROBE_TIMEOUT
+    stable_state: tuple[str, int] | None = None
+    stable_since: float | None = None
+    while True:
+        state = composer_state(sid, profile, window)
+        now = time.monotonic()
+        if state is not None and state != previous:
+            if state != stable_state:
+                stable_state = state
+                stable_since = now
+            elif stable_since is not None and now - stable_since >= settle_delay:
+                return state
+        else:
+            stable_state = None
+            stable_since = None
+        if now >= deadline:
+            return None
+        time.sleep(PROBE_INTERVAL)
+
+
+def type_body(
+    sid: str,
+    profile: Profile,
+    text: str,
+    initial: tuple[str, int],
+    window: str | None = None,
+    progress: BodyProgress | None = None,
+) -> tuple[str, int]:
+    """Type bounded marked chunks, removing each marker before continuing."""
+    if progress is None:
+        progress = BodyProgress()
+    marker = composer_probe_marker(text)
+    chunks = text_chunks(text, TYPE_CHUNK_BYTES - len(marker.encode("utf-8")))
+    state = initial
+    expected = ""
+    for index, chunk in enumerate(chunks):
+        attempted = expected + chunk
+        marked = attempted + marker
+        progress.owned_text = marked
+        try:
+            try:
+                type_text(sid, profile, chunk + marker, window)
+                changed = wait_for_composer_change(
+                    sid, profile, state, CHUNK_SETTLE_DELAY, window
+                )
+                if changed is None:
+                    raise ComposerDirty(
+                        f"message chunk {index + 1}/{len(chunks)} was typed but the "
+                        "target composer did not confirm it; submit withheld",
+                        marked,
+                    )
+                if not composer_has_expected_tail(
+                    changed[0], marked, chunk + marker
+                ):
+                    raise ComposerDirty(
+                        f"message chunk {index + 1}/{len(chunks)} is incomplete in "
+                        "the target composer; submit withheld",
+                        marked,
+                    )
+                type_text(sid, profile, "\x7f" * len(marker), window)
+                settle_delay = (
+                    COMPOSER_SETTLE_DELAY
+                    if index == len(chunks) - 1
+                    else CHUNK_SETTLE_DELAY
+                )
+                unmarked = wait_for_composer_change(
+                    sid, profile, changed, settle_delay, window
+                )
+                if unmarked is None or marker in unmarked[0]:
+                    raise ComposerDirty(
+                        f"message marker after chunk {index + 1}/{len(chunks)} was "
+                        "not confirmably removed; submit withheld",
+                        marked,
+                    )
+                if not composer_has_expected_tail(unmarked[0], attempted, chunk):
+                    raise ComposerDirty(
+                        f"message chunk {index + 1}/{len(chunks)} changed during "
+                        "marker removal; submit withheld",
+                        marked,
+                    )
+                progress.owned_text = attempted
+            except ComposerDirty:
+                raise
+            except (
+                OSError,
+                subprocess.SubprocessError,
+                ValueError,
+                RuntimeError,
+            ) as err:
+                raise ComposerDirty(
+                    f"message chunk {index + 1}/{len(chunks)} failed after its body "
+                    f"write started: {err}; submit withheld",
+                    marked,
+                ) from err
+        except KeyboardInterrupt as err:
+            raise ComposerDirty(
+                f"interrupted during message chunk {index + 1}/{len(chunks)}; "
+                "submit withheld",
+                marked,
+                interrupted=True,
+            ) from err
+        expected = attempted
+        state = unmarked
+    return state
+
+
+def composer_has_expected_tail(
+    content: str,
+    expected: str,
+    chunk: str,
+) -> bool:
+    """Match a source suffix while allowing visual line wrapping."""
+    positions = {len(expected)}
+    rows = content.splitlines() or [content]
+    for index in range(len(rows) - 1, -1, -1):
+        row = rows[index]
+        matched = {
+            end - len(row)
+            for end in positions
+            if end >= len(row) and expected[end - len(row) : end] == row
+        }
+        if not matched:
+            return False
+        if index:
+            # Plain screen text omits a source space consumed by visual wrapping.
+            positions = matched | {
+                start - 1
+                for start in matched
+                if start and expected[start - 1] == " "
+            }
+        else:
+            positions = matched
+    probe_start = max(0, len(expected) - len(chunk) - CHUNK_VERIFY_OVERLAP)
+    matching_starts = {start for start in positions if start <= probe_start}
+    if not matching_starts:
+        return False
+    if 0 in matching_starts:
+        return True
+    return not chunk_tail_is_ambiguous(expected, chunk)
+
+
+def chunk_tail_is_ambiguous(expected: str, chunk: str) -> bool:
+    """Reject a clipped tail that could hide a deletion from this chunk."""
+    if not chunk:
+        return False
+    expected_length = len(expected)
+    chunk_length = len(chunk)
+    visible_length = min(
+        expected_length, chunk_length + CHUNK_VERIFY_OVERLAP
+    )
+    chunk_start = expected_length - chunk_length
+    for missing_start in range(chunk_start, expected_length):
+        for missing_end in range(missing_start + 1, expected_length + 1):
+            missing_length = missing_end - missing_start
+            earlier_start = expected_length - missing_length - visible_length
+            if earlier_start < 0:
+                continue
+            if (
+                expected[earlier_start:missing_start]
+                == expected[expected_length - visible_length : missing_end]
+            ):
+                return True
+    return False
+
+
+def composer_owned_spans(
+    content: str, owned_text: str, allowed_ends: set[int]
+) -> set[tuple[int, int]]:
+    """Locate visible contiguous owned text ending at an allowed prefix boundary."""
+    if not content:
+        return {
+            (end - 1, end)
+            for end in allowed_ends
+            if end == 1 and owned_text[:end] == " "
+        }
+    valid_ends = {end for end in allowed_ends if 0 < end <= len(owned_text)}
+    positions = {(end, end) for end in valid_ends}
+    positions.update(
+        (end - 1, end) for end in valid_ends if owned_text[end - 1] == " "
+    )
+    rows = content.splitlines() or [content]
+    for index in range(len(rows) - 1, -1, -1):
+        row = rows[index]
+        matched = {
+            (position - len(row), end)
+            for position, end in positions
+            if position >= len(row)
+            and owned_text[position - len(row) : position] == row
+        }
+        if not matched:
+            return set()
+        if index:
+            positions = matched | {
+                (start - 1, end)
+                for start, end in matched
+                if start and owned_text[start - 1] == " "
+            }
+        else:
+            positions = matched
+    return positions
+
+
+def wait_for_cleanup_state(
+    sid: str,
+    profile: Profile,
+    previous: tuple[str, int] | None,
+    owned_text: str,
+    allowed_ends: set[int],
+    window: str | None = None,
+    accept_empty: bool = True,
+) -> tuple[tuple[str, int], set[tuple[int, int]]] | None:
+    """Wait for a backspace batch to reach a stable observable state."""
+    deadline = time.monotonic() + PROBE_TIMEOUT
+    stable: tuple[
+        tuple[str, int] | None, frozenset[tuple[int, int]]
+    ] | None = None
+    stable_since: float | None = None
+    while True:
+        state = composer_state(sid, profile, window)
+        now = time.monotonic()
+        is_empty = state is not None and (
+            state[1] == EMPTY_CURSOR_COLUMN
+            and composer_is_empty(profile, state[0])
+        )
+        if is_empty and accept_empty:
+            return state, set()
+        spans = (
+            composer_owned_spans(state[0], owned_text, allowed_ends)
+            if state is not None
+            else set()
+        )
+        if state == previous or (is_empty and not accept_empty):
+            stable = None
+            stable_since = None
+        else:
+            candidate = state, frozenset(spans)
+            if candidate != stable:
+                stable = candidate
+                stable_since = now
+            elif (
+                stable_since is not None
+                and now - stable_since >= CHUNK_SETTLE_DELAY
+            ):
+                if state is None:
+                    return None
+                return state, spans
+        if now >= deadline:
+            return None
+        time.sleep(PROBE_INTERVAL)
+
+
+def clear_composer(
+    sid: str,
+    profile: Profile,
+    initial: tuple[str, int],
+    owned_text: str,
+    window: str | None = None,
+) -> bool:
+    """Backspace text owned by this send without interrupting an active turn."""
+    allowed_ends = set(range(1, len(owned_text) + 1))
+    settled = wait_for_cleanup_state(
+        sid,
+        profile,
+        initial,
+        owned_text,
+        allowed_ends,
+        window,
+        accept_empty=False,
+    )
+    if settled is None:
+        return False
+    state, spans = settled
+    while True:
+        if state == initial or (
+            state[1] == EMPTY_CURSOR_COLUMN
+            and composer_is_empty(profile, state[0])
+        ):
+            return True
+        if not spans:
+            return False
+        previous_end = max(end for _, end in spans)
+        delete_count = min(
+            TYPE_CHUNK_BYTES, min(end - start for start, end in spans)
+        )
+        if not delete_count:
+            return False
+        type_text(sid, profile, "\x7f" * delete_count, window)
+        next_ends = {
+            candidate
+            for _, end in spans
+            for candidate in range(end - delete_count, end)
+        }
+        settled = wait_for_cleanup_state(
+            sid, profile, state, owned_text, next_ends, window
+        )
+        if settled is None:
+            return False
+        state, spans = settled
+        if (
+            state[1] == EMPTY_CURSOR_COLUMN
+            and composer_is_empty(profile, state[0])
+        ):
+            return True
+        if not spans:
+            return False
+        if max(end for _, end in spans) >= previous_end:
+            return False
+        allowed_ends = {end for _, end in spans}
+
+
+def wait_for_accepted(
+    sid: str,
+    profile: Profile,
+    composed: tuple[str, int],
+    window: str | None = None,
+) -> bool:
+    """Wait until submission clears the composed state and restores column 2."""
+    deadline = time.monotonic() + PROBE_TIMEOUT
+    stable_state: tuple[str, int] | None = None
+    stable_since: float | None = None
+    while True:
+        state = composer_state(sid, profile, window)
+        now = time.monotonic()
+        accepted = (
+            state is not None
+            and state[1] == EMPTY_CURSOR_COLUMN
+            and state[0] != composed[0]
+            and composer_is_empty(profile, state[0])
+        )
+        if accepted:
+            if state != stable_state:
+                stable_state = state
+                stable_since = now
+            elif (
+                stable_since is not None
+                and now - stable_since >= CHUNK_SETTLE_DELAY
+            ):
+                return True
+        else:
+            stable_state = None
+            stable_since = None
+        if now >= deadline:
+            return False
+        time.sleep(PROBE_INTERVAL)
+
+
 def normalize(profile: Profile, message: str) -> str:
     line = " ".join(message.split())
+    if any(unicodedata.category(char) == "Cc" for char in line):
+        raise ValueError("chat message contains a control character")
     prefix = profile.label.strip()
     while line.lower().startswith(prefix.lower()):
         line = line[len(prefix) :].lstrip(": ").strip()
@@ -324,104 +897,182 @@ def normalize(profile: Profile, message: str) -> str:
     return profile.label + line
 
 
-def composer_has_message(profile: Profile, content: str, typed: str) -> bool:
-    pasted = bool(PASTED_RE.fullmatch(content))
-    if profile.agent == "claude":
-        shown = " ".join(content.split())
-        sent = " ".join(typed.split())
-        label = profile.label.strip()
-        if not sent.startswith(label):
-            return False
-        if not (shown.startswith(label) or PASTED_TEXT_RE.match(shown)):
-            return False
-
-        body = sent[len(label) :].lstrip()
-        if not body:
-            return False
-        if shown.startswith(label):
-            return body[:MESSAGE_FRAGMENT] in shown
-
-        fragment_len = min(MESSAGE_FRAGMENT, len(body))
-        return any(
-            body[start : start + fragment_len] in shown
-            for start in range(len(body) - fragment_len + 1)
+def raise_after_composer_dirty(
+    sid: str,
+    profile: Profile,
+    initial: tuple[str, int],
+    dirty: ComposerDirty,
+    window: str | None = None,
+) -> None:
+    """Attempt guarded cleanup, then raise with the resulting composer state."""
+    try:
+        cleared = clear_composer(
+            sid, profile, initial, dirty.owned_text, window
         )
-    required = min(len(typed), MIN_WRAPPED_PROBE)
-    literal = typed.startswith(content) and len(content) >= required
-    return literal or pasted
+    except KeyboardInterrupt as cleanup_err:
+        raise KeyboardInterrupt(
+            f"{dirty}; composer cleanup interrupted"
+        ) from cleanup_err
+    except (OSError, subprocess.SubprocessError, ValueError, RuntimeError):
+        cleared = False
+    detail = "composer cleared" if cleared else "composer cleanup failed"
+    if dirty.interrupted:
+        raise KeyboardInterrupt(f"{dirty}; {detail}") from dirty
+    raise ComposerDirty(f"{dirty}; {detail}", dirty.owned_text) from dirty
 
 
-def wait_for_composed(sid: str, profile: Profile, typed: str) -> str | None:
-    deadline = time.monotonic() + PROBE_TIMEOUT
-    while True:
-        content = prompt_text(profile, pane_text(sid, profile))
-        if content and composer_has_message(profile, content, typed):
-            return content
-        if time.monotonic() >= deadline:
-            return None
-        time.sleep(0.1)
-
-
-def wait_for_accepted(sid: str, profile: Profile, held: str) -> bool:
-    deadline = time.monotonic() + PROBE_TIMEOUT
-    while True:
-        content = prompt_text(profile, pane_text(sid, profile))
-        if content is None or content != held:
-            return True
-        if time.monotonic() >= deadline:
-            return False
-        time.sleep(0.1)
-
-
-def send(sid: str, profile: Profile, message: str) -> int:
-    typed = normalize(profile, message)
-    pane = pane_text(sid, profile)
-    if live_prompt_text(profile, pane) is None:
-        raise PromptBlocked(
-            "target composer prompt is not recognisable (shell mode, disabled input, a "
-            "trailing modal or status row, or an unknown prompt glyph); nothing was typed"
-        )
-    if cursor_column(sid, profile) != EMPTY_CURSOR_COLUMN:
-        raise PromptBlocked("target composer is not confirmably empty; nothing was typed")
-
-    if profile.agent == "claude":
-        # Type the routing label on its own so it stays visible when Claude compacts the
-        # body into a paste marker.
-        type_text(sid, profile, profile.label)
-        type_text(sid, profile, typed[len(profile.label) :])
-    else:
-        type_text(sid, profile, typed)
-    held = wait_for_composed(sid, profile, typed)
-    if held is None:
-        raise RuntimeError(
-            "message was typed but not verified in the target composer; submit withheld"
-        )
-
-    time.sleep(SUBMIT_DELAY)
-    type_text(sid, profile, profile.submit)
-    if not wait_for_accepted(sid, profile, held):
-        raise RuntimeError("target did not accept the message; it may remain composed")
-    return len(message)
-
-
-def send_with_retry(sid: str, profile: Profile, message: str) -> int:
-    """Retry only a pre-write occupied-composer refusal."""
-    for attempt in range(1, RETRY_ATTEMPTS + 1):
+def send(
+    sid: str,
+    profile: Profile,
+    message: str,
+    window: str | None = None,
+    prepared: str | None = None,
+    delivery: DeliveryProgress | None = None,
+) -> int:
+    if prepared is None:
         try:
-            return send(sid, profile, message)
-        except PromptBlocked as err:
-            if attempt == RETRY_ATTEMPTS:
-                raise PromptBlocked(
-                    f"{err} after {RETRY_ATTEMPTS} attempts"
-                ) from err
-            print(
-                f"peer-chat: attempt {attempt}/{RETRY_ATTEMPTS} blocked; "
-                f"retrying in {RETRY_DELAY:g}s: {err}",
-                file=sys.stderr,
-                flush=True,
+            typed = normalize(profile, message)
+        except KeyboardInterrupt as err:
+            raise KeyboardInterrupt(
+                "interrupted during message normalisation; nothing was typed"
+            ) from err
+    else:
+        typed = prepared
+    try:
+        pane = pane_text(sid, profile, window)
+        empty_text = live_prompt_text(profile, pane)
+        if empty_text is None:
+            raise PromptBlocked(
+                "target composer prompt is not recognisable (shell mode, disabled "
+                "input, a trailing modal or status row, or an unknown prompt glyph); "
+                "nothing was typed"
             )
-            time.sleep(RETRY_DELAY)
-    raise AssertionError("unreachable")
+        if not composer_is_empty(profile, empty_text):
+            raise PromptBlocked(
+                "target composer contains text; nothing was typed"
+            )
+        if cursor_column(sid, profile, window) != EMPTY_CURSOR_COLUMN:
+            raise PromptBlocked(
+                "target composer is not confirmably empty; nothing was typed"
+            )
+    except PromptBlocked:
+        raise
+    except KeyboardInterrupt as err:
+        raise KeyboardInterrupt(
+            "interrupted during pre-write checks; nothing was typed"
+        ) from err
+    except (OSError, subprocess.SubprocessError, ValueError, RuntimeError) as err:
+        raise RuntimeError(
+            f"pre-write check failed; nothing was typed: {err}"
+        ) from err
+
+    initial = (empty_text, EMPTY_CURSOR_COLUMN)
+    if delivery is not None:
+        delivery.phase = "started"
+    phase = "body"
+    progress = BodyProgress()
+    try:
+        try:
+            composed = type_body(
+                sid, profile, typed, initial, window, progress
+            )
+            before_submit = composer_state(sid, profile, window)
+            if before_submit != composed:
+                raise ComposerDirty(
+                    "target composer changed before submit; submit withheld",
+                    typed,
+                )
+            # Enter the ambiguous phase before Return, so an interrupt at either call
+            # boundary cannot be mistaken for a safe pre-submit failure.
+            phase = "submit"
+            type_text(sid, profile, profile.submit, window)
+            phase = "accept"
+            accepted = wait_for_accepted(sid, profile, composed, window)
+            if not accepted:
+                raise DeliveryAmbiguous(
+                    "target did not confirm submission; delivery is ambiguous; "
+                    "do not resend"
+                )
+            return len(message)
+        except ComposerDirty as err:
+            raise_after_composer_dirty(sid, profile, initial, err, window)
+        except DeliveryAmbiguous:
+            raise
+        except (OSError, subprocess.SubprocessError, ValueError, RuntimeError) as err:
+            if phase == "body":
+                dirty = ComposerDirty(
+                    f"final composer check failed: {err}; submit withheld",
+                    progress.owned_text,
+                )
+                raise_after_composer_dirty(
+                    sid, profile, initial, dirty, window
+                )
+            if phase == "submit":
+                detail = "submit request failed"
+            else:
+                detail = "submission confirmation failed"
+            raise RuntimeError(
+                f"{detail}; delivery is ambiguous; do not resend: {err}"
+            ) from err
+    except KeyboardInterrupt as err:
+        if phase == "body":
+            if "; composer " in str(err):
+                raise
+            dirty = ComposerDirty(
+                "interrupted after the message body transaction started; "
+                "submit withheld",
+                progress.owned_text,
+                interrupted=True,
+            )
+            raise_after_composer_dirty(sid, profile, initial, dirty, window)
+        if phase == "submit":
+            detail = "submit request was interrupted"
+        else:
+            detail = "submission confirmation was interrupted"
+        raise KeyboardInterrupt(
+            f"{detail}; delivery is ambiguous; do not resend"
+        ) from err
+
+
+def send_with_retry(
+    sid: str,
+    profile: Profile,
+    message: str,
+    window: str | None = None,
+    progress: DeliveryProgress | None = None,
+) -> int:
+    """Retry only a pre-write occupied-composer refusal."""
+    delivery = progress if progress is not None else DeliveryProgress()
+    try:
+        prepared = normalize(profile, message)
+    except KeyboardInterrupt as err:
+        raise KeyboardInterrupt(
+            "interrupted during message normalisation; nothing was typed"
+        ) from err
+    try:
+        for attempt in range(1, RETRY_ATTEMPTS + 1):
+            try:
+                return send(sid, profile, message, window, prepared, delivery)
+            except PromptBlocked as err:
+                if attempt == RETRY_ATTEMPTS:
+                    raise PromptBlocked(
+                        f"{err} after {RETRY_ATTEMPTS} attempts"
+                    ) from err
+                print(
+                    f"peer-chat: attempt {attempt}/{RETRY_ATTEMPTS} blocked; "
+                    f"retrying in {RETRY_DELAY:g}s: {err}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                time.sleep(RETRY_DELAY)
+        raise AssertionError("unreachable")
+    except KeyboardInterrupt as wait_err:
+        if delivery.phase == "not_started":
+            raise KeyboardInterrupt(
+                "interrupted while handling a pre-write refusal; "
+                "nothing was typed"
+            ) from wait_err
+        raise
 
 
 def message_name(value: str) -> str:
@@ -430,6 +1081,13 @@ def message_name(value: str) -> str:
             "message name must match peer-chat-<sender>-<suffix>.txt"
         )
     return value
+
+
+def selector_argument(value: str) -> str:
+    selector = value.strip()
+    if not selector:
+        raise argparse.ArgumentTypeError("selector must not be empty")
+    return selector
 
 
 def private_spool_fd(create: bool) -> int:
@@ -472,7 +1130,17 @@ def prepare_message(name: str) -> Path:
 
 def read_message(use_stdin: bool, message_file: str | None) -> str:
     if use_stdin:
-        return sys.stdin.read()
+        binary = getattr(sys.stdin, "buffer", None)
+        if binary is not None:
+            body = binary.read(MAX_MESSAGE_BYTES + 1)
+            if len(body) > MAX_MESSAGE_BYTES:
+                raise ValueError(f"stdin message exceeds {MAX_MESSAGE_BYTES} bytes")
+            return body.decode("utf-8")
+
+        message = sys.stdin.read(MAX_MESSAGE_BYTES + 1)
+        if len(message.encode("utf-8")) > MAX_MESSAGE_BYTES:
+            raise ValueError(f"stdin message exceeds {MAX_MESSAGE_BYTES} bytes")
+        return message
     if message_file is None:
         raise ValueError("provide --stdin or --message-file NAME")
 
@@ -526,12 +1194,22 @@ def read_message(use_stdin: bool, message_file: str | None) -> str:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--to", choices=PROFILES)
-    parser.add_argument("--session")
+    parser.add_argument("--session", type=selector_argument)
+    parser.add_argument(
+        "--window",
+        type=selector_argument,
+        help="agterm window id or prefix (defaults to AGTERM_WINDOW_ID)",
+    )
     parser.add_argument(
         "--target-command",
         type=command_name,
         metavar="NAME",
         help="target agent executable or wrapper name",
+    )
+    parser.add_argument(
+        "--queue",
+        action="store_true",
+        help="queue a Codex message with Tab instead of steering with Return",
     )
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--stdin", action="store_true")
@@ -549,30 +1227,61 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     args = parser.parse_args(argv)
     if args.prepare_message:
-        if args.to or args.session or args.target_command:
+        if args.to or args.session or args.window or args.target_command or args.queue:
             parser.error("--prepare-message does not accept target options")
     elif not args.to:
         parser.error("--to is required when sending")
+    elif args.queue and args.to != "codex":
+        parser.error("--queue is available only with --to codex")
     return args
 
 
-def main() -> int:
+def report_success(sent: int) -> None:
+    """Emit the machine-readable receipt after delivery was confirmed."""
+    print(json.dumps({"sent": sent}), flush=True)
+
+
+def run_main(progress: DeliveryProgress) -> int:
+    """Run one CLI operation inside main's outer signal boundary."""
     args = parse_args()
-    try:
-        if args.prepare_message:
-            path = prepare_message(args.prepare_message)
-            print(json.dumps({"messageFile": str(path)}))
-            return 0
-        profile = target_profile(args.to, args.target_command)
-        sid = resolve_session(args.session, profile)
-        message = read_message(args.stdin, args.message_file)
-        sent = send_with_retry(sid, profile, message)
-        print(json.dumps({"sent": sent}))
+    if args.prepare_message:
+        path = prepare_message(args.prepare_message)
+        print(json.dumps({"messageFile": str(path)}))
         return 0
-    except KeyboardInterrupt:
-        print("peer-chat: interrupted", file=sys.stderr)
+    profile = target_profile(args.to, args.target_command, args.queue)
+    window, sid = resolve_target(args.session, args.window, profile)
+    message = read_message(args.stdin, args.message_file)
+    sent = send_with_retry(sid, profile, message, window, progress)
+    progress.phase = "confirmed"
+    report_success(sent)
+    return 0
+
+
+def main() -> int:
+    progress = DeliveryProgress()
+    try:
+        return run_main(progress)
+    except KeyboardInterrupt as err:
+        detail_text = str(err)
+        if not detail_text and progress.phase == "confirmed":
+            detail_text = (
+                "delivery was confirmed; do not resend; success report interrupted"
+            )
+        elif not detail_text and progress.phase == "started":
+            detail_text = "delivery status is unavailable; do not resend"
+        elif not detail_text and progress.phase == "not_started":
+            detail_text = "nothing was typed"
+        detail = f": {detail_text}" if detail_text else ""
+        print(f"peer-chat: interrupted{detail}", file=sys.stderr)
         return 130
     except (OSError, subprocess.SubprocessError, ValueError, RuntimeError) as err:
+        if progress.phase == "confirmed":
+            print(
+                "peer-chat: delivery was confirmed; do not resend; "
+                f"success report failed: {err}",
+                file=sys.stderr,
+            )
+            return 1
         print(f"peer-chat: {err}", file=sys.stderr)
         return 1
 

--- a/cookbook/two-agent-chat/test_peer_chat.py
+++ b/cookbook/two-agent-chat/test_peer_chat.py
@@ -1,104 +1,70 @@
 #!/usr/bin/env python3
-"""Regression checks for the two-agent chat composer parser."""
+"""Regression checks for the two-agent chat transport."""
 
 import argparse
+import inspect
 import io
+import json
 import os
 import runpy
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, call, patch
 
 SCRIPT = runpy.run_path(Path(__file__).with_name("peer-chat.py"))
-CLAUDE_PROMPT_TEXT = SCRIPT["claude_prompt_text"]
-CODEX_PROMPT_TEXT = SCRIPT["codex_prompt_text"]
-COMPOSER_HAS_MESSAGE = SCRIPT["composer_has_message"]
+CHUNK_SETTLE_DELAY = SCRIPT["CHUNK_SETTLE_DELAY"]
+CHUNK_VERIFY_OVERLAP = SCRIPT["CHUNK_VERIFY_OVERLAP"]
+CLEAR_COMPOSER = SCRIPT["clear_composer"]
+COMPOSER_DIRTY = SCRIPT["ComposerDirty"]
+COMPOSER_HAS_EXPECTED_TAIL = SCRIPT["composer_has_expected_tail"]
+COMPOSER_IS_EMPTY = SCRIPT["composer_is_empty"]
+COMPOSER_PROBE_MARKER = SCRIPT["composer_probe_marker"]
+COMPOSER_STATE = SCRIPT["composer_state"]
+CURSOR_COLUMN = SCRIPT["cursor_column"]
+DELIVERY_PROGRESS = SCRIPT["DeliveryProgress"]
 LIVE_PROMPT_TEXT = SCRIPT["live_prompt_text"]
 MAIN = SCRIPT["main"]
 MAX_MESSAGE_BYTES = SCRIPT["MAX_MESSAGE_BYTES"]
 MESSAGE_NAME = SCRIPT["message_name"]
-PASTED_RE = SCRIPT["PASTED_RE"]
 PROFILES = SCRIPT["PROFILES"]
 PROMPT_BLOCKED = SCRIPT["PromptBlocked"]
 SEND = SCRIPT["send"]
+SEND_WITH_RETRY = SCRIPT["send_with_retry"]
+COMPOSER_SETTLE_DELAY = SCRIPT["COMPOSER_SETTLE_DELAY"]
+TEXT_CHUNKS = SCRIPT["text_chunks"]
+TYPE_BODY = SCRIPT["type_body"]
+TYPE_CHUNK_BYTES = SCRIPT["TYPE_CHUNK_BYTES"]
+WAIT_FOR_ACCEPTED = SCRIPT["wait_for_accepted"]
+WAIT_FOR_COMPOSER_CHANGE = SCRIPT["wait_for_composer_change"]
 CLAUDE_PROFILE = PROFILES["claude"]
 PARSE_ARGS = SCRIPT["parse_args"]
 PREPARE_MESSAGE = SCRIPT["prepare_message"]
 READ_MESSAGE = SCRIPT["read_message"]
+RESOLVE_WINDOW = SCRIPT["resolve_window"]
+RESOLVE_TARGET = SCRIPT["resolve_target"]
+RUN_MAIN = SCRIPT["run_main"]
+TARGET_PROFILE = SCRIPT["target_profile"]
+PANE_TEXT = SCRIPT["pane_text"]
+TREE = SCRIPT["tree"]
+TYPE_TEXT = SCRIPT["type_text"]
 RULE = "─" * 40
 CODEX_FOOTER = "  repo · master · gpt-5.6 high · Context 0% used"
 
 
-class ClaudePromptTextTests(unittest.TestCase):
-    def test_plain_rule(self) -> None:
-        screen = f"{RULE}\n❯ Chat from Codex: ping\n{RULE}"
+def stepping_time(step: float = 0.11) -> Mock:
+    current = [-step]
 
-        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
+    def monotonic() -> float:
+        current[0] += step
+        return current[0]
 
-    def test_rule_with_context_label(self) -> None:
-        screen = f"{RULE} e2e ─\n❯ Chat from Codex: ping\n{RULE}"
+    return Mock(monotonic=Mock(side_effect=monotonic), sleep=Mock())
 
-        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
 
-    def test_wrapped_box_needs_no_rule_above(self) -> None:
-        screen = (
-            "older output\n"
-            "❯ Chat from Codex: a wrapped message\n"
-            "  with a continuation\n"
-            f"{RULE}"
-        )
-
-        self.assertEqual(
-            CLAUDE_PROMPT_TEXT(screen),
-            "Chat from Codex: a wrapped message with a continuation",
-        )
-
-    def test_latest_prompt_wins_over_an_older_ruled_prompt(self) -> None:
-        screen = (
-            f"{RULE}\n"
-            "❯ Chat from Codex: old\n"
-            f"{RULE}\n"
-            "older response\n"
-            "❯ Chat from Codex: current\n"
-            "  continuation\n"
-            f"{RULE}"
-        )
-
-        self.assertEqual(
-            CLAUDE_PROMPT_TEXT(screen),
-            "Chat from Codex: current continuation",
-        )
-
-    def test_labelled_rule_terminates_a_wrapped_box(self) -> None:
-        screen = (
-            "older output\n"
-            "❯ Chat from Codex: wrapped\n"
-            "  tail\n"
-            f"{RULE} e2e ─\n"
-            "  UMBP: agterm [master]"
-        )
-
-        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: wrapped tail")
-
-    def test_rule_after_prompt_is_not_required(self) -> None:
-        screen = f"{RULE} e2e ─\n❯ Chat from Codex: ping"
-
-        self.assertEqual(CLAUDE_PROMPT_TEXT(screen), "Chat from Codex: ping")
-
-    def test_wrapped_box_needs_no_closing_rule(self) -> None:
-        screen = (
-            "older output\n"
-            "❯ Chat from Codex: a wrapped message\n"
-            "  with a continuation"
-        )
-
-        self.assertEqual(
-            CLAUDE_PROMPT_TEXT(screen),
-            "Chat from Codex: a wrapped message with a continuation",
-        )
-
+class ClaudeLivePromptTextTests(unittest.TestCase):
     def test_live_wrapped_box_without_closing_rule_is_refused(self) -> None:
         screen = (
             "older output\n"
@@ -113,27 +79,120 @@ class ClaudePromptTextTests(unittest.TestCase):
 
         self.assertIsNone(LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen))
 
+    def test_closed_historical_prompt_above_a_dialog_is_refused(self) -> None:
+        screen = (
+            f"{RULE}\n"
+            "❯ previous user prompt\n"
+            "assistant response\n"
+            f"{RULE}\n"
+            "Allow this command?\n"
+            "  1. Yes\n"
+            "  2. No"
+        )
 
-class CodexPromptTextTests(unittest.TestCase):
+        self.assertIsNone(LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen))
+
+    def test_live_composer_accepts_indented_status_rows(self) -> None:
+        screen = (
+            f"{RULE}\n"
+            "❯ Chat from Codex: review this\n"
+            f"{RULE}\n"
+            "  repo [branch] [Opus 5] 70% /rc\n"
+            "  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+        )
+
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen),
+            "Chat from Codex: review this",
+        )
+
+    def test_queue_hints_are_known_empty_claude_placeholders(self) -> None:
+        hints = [
+            "Press up to edit queued messages",
+            "Press up to edit queued messages, Enter to send them immediately",
+        ]
+
+        for hint in hints:
+            with self.subTest(hint=hint):
+                screen = f"{RULE}\n❯ {hint}\n{RULE}"
+                content = LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen)
+                self.assertEqual(content, hint)
+                self.assertTrue(COMPOSER_IS_EMPTY(CLAUDE_PROFILE, content))
+
+    def test_wrapped_queue_hint_is_a_known_empty_claude_placeholder(self) -> None:
+        screen = (
+            f"{RULE}\n"
+            "❯ Press up to edit queued messages, Enter to\n"
+            "  send them immediately\n"
+            f"{RULE}"
+        )
+
+        content = LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen)
+
+        self.assertEqual(
+            content,
+            "Press up to edit queued messages, Enter to\nsend them immediately",
+        )
+        self.assertTrue(COMPOSER_IS_EMPTY(CLAUDE_PROFILE, content))
+
+
+class CodexLivePromptTextTests(unittest.TestCase):
+    def test_numbered_approval_selection_is_not_a_composer(self) -> None:
+        screen = (
+            "Would you like to run the following command?\n\n"
+            "› 1. Yes, proceed (y)\n"
+            "  2. Yes, and don't ask again\n"
+            "  3. No, and tell Codex what to do differently\n"
+        )
+
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
+
     def test_default_glyph(self) -> None:
         screen = f"› Chat from Claude: ping\n{CODEX_FOOTER}"
 
-        self.assertEqual(CODEX_PROMPT_TEXT(screen), "Chat from Claude: ping")
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(PROFILES["codex"], screen), "Chat from Claude: ping"
+        )
+
+    def test_wrapped_composer_ignores_the_changing_footer(self) -> None:
+        screen = (
+            "» Chat from Claude: a long reply whose first row wraps\n"
+            "  onto a second row and remains in the composer\n"
+            f"{CODEX_FOOTER}"
+        )
+
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(PROFILES["codex"], screen),
+            "Chat from Claude: a long reply whose first row wraps\nonto a second "
+            "row and remains in the composer",
+        )
 
     def test_ultra_effort_glyph(self) -> None:
         screen = f"» [Pasted Content 1868 chars]\n{CODEX_FOOTER}"
 
-        self.assertEqual(CODEX_PROMPT_TEXT(screen), "[Pasted Content 1868 chars]")
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(PROFILES["codex"], screen),
+            "[Pasted Content 1868 chars]",
+        )
 
     def test_empty_composer_placeholder(self) -> None:
         screen = f"» Ask Codex to do anything\n{CODEX_FOOTER}"
 
-        self.assertEqual(CODEX_PROMPT_TEXT(screen), "Ask Codex to do anything")
+        self.assertEqual(
+            LIVE_PROMPT_TEXT(PROFILES["codex"], screen), "Ask Codex to do anything"
+        )
+
+    def test_wrapped_empty_composer_placeholder_is_known_empty(self) -> None:
+        screen = f"» Ask Codex to do\n  anything\n{CODEX_FOOTER}"
+        content = LIVE_PROMPT_TEXT(PROFILES["codex"], screen)
+
+        self.assertEqual(content, "Ask Codex to do\nanything")
+        self.assertTrue(COMPOSER_IS_EMPTY(PROFILES["codex"], content))
 
     def test_shell_mode_is_not_a_prompt(self) -> None:
         screen = f"! ls -la\n{CODEX_FOOTER}"
 
-        self.assertIsNone(CODEX_PROMPT_TEXT(screen))
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
 
     def test_live_shell_blocks_an_older_composer(self) -> None:
         screen = (
@@ -143,12 +202,11 @@ class CodexPromptTextTests(unittest.TestCase):
             "  shell mode active"
         )
 
-        self.assertIsNone(CODEX_PROMPT_TEXT(screen))
+        self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
 
     def test_prompt_shaped_shell_output_is_not_a_composer(self) -> None:
         screen = f"! printf output\n  › fake output\n{CODEX_FOOTER}"
 
-        self.assertIsNone(CODEX_PROMPT_TEXT(screen))
         self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
 
     def test_live_prompt_is_adjacent_to_the_footer(self) -> None:
@@ -220,87 +278,15 @@ class CodexPromptTextTests(unittest.TestCase):
         self.assertIsNone(LIVE_PROMPT_TEXT(PROFILES["codex"], screen))
 
 
-class ComposerHasMessageTests(unittest.TestCase):
-    def test_label_leading_summary_keeps_opening_body_fragment(self) -> None:
-        typed = "Chat from Codex: opening transport fragment and more text"
-        shown = "Chat from Codex: opening transport fragment [Pasted text #16]"
-
-        self.assertTrue(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
-
-    def test_label_leading_row_without_opening_body_fragment_is_refused(self) -> None:
-        typed = "Chat from Codex: opening transport fragment and more text"
-        shown = "Chat from Codex: unrelated composer content"
-
-        self.assertFalse(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
-
-    def test_label_leading_bare_paste_marker_is_refused(self) -> None:
-        typed = "Chat from Codex: opening transport fragment and more text"
-        shown = "Chat from Codex: [Pasted text #16]"
-
-        self.assertFalse(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
-
-    def test_summary_leading_row_keeps_later_body_fragment(self) -> None:
-        typed = (
-            "Chat from Codex: opening transport fragment followed by a later "
-            "acceptance fragment in the body"
-        )
-        shown = "[Pasted text #7 +12 lines] later acceptance fragment"
-
-        self.assertTrue(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
-
-    def test_singular_line_count_summary_is_accepted(self) -> None:
-        typed = "Chat from Codex: opening transport fragment and later acceptance text"
-        shown = "[Pasted text #7 +1 line] later acceptance text"
-
-        self.assertTrue(COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed))
-
-    def test_summary_only_row_is_refused(self) -> None:
-        typed = "Chat from Codex: opening transport fragment and more text"
-
-        for shown in ("[Pasted text #7]", "[Pasted text #7 +12 lines]"):
-            with self.subTest(shown=shown):
-                self.assertFalse(
-                    COMPOSER_HAS_MESSAGE(CLAUDE_PROFILE, shown, typed)
-                )
-
-    def test_codex_accepts_paste_marker(self) -> None:
-        typed = "Chat from Claude: " + "x" * 2000
-
-        self.assertTrue(
-            COMPOSER_HAS_MESSAGE(
-                PROFILES["codex"], "[Pasted Content 2018 chars]", typed
-            )
-        )
-
-    def test_codex_requires_literal_prefix(self) -> None:
-        typed = "Chat from Claude: ping pong " + "x" * 40
-
-        self.assertTrue(COMPOSER_HAS_MESSAGE(PROFILES["codex"], typed[:45], typed))
-        self.assertFalse(COMPOSER_HAS_MESSAGE(PROFILES["codex"], "Chat from", typed))
-        self.assertFalse(
-            COMPOSER_HAS_MESSAGE(PROFILES["codex"], "something else", typed)
-        )
-
-
-class PastedMarkerTests(unittest.TestCase):
-    def test_codex_marker(self) -> None:
-        self.assertTrue(PASTED_RE.fullmatch("[Pasted Content 1 char]"))
-        self.assertTrue(PASTED_RE.fullmatch("[Pasted Content 1868 chars]"))
-
-    def test_claude_marker_is_checked_separately(self) -> None:
-        self.assertIsNone(PASTED_RE.fullmatch("[Pasted text #1 +12 lines]"))
-
-    def test_other_brackets_are_not_markers(self) -> None:
-        self.assertIsNone(PASTED_RE.fullmatch("[Image #1]"))
-
-
 class SendPreflightTests(unittest.TestCase):
     def test_prompt_is_checked_before_cursor(self) -> None:
         pane_text = Mock(return_value=f"! ls -la\n{CODEX_FOOTER}")
         cursor_column = Mock(return_value=2)
+        type_text = Mock()
         replacements = {
             "pane_text": pane_text,
             "cursor_column": cursor_column,
+            "type_text": type_text,
         }
 
         with patch.dict(SEND.__globals__, replacements), self.assertRaises(
@@ -310,6 +296,2097 @@ class SendPreflightTests(unittest.TestCase):
 
         pane_text.assert_called_once()
         cursor_column.assert_not_called()
+        type_text.assert_not_called()
+
+    def test_cursor_refusal_writes_nothing(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "pane_text": Mock(
+                return_value=f"» Ask Codex to do anything\n{CODEX_FOOTER}"
+            ),
+            "cursor_column": Mock(return_value=3),
+            "type_text": type_text,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaises(
+            PROMPT_BLOCKED
+        ):
+            SEND("session-id", PROFILES["codex"], "ping")
+
+        type_text.assert_not_called()
+
+    def test_full_width_codex_draft_at_column_two_is_refused(self) -> None:
+        type_body = Mock()
+        draft = "x" * 83
+        replacements = {
+            "pane_text": Mock(return_value=f"» {draft}\n{CODEX_FOOTER}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": type_body,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            PROMPT_BLOCKED, "composer contains text; nothing was typed"
+        ):
+            SEND("session-id", PROFILES["codex"], "ping")
+
+        type_body.assert_not_called()
+
+    def test_claude_draft_at_column_two_is_refused(self) -> None:
+        type_body = Mock()
+        replacements = {
+            "pane_text": Mock(
+                return_value=f"{RULE}\n❯ existing draft\n{RULE}"
+            ),
+            "cursor_column": Mock(return_value=2),
+            "type_body": type_body,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            PROMPT_BLOCKED, "composer contains text; nothing was typed"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "ping")
+
+        type_body.assert_not_called()
+
+    def test_preflight_transport_failure_says_nothing_was_typed(self) -> None:
+        type_body = Mock()
+        replacements = {
+            "pane_text": Mock(side_effect=ValueError("malformed JSON")),
+            "type_body": type_body,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            RuntimeError, "pre-write check failed; nothing was typed: malformed JSON"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        type_body.assert_not_called()
+
+    def test_long_message_then_return_are_separate_writes(self) -> None:
+        pane_text = Mock(return_value=f"{RULE}\n❯ \n{RULE}")
+        message = "opening " + "body " * 4_000 + "closing"
+        expected = "Chat from Codex: " + " ".join(message.split())
+        type_body = Mock(return_value=(expected, 12))
+        type_text = Mock()
+        calls = Mock()
+        calls.attach_mock(type_body, "type_body")
+        calls.attach_mock(type_text, "type_text")
+        replacements = {
+            "pane_text": pane_text,
+            "cursor_column": Mock(return_value=2),
+            "type_body": type_body,
+            "composer_state": Mock(return_value=(expected, 12)),
+            "type_text": type_text,
+            "wait_for_accepted": Mock(return_value=True),
+        }
+
+        with patch.dict(SEND.__globals__, replacements):
+            self.assertEqual(SEND("session-id", CLAUDE_PROFILE, message), len(message))
+
+        self.assertEqual(
+            calls.mock_calls,
+            [
+                call.type_body(
+                    "session-id", CLAUDE_PROFILE, expected, ("", 2), None, ANY
+                ),
+                call.type_text("session-id", CLAUDE_PROFILE, "\n", None),
+            ],
+        )
+
+    def test_codex_default_and_queued_submit_keys(self) -> None:
+        pane_text = Mock(return_value=f"» Ask Codex to do anything\n{CODEX_FOOTER}")
+        type_body = Mock(
+            side_effect=[
+                ("Chat from Claude: steer", 25),
+                ("Chat from Claude: queued", 26),
+            ]
+        )
+        type_text = Mock()
+        replacements = {
+            "pane_text": pane_text,
+            "cursor_column": Mock(return_value=2),
+            "type_body": type_body,
+            "composer_state": Mock(
+                side_effect=[
+                    ("Chat from Claude: steer", 25),
+                    ("Chat from Claude: queued", 26),
+                ]
+            ),
+            "type_text": type_text,
+            "wait_for_accepted": Mock(return_value=True),
+        }
+
+        with patch.dict(SEND.__globals__, replacements):
+            SEND("session-id", TARGET_PROFILE("codex", None), "steer")
+            SEND("session-id", TARGET_PROFILE("codex", None, queue=True), "queued")
+
+        self.assertEqual(type_body.call_args_list[0].args[2], "Chat from Claude: steer")
+        self.assertEqual(type_text.call_args_list[0].args[2], "\n")
+        self.assertEqual(type_body.call_args_list[1].args[2], "Chat from Claude: queued")
+        self.assertEqual(type_text.call_args_list[1].args[2], "\t")
+
+    def test_interrupt_during_submit_reports_ambiguous_delivery(self) -> None:
+        type_text = Mock(side_effect=KeyboardInterrupt())
+        wait_for_accepted = Mock()
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(return_value=("Chat from Codex: body", 23)),
+            "composer_state": Mock(return_value=("Chat from Codex: body", 23)),
+            "type_text": type_text,
+            "wait_for_accepted": wait_for_accepted,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt, "submit request.*delivery is ambiguous.*do not resend"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        wait_for_accepted.assert_not_called()
+
+    def test_submit_value_error_reports_ambiguous_delivery(self) -> None:
+        wait_for_accepted = Mock()
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(return_value=("Chat from Codex: body", 23)),
+            "composer_state": Mock(return_value=("Chat from Codex: body", 23)),
+            "type_text": Mock(side_effect=ValueError("malformed JSON")),
+            "wait_for_accepted": wait_for_accepted,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            RuntimeError,
+            "submit request failed.*delivery is ambiguous.*do not resend.*malformed JSON",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        wait_for_accepted.assert_not_called()
+
+    def test_interrupt_during_acceptance_reports_ambiguous_delivery(self) -> None:
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(return_value=("Chat from Codex: body", 23)),
+            "composer_state": Mock(return_value=("Chat from Codex: body", 23)),
+            "type_text": Mock(),
+            "wait_for_accepted": Mock(side_effect=KeyboardInterrupt()),
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt,
+            "submission confirmation.*delivery is ambiguous.*do not resend",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+    def test_acceptance_probe_failure_reports_ambiguous_delivery(self) -> None:
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(return_value=("Chat from Codex: body", 23)),
+            "composer_state": Mock(return_value=("Chat from Codex: body", 23)),
+            "type_text": Mock(),
+            "wait_for_accepted": Mock(side_effect=ValueError("malformed JSON")),
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            RuntimeError,
+            "submission confirmation failed.*delivery is ambiguous.*do not resend.*malformed JSON",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+    def test_unconfirmed_chunk_withholds_submit(self) -> None:
+        type_body = Mock(
+            side_effect=COMPOSER_DIRTY(
+                "chunk unconfirmed; submit withheld", "Chat from Codex: body"
+            )
+        )
+        type_text = Mock()
+        clear_composer = Mock(return_value=True)
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": type_body,
+            "type_text": type_text,
+            "clear_composer": clear_composer,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            COMPOSER_DIRTY, "submit withheld; composer cleared"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        type_body.assert_called_once_with(
+            "session-id",
+            CLAUDE_PROFILE,
+            "Chat from Codex: body",
+            ("", 2),
+            None,
+            ANY,
+        )
+        clear_composer.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, ("", 2), "Chat from Codex: body", None
+        )
+        type_text.assert_not_called()
+
+    def test_transport_failure_after_a_confirmed_chunk_cleans_composer(self) -> None:
+        message = "a" * (TYPE_CHUNK_BYTES * 2)
+        typed = "Chat from Codex: " + message
+        marker = COMPOSER_PROBE_MARKER(typed)
+        chunks = TEXT_CHUNKS(
+            typed, TYPE_CHUNK_BYTES - len(marker.encode("utf-8"))
+        )
+        first_chunk, second_chunk = chunks[:2]
+        marked_state = (first_chunk + marker, 24)
+        unmarked_state = (first_chunk, 24)
+        type_text = Mock(
+            side_effect=[None, None, ValueError("transport failed")]
+        )
+        clear_composer = Mock(return_value=True)
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_text": type_text,
+            "wait_for_composer_change": Mock(
+                side_effect=[marked_state, unmarked_state]
+            ),
+            "clear_composer": clear_composer,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            COMPOSER_DIRTY, "transport failed.*composer cleared"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, message)
+
+        self.assertEqual(type_text.call_count, 3)
+        clear_composer.assert_called_once_with(
+            "session-id",
+            CLAUDE_PROFILE,
+            ("", 2),
+            first_chunk + second_chunk + marker,
+            None,
+        )
+
+    def test_interrupt_after_a_confirmed_chunk_cleans_composer(self) -> None:
+        message = "a" * (TYPE_CHUNK_BYTES * 2)
+        typed = "Chat from Codex: " + message
+        marker = COMPOSER_PROBE_MARKER(typed)
+        chunks = TEXT_CHUNKS(
+            typed, TYPE_CHUNK_BYTES - len(marker.encode("utf-8"))
+        )
+        first_chunk, second_chunk = chunks[:2]
+        marked_state = (first_chunk + marker, 24)
+        unmarked_state = (first_chunk, 24)
+        type_text = Mock(side_effect=[None, None, KeyboardInterrupt()])
+        clear_composer = Mock(return_value=True)
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_text": type_text,
+            "wait_for_composer_change": Mock(
+                side_effect=[marked_state, unmarked_state]
+            ),
+            "clear_composer": clear_composer,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt, "submit withheld; composer cleared"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, message)
+
+        self.assertEqual(type_text.call_count, 3)
+        clear_composer.assert_called_once_with(
+            "session-id",
+            CLAUDE_PROFILE,
+            ("", 2),
+            first_chunk + second_chunk + marker,
+            None,
+        )
+
+    def test_interrupt_during_marked_tail_check_cleans_marker(self) -> None:
+        typed = "Chat from Codex: body"
+        marker = COMPOSER_PROBE_MARKER(typed)
+        marked = typed + marker
+        type_text = Mock()
+        clear_composer = Mock(return_value=True)
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_text": type_text,
+            "wait_for_composer_change": Mock(return_value=(marked, 24)),
+            "composer_has_expected_tail": Mock(side_effect=KeyboardInterrupt()),
+            "clear_composer": clear_composer,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt, "submit withheld; composer cleared"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        clear_composer.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, ("", 2), marked, None
+        )
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, marked, None
+        )
+
+    def test_interrupt_during_unmarked_tail_check_cleans_body(self) -> None:
+        typed = "Chat from Codex: body"
+        marker = COMPOSER_PROBE_MARKER(typed)
+        marked = typed + marker
+        type_text = Mock()
+        clear_composer = Mock(return_value=True)
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_text": type_text,
+            "wait_for_composer_change": Mock(
+                side_effect=[(marked, 24), (typed, 23)]
+            ),
+            "composer_has_expected_tail": Mock(
+                side_effect=[True, KeyboardInterrupt()]
+            ),
+            "clear_composer": clear_composer,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt, "submit withheld; composer cleared"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        clear_composer.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, ("", 2), marked, None
+        )
+        self.assertEqual(
+            type_text.call_args_list,
+            [
+                call("session-id", CLAUDE_PROFILE, marked, None),
+                call(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    "\x7f" * len(marker),
+                    None,
+                ),
+            ],
+        )
+
+    def test_raw_body_transaction_interrupt_uses_guarded_cleanup(self) -> None:
+        typed = "Chat from Codex: body"
+        marker = COMPOSER_PROBE_MARKER(typed)
+        partial = "Chat from Codex:" + marker
+        type_text = Mock()
+        clear_composer = Mock(return_value=True)
+
+        def interrupt_with_partial_progress(*args: object) -> None:
+            args[-1].owned_text = partial
+            raise KeyboardInterrupt()
+
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(side_effect=interrupt_with_partial_progress),
+            "type_text": type_text,
+            "clear_composer": clear_composer,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt,
+            "body transaction started; submit withheld; composer cleared",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        clear_composer.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, ("", 2), partial, None
+        )
+        type_text.assert_not_called()
+
+    def test_interrupt_during_cleanup_preserves_partial_body_warning(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(
+                side_effect=COMPOSER_DIRTY(
+                    "message chunk failed; submit withheld",
+                    "Chat from Codex: partial body",
+                )
+            ),
+            "type_text": type_text,
+            "clear_composer": Mock(side_effect=KeyboardInterrupt()),
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            KeyboardInterrupt,
+            "submit withheld; composer cleanup interrupted",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "partial body")
+
+        type_text.assert_not_called()
+
+    def test_cleanup_value_error_reports_failure_without_submitting(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(
+                side_effect=COMPOSER_DIRTY(
+                    "message chunk failed; submit withheld",
+                    "Chat from Codex: partial body",
+                )
+            ),
+            "type_text": type_text,
+            "clear_composer": Mock(side_effect=ValueError("malformed JSON")),
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            COMPOSER_DIRTY,
+            "submit withheld; composer cleanup failed",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "partial body")
+
+        type_text.assert_not_called()
+
+    def test_missing_middle_withholds_submit(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(
+                side_effect=COMPOSER_DIRTY(
+                    "message chunk 2/3 is incomplete; submit withheld",
+                    "Chat from Codex: opening missing",
+                )
+            ),
+            "type_text": type_text,
+            "clear_composer": Mock(return_value=True),
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            COMPOSER_DIRTY, "incomplete; submit withheld; composer cleared"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "opening missing middle closing")
+
+        type_text.assert_not_called()
+
+    def test_control_character_is_rejected_before_any_pane_write(self) -> None:
+        pane_text = Mock()
+        type_body = Mock()
+        type_text = Mock()
+        replacements = {
+            "pane_text": pane_text,
+            "type_body": type_body,
+            "type_text": type_text,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            ValueError, "control character"
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "safe prefix\0unsafe suffix")
+
+        pane_text.assert_not_called()
+        type_body.assert_not_called()
+        type_text.assert_not_called()
+
+    def test_unaccepted_submit_is_reported(self) -> None:
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(return_value=("Chat from Codex: body", 22)),
+            "composer_state": Mock(return_value=("Chat from Codex: body", 22)),
+            "type_text": Mock(),
+            "wait_for_accepted": Mock(return_value=False),
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            RuntimeError,
+            "did not confirm submission.*delivery is ambiguous.*do not resend",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+    def test_changed_composer_before_submit_withholds_return(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "pane_text": Mock(return_value=f"{RULE}\n❯ \n{RULE}"),
+            "cursor_column": Mock(return_value=2),
+            "type_body": Mock(return_value=("Chat from Codex: body", 23)),
+            "composer_state": Mock(return_value=None),
+            "clear_composer": Mock(return_value=False),
+            "type_text": type_text,
+        }
+
+        with patch.dict(SEND.__globals__, replacements), self.assertRaisesRegex(
+            COMPOSER_DIRTY,
+            "composer changed before submit; submit withheld; composer cleanup failed",
+        ):
+            SEND("session-id", CLAUDE_PROFILE, "body")
+
+        type_text.assert_not_called()
+
+
+class ComposerTransitionTests(unittest.TestCase):
+    def test_unchanged_composer_through_deadline_rejects_the_event(self) -> None:
+        composer_state = Mock(return_value=("same body", 18))
+        clock = Mock(
+            monotonic=Mock(side_effect=[0.0, 0.1, 3.1]),
+            sleep=Mock(),
+        )
+        replacements = {
+            "composer_state": composer_state,
+            "time": clock,
+        }
+
+        with patch.dict(WAIT_FOR_COMPOSER_CHANGE.__globals__, replacements):
+            self.assertIsNone(
+                WAIT_FOR_COMPOSER_CHANGE(
+                    "session-id",
+                    PROFILES["codex"],
+                    ("same body", 18),
+                    CHUNK_SETTLE_DELAY,
+                )
+            )
+
+        self.assertEqual(composer_state.call_count, 2)
+
+    def test_change_waits_for_the_composer_only_to_settle(self) -> None:
+        self.assertGreaterEqual(COMPOSER_SETTLE_DELAY, 0.5)
+        composer_state = Mock(
+            side_effect=[
+                ("part 1", 2),
+                ("part 2", 2),
+                ("part 2", 2),
+                ("part 2", 2),
+            ]
+        )
+        clock = Mock(
+            monotonic=Mock(side_effect=[0.0, 0.1, 0.4, 0.7, 0.9]),
+            sleep=Mock(),
+        )
+        replacements = {
+            "composer_state": composer_state,
+            "time": clock,
+        }
+
+        with patch.dict(WAIT_FOR_COMPOSER_CHANGE.__globals__, replacements):
+            self.assertEqual(
+                WAIT_FOR_COMPOSER_CHANGE(
+                    "session-id",
+                    PROFILES["codex"],
+                    ("part 1", 2),
+                    COMPOSER_SETTLE_DELAY,
+                ),
+                ("part 2", 2),
+            )
+
+        self.assertEqual(composer_state.call_count, 4)
+        self.assertEqual(clock.sleep.call_count, 3)
+
+    def test_accepted_requires_changed_state_and_empty_cursor(self) -> None:
+        replacements = {
+            "composer_state": Mock(
+                side_effect=[
+                    ("reflowed body", 2),
+                    ("Ask Codex to do anything", 2),
+                    ("Ask Codex to do anything", 2),
+                ]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(WAIT_FOR_ACCEPTED.__globals__, replacements):
+            self.assertTrue(
+                WAIT_FOR_ACCEPTED(
+                    "session-id", PROFILES["codex"], ("body", 18)
+                )
+            )
+
+        self.assertEqual(replacements["composer_state"].call_count, 3)
+
+    def test_reflowed_unsent_body_at_column_two_is_not_accepted(self) -> None:
+        replacements = {
+            "composer_state": Mock(return_value=("reflowed unsent body", 2)),
+            "time": Mock(
+                monotonic=Mock(side_effect=[0.0, 3.1]), sleep=Mock()
+            ),
+        }
+
+        with patch.dict(WAIT_FOR_ACCEPTED.__globals__, replacements):
+            self.assertFalse(
+                WAIT_FOR_ACCEPTED(
+                    "session-id",
+                    PROFILES["codex"],
+                    ("original unsent body", 27),
+                )
+            )
+
+    def test_cursor_reset_with_the_same_body_is_not_accepted(self) -> None:
+        replacements = {
+            "composer_state": Mock(return_value=("same body", 2)),
+            "time": Mock(monotonic=Mock(side_effect=[0.0, 3.1]), sleep=Mock()),
+        }
+
+        with patch.dict(WAIT_FOR_ACCEPTED.__globals__, replacements):
+            self.assertFalse(
+                WAIT_FOR_ACCEPTED(
+                    "session-id", PROFILES["codex"], ("same body", 18)
+                )
+            )
+
+    def test_queued_placeholder_counts_as_accepted(self) -> None:
+        replacements = {
+            "composer_state": Mock(
+                return_value=("Press up to edit queued messages", 2)
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(WAIT_FOR_ACCEPTED.__globals__, replacements):
+            self.assertTrue(
+                WAIT_FOR_ACCEPTED(
+                    "session-id", CLAUDE_PROFILE, ("Chat from Codex: body", 25)
+                )
+            )
+
+
+class ComposerCleanupTests(unittest.TestCase):
+    def test_clear_does_not_claim_an_unobserved_body_was_removed(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(return_value=("", 2)),
+            "time": Mock(
+                monotonic=Mock(side_effect=[0.0, 3.1]), sleep=Mock()
+            ),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertFalse(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), "queued body"
+                )
+            )
+
+        type_text.assert_not_called()
+
+    def test_clear_waits_for_body_after_the_initial_empty_state(self) -> None:
+        owned = "delayed body"
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[("", 2), (owned, 14), (owned, 14), ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * len(owned), None
+        )
+
+    def test_clear_backspaces_without_interrupting_the_active_turn(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[("partial body", 14), ("partial body", 14), ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), "partial body"
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * len("partial body"), None
+        )
+
+    def test_clear_does_not_repeat_unchanged_periodic_text(self) -> None:
+        repeated = ("a" * 80, 2)
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[repeated] * 10 + [("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), "a" * 400
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * 80, None
+        )
+
+    def test_clear_waits_for_a_lagging_backspace_batch(self) -> None:
+        owned = " ".join(f"word-{index:03d}" for index in range(36))
+        remaining = owned[:-TYPE_CHUNK_BYTES]
+        full = (owned, 28)
+        partial = (remaining, 17)
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[full] * 12 + [partial, partial, ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        self.assertEqual(
+            [len(item.args[2]) for item in type_text.call_args_list],
+            [TYPE_CHUNK_BYTES, len(remaining)],
+        )
+
+    def test_clear_does_not_repeat_a_stalled_backspace_batch(self) -> None:
+        owned = " ".join(f"word-{index:03d}" for index in range(36))
+        full = (owned, 28)
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(return_value=full),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertFalse(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * TYPE_CHUNK_BYTES, None
+        )
+
+    def test_clear_ignores_one_torn_unowned_sample(self) -> None:
+        owned = " ".join(f"word-{index:03d}" for index in range(36))
+        remaining = owned[:-TYPE_CHUNK_BYTES]
+        full = (owned, 28)
+        torn = (owned, 17)
+        partial = (remaining, 17)
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[full, full, torn, partial, partial, ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        self.assertEqual(
+            [len(item.args[2]) for item in type_text.call_args_list],
+            [TYPE_CHUNK_BYTES, len(remaining)],
+        )
+
+    def test_clear_ignores_one_unrecognised_sample(self) -> None:
+        owned = " ".join(f"word-{index:03d}" for index in range(36))
+        remaining = owned[:-TYPE_CHUNK_BYTES]
+        full = (owned, 28)
+        partial = (remaining, 17)
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[full, full, None, partial, partial, ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        self.assertEqual(
+            [len(item.args[2]) for item in type_text.call_args_list],
+            [TYPE_CHUNK_BYTES, len(remaining)],
+        )
+
+    def test_clear_ignores_an_initial_unrecognised_sample(self) -> None:
+        owned = "partial body"
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[None, (owned, 14), (owned, 14), ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * len(owned), None
+        )
+
+    def test_clear_continues_from_a_partly_applied_batch(self) -> None:
+        owned = " ".join(f"word-{index:03d}" for index in range(36))
+        after_partial = owned[:-120]
+        after_second = after_partial[:-TYPE_CHUNK_BYTES]
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[
+                    (owned, 28),
+                    (owned, 28),
+                    (after_partial, 19),
+                    (after_partial, 19),
+                    (after_second, 8),
+                    (after_second, 8),
+                    ("", 2),
+                ]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        self.assertEqual(
+            [len(item.args[2]) for item in type_text.call_args_list],
+            [TYPE_CHUNK_BYTES, TYPE_CHUNK_BYTES, len(after_second)],
+        )
+
+    def test_clear_owns_a_distinct_scrolled_suffix(self) -> None:
+        owned = " ".join(f"token-{index:03d}" for index in range(90))
+        remaining_ends = list(range(len(owned), 0, -TYPE_CHUNK_BYTES))
+        rendered = {
+            end: (owned[max(0, end - 240) : end], 2)
+            for end in remaining_ends
+        }
+        states = []
+        for end in remaining_ends:
+            states.extend([rendered[end]] * 2)
+        states.append(("", 2))
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(side_effect=states),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        expected_sizes = [
+            min(TYPE_CHUNK_BYTES, end) for end in remaining_ends
+        ]
+        self.assertEqual(
+            [len(item.args[2]) for item in type_text.call_args_list],
+            expected_sizes,
+        )
+
+    def test_clear_continues_while_small_batches_make_progress(self) -> None:
+        owned = "".join(f"{index:04d}" for index in range(250))
+        remaining = [len(owned)]
+
+        def composer_state(*_args: object) -> tuple[str, int]:
+            if not remaining[0]:
+                return "", 2
+            start = max(0, remaining[0] - 10)
+            return owned[start : remaining[0]], 11
+
+        def type_text(*args: object) -> None:
+            typed = str(args[2])
+            self.assertEqual(set(typed), {"\x7f"})
+            remaining[0] -= len(typed)
+
+        write = Mock(side_effect=type_text)
+        replacements = {
+            "type_text": write,
+            "composer_state": Mock(side_effect=composer_state),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        self.assertEqual(remaining[0], 0)
+        self.assertEqual(write.call_count, len(owned) // 10)
+
+    def test_clear_accepts_a_parser_elided_trailing_space(self) -> None:
+        remaining = "alpha beta gamma "
+        owned = remaining + "x" * TYPE_CHUNK_BYTES
+
+        def parsed(text: str) -> str:
+            content = LIVE_PROMPT_TEXT(
+                CLAUDE_PROFILE, f"{RULE}\n❯ {text}\n{RULE}"
+            )
+            self.assertIsNotNone(content)
+            return content or ""
+
+        full = (parsed(owned), 24)
+        trimmed = (parsed(remaining), 18)
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[full, full, trimmed, trimmed, ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        self.assertEqual(
+            [len(item.args[2]) for item in type_text.call_args_list],
+            [TYPE_CHUNK_BYTES, len(remaining)],
+        )
+
+    def test_clear_stops_when_foreign_text_appears_after_one_batch(self) -> None:
+        owned = "alpha beta gamma delta epsilon"
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[
+                    ("delta epsilon", 14),
+                    ("delta epsilon", 14),
+                    ("alpha beta USER", 16),
+                    ("alpha beta USER", 16),
+                ]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertFalse(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * len("delta epsilon"), None
+        )
+
+    def test_clear_accepts_a_partially_written_marker_prefix(self) -> None:
+        owned = "payload [peer-check:0]"
+        partial = "payload [peer-ch"
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(
+                side_effect=[(partial, 17), (partial, 17), ("", 2)]
+            ),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertTrue(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), owned
+                )
+            )
+
+        type_text.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "\x7f" * len(partial), None
+        )
+
+    def test_unrecognised_composer_is_never_backspaced(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(return_value=None),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertFalse(
+                CLEAR_COMPOSER(
+                    "session-id", CLAUDE_PROFILE, ("", 2), "a" * 400
+                )
+            )
+
+        type_text.assert_not_called()
+
+    def test_foreign_suffix_is_never_backspaced(self) -> None:
+        type_text = Mock()
+        replacements = {
+            "type_text": type_text,
+            "composer_state": Mock(return_value=("script prefix USER DRAFT", 27)),
+            "time": stepping_time(),
+        }
+
+        with patch.dict(CLEAR_COMPOSER.__globals__, replacements):
+            self.assertFalse(
+                CLEAR_COMPOSER(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    ("", 2),
+                    "script prefix",
+                )
+            )
+
+        type_text.assert_not_called()
+
+
+class WindowPropagationTests(unittest.TestCase):
+    def test_composer_state_checks_target_once_per_sample(self) -> None:
+        require_target = Mock(return_value="full-session-id")
+        pane_text = Mock(return_value="screen")
+        cursor_column = Mock(return_value=17)
+        replacements = {
+            "require_target": require_target,
+            "_pane_text_unchecked": pane_text,
+            "_cursor_column_unchecked": cursor_column,
+            "live_prompt_text": Mock(return_value="body"),
+        }
+
+        with patch.dict(COMPOSER_STATE.__globals__, replacements):
+            self.assertEqual(
+                COMPOSER_STATE(
+                    "session-prefix", CLAUDE_PROFILE, "stable-window-id"
+                ),
+                ("body", 17),
+            )
+
+        require_target.assert_called_once_with(
+            "session-prefix", CLAUDE_PROFILE, "stable-window-id"
+        )
+        pane_text.assert_called_once_with(
+            "full-session-id", CLAUDE_PROFILE, "stable-window-id"
+        )
+        cursor_column.assert_called_once_with(
+            "full-session-id", CLAUDE_PROFILE, "stable-window-id"
+        )
+
+    def test_tree_read_is_window_scoped(self) -> None:
+        ctl = Mock(return_value='{"result": {"tree": {}}}')
+
+        with patch.dict(TREE.__globals__, {"ctl": ctl}):
+            TREE("stable-window-id")
+
+        ctl.assert_called_once_with(
+            "tree", "--json", "--window", "stable-window-id"
+        )
+
+    def test_pane_read_is_window_scoped(self) -> None:
+        require_target = Mock()
+        ctl = Mock(return_value="screen")
+
+        with patch.dict(
+            PANE_TEXT.__globals__,
+            {"require_target": require_target, "ctl": ctl},
+        ):
+            PANE_TEXT(
+                "session-id", CLAUDE_PROFILE, "stable-window-id"
+            )
+
+        require_target.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "stable-window-id"
+        )
+        ctl.assert_called_once_with(
+            "session",
+            "text",
+            "--pane",
+            "left",
+            "--target",
+            "session-id",
+            "--lines",
+            str(SCRIPT["BOX_LINES"]),
+            "--window",
+            "stable-window-id",
+        )
+
+    def test_cursor_read_is_window_scoped(self) -> None:
+        require_target = Mock()
+        ctl = Mock(return_value="2\n")
+
+        with patch.dict(
+            CURSOR_COLUMN.__globals__,
+            {"require_target": require_target, "ctl": ctl},
+        ):
+            self.assertEqual(
+                CURSOR_COLUMN(
+                    "session-id", CLAUDE_PROFILE, "stable-window-id"
+                ),
+                2,
+            )
+
+        require_target.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "stable-window-id"
+        )
+        ctl.assert_called_once_with(
+            "surface",
+            "cursor",
+            "--target",
+            "surface:session-id:left",
+            "--window",
+            "stable-window-id",
+        )
+
+
+class TypeTextTests(unittest.TestCase):
+    def test_rechecks_target_then_writes_body_on_stdin(self) -> None:
+        require_target = Mock()
+        ctl = Mock(return_value="")
+        calls = Mock()
+        calls.attach_mock(require_target, "require_target")
+        calls.attach_mock(ctl, "ctl")
+        replacements = {"require_target": require_target, "ctl": ctl}
+
+        with patch.dict(TYPE_TEXT.__globals__, replacements):
+            TYPE_TEXT("session-id", CLAUDE_PROFILE, "body\n")
+
+        self.assertEqual(
+            calls.mock_calls,
+            [
+                call.require_target("session-id", CLAUDE_PROFILE, None),
+                call.ctl(
+                    "session",
+                    "type",
+                    "--stdin",
+                    "--pane",
+                    "left",
+                    "--target",
+                    "session-id",
+                    input_text="body\n",
+                ),
+            ],
+        )
+
+    def test_window_is_pinned_for_the_recheck_and_write(self) -> None:
+        require_target = Mock()
+        ctl = Mock(return_value="")
+        replacements = {"require_target": require_target, "ctl": ctl}
+
+        with patch.dict(TYPE_TEXT.__globals__, replacements):
+            TYPE_TEXT(
+                "session-id", CLAUDE_PROFILE, "body", "stable-window-id"
+            )
+
+        require_target.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "stable-window-id"
+        )
+        ctl.assert_called_once_with(
+            "session",
+            "type",
+            "--stdin",
+            "--pane",
+            "left",
+            "--target",
+            "session-id",
+            "--window",
+            "stable-window-id",
+            input_text="body",
+        )
+
+
+class TypeBodyTests(unittest.TestCase):
+    def test_probe_marker_is_absent_from_the_message(self) -> None:
+        message = "body [peer-check:0] more body"
+
+        marker = COMPOSER_PROBE_MARKER(message)
+
+        self.assertEqual(marker, " [peer-check:1]")
+        self.assertNotIn(marker, message)
+
+    def test_chunks_preserve_utf8_without_exceeding_limit(self) -> None:
+        message = "a" * (TYPE_CHUNK_BYTES - 1) + "€" + "b" * 901
+
+        chunks = TEXT_CHUNKS(message)
+
+        self.assertEqual("".join(chunks), message)
+        self.assertTrue(
+            all(len(chunk.encode("utf-8")) <= TYPE_CHUNK_BYTES for chunk in chunks)
+        )
+
+    def test_chunks_start_at_word_boundaries(self) -> None:
+        message = "first " + "word " * 100 + "last"
+
+        chunks = TEXT_CHUNKS(message)
+
+        self.assertEqual("".join(chunks), message)
+        self.assertTrue(all(chunk.startswith(" ") for chunk in chunks[1:]))
+
+    def test_repeated_words_stay_in_bounded_events(self) -> None:
+        message = "prefix " + "foo " * 300 + "suffix"
+
+        chunks = TEXT_CHUNKS(message)
+
+        self.assertEqual("".join(chunks), message)
+        self.assertEqual(len(chunks), 7)
+        self.assertTrue(
+            all(len(chunk.encode("utf-8")) <= TYPE_CHUNK_BYTES for chunk in chunks)
+        )
+
+    def test_overlong_unicode_token_uses_utf8_safe_bounded_events(self) -> None:
+        message = "ж" * TYPE_CHUNK_BYTES
+
+        chunks = TEXT_CHUNKS(message)
+
+        self.assertEqual("".join(chunks), message)
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(
+            all(len(chunk.encode("utf-8")) <= TYPE_CHUNK_BYTES for chunk in chunks)
+        )
+
+    def test_each_chunk_waits_for_an_observed_composer_transition(self) -> None:
+        type_text = Mock()
+        marker = COMPOSER_PROBE_MARKER("body")
+        chunk_limit = TYPE_CHUNK_BYTES - len(marker.encode("utf-8"))
+        message = "a" * (chunk_limit + 1)
+        chunks = TEXT_CHUNKS(message, chunk_limit)
+        first_marked = (chunks[0] + marker, 2)
+        first_unmarked = (chunks[0], 2)
+        final_marked = (message + marker, 3)
+        final_unmarked = (message, 3)
+        wait_for_change = Mock(
+            side_effect=[
+                first_marked,
+                first_unmarked,
+                final_marked,
+                final_unmarked,
+            ]
+        )
+        calls = Mock()
+        calls.attach_mock(type_text, "type_text")
+        calls.attach_mock(wait_for_change, "wait_for_change")
+        replacements = {
+            "type_text": type_text,
+            "wait_for_composer_change": wait_for_change,
+        }
+        with patch.dict(TYPE_BODY.__globals__, replacements):
+            self.assertEqual(
+                TYPE_BODY("session-id", CLAUDE_PROFILE, message, ("", 2)),
+                final_unmarked,
+            )
+
+        self.assertEqual(
+            calls.mock_calls,
+            [
+                call.type_text(
+                    "session-id", CLAUDE_PROFILE, chunks[0] + marker, None
+                ),
+                call.wait_for_change(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    ("", 2),
+                    CHUNK_SETTLE_DELAY,
+                    None,
+                ),
+                call.type_text(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    "\x7f" * len(marker),
+                    None,
+                ),
+                call.wait_for_change(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    first_marked,
+                    CHUNK_SETTLE_DELAY,
+                    None,
+                ),
+                call.type_text(
+                    "session-id", CLAUDE_PROFILE, chunks[1] + marker, None
+                ),
+                call.wait_for_change(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    first_unmarked,
+                    CHUNK_SETTLE_DELAY,
+                    None,
+                ),
+                call.type_text(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    "\x7f" * len(marker),
+                    None,
+                ),
+                call.wait_for_change(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    final_marked,
+                    COMPOSER_SETTLE_DELAY,
+                    None,
+                ),
+            ],
+        )
+        body_events = [
+            item.args[2]
+            for item in type_text.call_args_list
+            if not item.args[2].startswith("\x7f")
+        ]
+        self.assertTrue(
+            all(len(item.encode("utf-8")) <= TYPE_CHUNK_BYTES for item in body_events)
+        )
+
+    def test_periodic_viewport_ambiguity_fails_before_submit(self) -> None:
+        marker = COMPOSER_PROBE_MARKER("body")
+        chunk_limit = TYPE_CHUNK_BYTES - len(marker.encode("utf-8"))
+        message = "x" * (chunk_limit * 3)
+        chunks = TEXT_CHUNKS(message, chunk_limit)
+        visible = chunk_limit + CHUNK_VERIFY_OVERLAP
+        expected = ""
+        states = []
+        for chunk in chunks:
+            expected += chunk
+            states.extend(
+                [
+                    ((expected + marker)[-(visible + len(marker)) :], 2),
+                    (expected[-visible:], 2),
+                ]
+            )
+        type_text = Mock()
+        wait_for_change = Mock(side_effect=states)
+        replacements = {
+            "type_text": type_text,
+            "wait_for_composer_change": wait_for_change,
+        }
+
+        with (
+            patch.dict(TYPE_BODY.__globals__, replacements),
+            self.assertRaisesRegex(RuntimeError, "chunk 2/3 is incomplete"),
+        ):
+            TYPE_BODY("session-id", CLAUDE_PROFILE, message, ("", 2))
+
+        self.assertEqual(wait_for_change.call_count, 3)
+        self.assertEqual(len(type_text.call_args_list), 3)
+        self.assertTrue(type_text.call_args_list[-1].args[2].endswith(marker))
+
+    def test_missing_chunk_transition_stops_before_later_chunks(self) -> None:
+        type_text = Mock()
+        marker = COMPOSER_PROBE_MARKER("body")
+        chunk_limit = TYPE_CHUNK_BYTES - len(marker.encode("utf-8"))
+        message = "a" * chunk_limit + "b" * (chunk_limit - 1) + "Zc"
+        chunks = TEXT_CHUNKS(message, chunk_limit)
+        first_marked = (chunks[0] + marker, 2)
+        first_unmarked = (chunks[0], 2)
+        wait_for_change = Mock(side_effect=[first_marked, first_unmarked, None])
+        replacements = {
+            "type_text": type_text,
+            "wait_for_composer_change": wait_for_change,
+        }
+        with (
+            patch.dict(TYPE_BODY.__globals__, replacements),
+            self.assertRaisesRegex(RuntimeError, "chunk 2/3"),
+        ):
+            TYPE_BODY("session-id", CLAUDE_PROFILE, message, ("", 2))
+
+        self.assertEqual(
+            type_text.call_args_list,
+            [
+                call(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    chunks[0] + marker,
+                    None,
+                ),
+                call(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    "\x7f" * len(marker),
+                    None,
+                ),
+                call(
+                    "session-id",
+                    CLAUDE_PROFILE,
+                    chunks[1] + marker,
+                    None,
+                ),
+            ],
+        )
+
+    def test_incomplete_changed_chunk_stops_before_later_chunks(self) -> None:
+        type_text = Mock()
+        marker = COMPOSER_PROBE_MARKER("body")
+        chunk_limit = TYPE_CHUNK_BYTES - len(marker.encode("utf-8"))
+        message = "a" * chunk_limit + "b" * (chunk_limit - 1) + "Zc"
+        chunks = TEXT_CHUNKS(message, chunk_limit)
+        first_marked = (chunks[0] + marker, 2)
+        first_unmarked = (chunks[0], 2)
+        incomplete_second = (chunks[0] + chunks[1][:-1] + marker, 2)
+        wait_for_change = Mock(
+            side_effect=[first_marked, first_unmarked, incomplete_second]
+        )
+        replacements = {
+            "type_text": type_text,
+            "wait_for_composer_change": wait_for_change,
+        }
+        with (
+            patch.dict(TYPE_BODY.__globals__, replacements),
+            self.assertRaisesRegex(RuntimeError, "chunk 2/3 is incomplete"),
+        ):
+            TYPE_BODY("session-id", CLAUDE_PROFILE, message, ("", 2))
+
+        self.assertEqual(len(type_text.call_args_list), 3)
+
+
+class ComposerTailTests(unittest.TestCase):
+    def test_terminal_wrapping_is_ignored(self) -> None:
+        typed = "Chat from Claude: one two three"
+        rendered = "Chat from Claude: one tw\no three"
+
+        self.assertTrue(
+            COMPOSER_HAS_EXPECTED_TAIL(rendered, typed, typed)
+        )
+
+    def test_space_loss_at_visual_wrap_is_unobservable(self) -> None:
+        typed = "a" * 64 + " beta [peer-check:0]"
+        rendered = "a" * 64 + "\nbeta [peer-check:0]"
+
+        self.assertTrue(
+            COMPOSER_HAS_EXPECTED_TAIL(rendered, typed, typed)
+        )
+
+    def test_missing_space_on_one_visual_row_is_rejected(self) -> None:
+        typed = "Chat from Claude: alpha beta"
+
+        self.assertFalse(
+            COMPOSER_HAS_EXPECTED_TAIL(
+                "Chat from Claude: alphabeta", typed, typed
+            )
+        )
+
+    def test_separator_anchor_rejects_a_missing_first_word_character(self) -> None:
+        expected = "a" * 400 + " alpha beta"
+        chunk = " alpha beta"
+        corrupted = "a" * 400 + " lpha beta"
+
+        self.assertFalse(
+            COMPOSER_HAS_EXPECTED_TAIL(corrupted[-100:], expected, chunk)
+        )
+
+    def test_missing_middle_is_rejected_even_when_tail_is_present(self) -> None:
+        typed = "Chat from Claude: opening missing middle closing"
+        rendered = "Chat from Claude: opening closing"
+
+        self.assertFalse(
+            COMPOSER_HAS_EXPECTED_TAIL(rendered, typed, typed)
+        )
+
+    def test_truncated_periodic_chunk_is_ambiguous(self) -> None:
+        marker = " [peer-check:0]"
+        previous = "a" * 64
+        chunk = "a" * 50 + marker
+        expected = previous + chunk
+        missing_chunk_prefix = "a" * 104 + marker
+
+        self.assertFalse(
+            COMPOSER_HAS_EXPECTED_TAIL(
+                missing_chunk_prefix, expected, chunk
+            )
+        )
+
+    def test_scrolled_prefix_is_not_required_after_earlier_chunks_passed(self) -> None:
+        earlier = "old " * 300
+        latest = " ".join(["latest"] * 30)
+        expected = earlier + latest
+        visible = expected[-(len(latest) + CHUNK_VERIFY_OVERLAP) :]
+        visible = visible.replace(" latest", "\nlatest", 2)
+
+        self.assertTrue(
+            COMPOSER_HAS_EXPECTED_TAIL(visible, expected, latest)
+        )
+
+
+class ArgumentTests(unittest.TestCase):
+    def test_queue_is_available_for_codex(self) -> None:
+        args = PARSE_ARGS(["--to", "codex", "--queue", "--stdin"])
+
+        self.assertTrue(args.queue)
+
+    def test_queue_is_refused_for_claude(self) -> None:
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            PARSE_ARGS(["--to", "claude", "--queue", "--stdin"])
+
+    def test_explicit_window_is_available_outside_the_target_window(self) -> None:
+        args = PARSE_ARGS(
+            ["--to", "claude", "--window", "window-id", "--stdin"]
+        )
+
+        self.assertEqual(args.window, "window-id")
+
+    def test_blank_explicit_selectors_are_refused(self) -> None:
+        for option in ("--session", "--window"):
+            with (
+                self.subTest(option=option),
+                redirect_stderr(io.StringIO()),
+                self.assertRaises(SystemExit),
+            ):
+                PARSE_ARGS(["--to", "claude", option, "", "--stdin"])
+
+
+class WindowResolutionTests(unittest.TestCase):
+    def test_blank_explicit_window_does_not_fall_back_to_active(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            self.assertRaisesRegex(RuntimeError, "window selector is empty"),
+        ):
+            RESOLVE_WINDOW("")
+
+    def test_blank_environment_window_does_not_fall_back_to_active(self) -> None:
+        with (
+            patch.dict(os.environ, {"AGTERM_WINDOW_ID": ""}, clear=True),
+            self.assertRaisesRegex(RuntimeError, "window selector is empty"),
+        ):
+            RESOLVE_WINDOW(None)
+
+    def test_environment_window_is_resolved_to_a_stable_id(self) -> None:
+        payload = {
+            "result": {
+                "windows": [
+                    {
+                        "id": "environment-window-full-id",
+                        "open": True,
+                        "active": False,
+                    }
+                ]
+            }
+        }
+        ctl = Mock(return_value=json.dumps(payload))
+
+        with (
+            patch.dict(os.environ, {"AGTERM_WINDOW_ID": "environment-window"}),
+            patch.dict(RESOLVE_WINDOW.__globals__, {"ctl": ctl}),
+        ):
+            self.assertEqual(
+                RESOLVE_WINDOW(None), "environment-window-full-id"
+            )
+
+        ctl.assert_called_once_with("window", "list", "--json")
+
+    def test_active_window_is_snapshotted_when_the_environment_is_absent(self) -> None:
+        payload = {
+            "result": {
+                "windows": [
+                    {"id": "closed", "open": False, "active": False},
+                    {"id": "active-window", "open": True, "active": True},
+                ]
+            }
+        }
+        replacements = {"ctl": Mock(return_value=json.dumps(payload))}
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.dict(RESOLVE_WINDOW.__globals__, replacements),
+        ):
+            self.assertEqual(RESOLVE_WINDOW(None), "active-window")
+
+    def test_explicit_active_selector_is_snapshotted(self) -> None:
+        payload = {
+            "result": {
+                "windows": [
+                    {"id": "first", "open": True, "active": False},
+                    {"id": "second", "open": True, "active": True},
+                ]
+            }
+        }
+
+        with patch.dict(
+            RESOLVE_WINDOW.__globals__,
+            {"ctl": Mock(return_value=json.dumps(payload))},
+        ):
+            self.assertEqual(RESOLVE_WINDOW("active"), "second")
+
+    def test_closed_explicit_window_is_refused(self) -> None:
+        payload = {
+            "result": {
+                "windows": [
+                    {"id": "closed-window", "open": False, "active": False}
+                ]
+            }
+        }
+
+        with (
+            patch.dict(
+                RESOLVE_WINDOW.__globals__,
+                {"ctl": Mock(return_value=json.dumps(payload))},
+            ),
+            self.assertRaisesRegex(RuntimeError, "not open"),
+        ):
+            RESOLVE_WINDOW("closed")
+
+    def test_environment_session_without_window_finds_its_open_owner(self) -> None:
+        target = {
+            "id": "session-full-id",
+            "hasSplit": True,
+            "foreground": ["claude"],
+            "splitForeground": ["codex"],
+        }
+        replacements = {
+            "open_window_ids": Mock(return_value=["window-a", "window-b"]),
+            "tree": Mock(side_effect=[{"sessions": [target]}, {"sessions": []}]),
+        }
+
+        with (
+            patch.dict(
+                os.environ, {"AGTERM_SESSION_ID": "session-full"}, clear=True
+            ),
+            patch.dict(RESOLVE_TARGET.__globals__, replacements),
+        ):
+            self.assertEqual(
+                RESOLVE_TARGET(None, None, CLAUDE_PROFILE),
+                ("window-a", "session-full-id"),
+            )
+
+    def test_explicit_session_ignores_the_ambient_window(self) -> None:
+        target = {
+            "id": "session-b-full-id",
+            "hasSplit": True,
+            "foreground": ["claude"],
+            "splitForeground": ["codex"],
+        }
+        resolve_window = Mock()
+        replacements = {
+            "resolve_window": resolve_window,
+            "open_window_ids": Mock(return_value=["window-a", "window-b"]),
+            "tree": Mock(side_effect=[{"sessions": []}, {"sessions": [target]}]),
+        }
+
+        with (
+            patch.dict(
+                os.environ, {"AGTERM_WINDOW_ID": "window-a"}, clear=True
+            ),
+            patch.dict(RESOLVE_TARGET.__globals__, replacements),
+        ):
+            self.assertEqual(
+                RESOLVE_TARGET("session-b", None, CLAUDE_PROFILE),
+                ("window-b", "session-b-full-id"),
+            )
+
+        resolve_window.assert_not_called()
+
+    def test_blank_session_selectors_do_not_fall_back(self) -> None:
+        for explicit, environment in (("", {}), (None, {"AGTERM_SESSION_ID": ""})):
+            with (
+                self.subTest(explicit=explicit, environment=environment),
+                patch.dict(os.environ, environment, clear=True),
+                self.assertRaisesRegex(RuntimeError, "session selector is empty"),
+            ):
+                RESOLVE_TARGET(explicit, None, CLAUDE_PROFILE)
+
+    def test_explicit_window_constrains_session_lookup(self) -> None:
+        resolve_session = Mock(side_effect=RuntimeError("no such session"))
+        replacements = {
+            "resolve_window": Mock(return_value="window-b"),
+            "resolve_session": resolve_session,
+        }
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.dict(RESOLVE_TARGET.__globals__, replacements),
+            self.assertRaisesRegex(RuntimeError, "no such session"),
+        ):
+            RESOLVE_TARGET("session-id", "window-b", CLAUDE_PROFILE)
+
+        resolve_session.assert_called_once_with(
+            "session-id", CLAUDE_PROFILE, "window-b"
+        )
+
+    def test_session_prefix_ambiguous_across_windows_is_refused(self) -> None:
+        first = {
+            "id": "session-one",
+            "hasSplit": True,
+            "foreground": ["claude"],
+        }
+        second = {
+            "id": "session-two",
+            "hasSplit": True,
+            "foreground": ["claude"],
+        }
+        replacements = {
+            "open_window_ids": Mock(return_value=["window-a", "window-b"]),
+            "tree": Mock(
+                side_effect=[{"sessions": [first]}, {"sessions": [second]}]
+            ),
+        }
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.dict(RESOLVE_TARGET.__globals__, replacements),
+            self.assertRaisesRegex(RuntimeError, "ambiguous session prefix"),
+        ):
+            RESOLVE_TARGET("session-", None, CLAUDE_PROFILE)
+
+
+class MainWindowFlowTests(unittest.TestCase):
+    @staticmethod
+    def args() -> argparse.Namespace:
+        return argparse.Namespace(
+            prepare_message=None,
+            stdin=True,
+            message_file=None,
+            to="claude",
+            session="session-prefix",
+            window="active",
+            target_command=None,
+            queue=False,
+        )
+
+    def replacements(self, send_with_retry: Mock) -> dict[str, object]:
+        return {
+            "parse_args": Mock(return_value=self.args()),
+            "target_profile": Mock(return_value=CLAUDE_PROFILE),
+            "resolve_target": Mock(
+                return_value=("stable-window-id", "stable-session-id")
+            ),
+            "read_message": Mock(return_value="body"),
+            "send_with_retry": send_with_retry,
+        }
+
+    def test_resolved_window_id_reaches_session_and_send(self) -> None:
+        profile = CLAUDE_PROFILE
+        resolve_target = Mock(
+            return_value=("stable-window-id", "stable-session-id")
+        )
+        send_with_retry = Mock(return_value=4)
+        replacements = {
+            "parse_args": Mock(return_value=self.args()),
+            "target_profile": Mock(return_value=profile),
+            "resolve_target": resolve_target,
+            "read_message": Mock(return_value="body"),
+            "send_with_retry": send_with_retry,
+        }
+
+        with (
+            patch.dict(MAIN.__globals__, replacements),
+            patch("sys.stdout", new=io.StringIO()),
+        ):
+            self.assertEqual(MAIN(), 0)
+
+        resolve_target.assert_called_once_with(
+            "session-prefix", "active", profile
+        )
+        send_with_retry.assert_called_once_with(
+            "stable-session-id", profile, "body", "stable-window-id", ANY
+        )
+
+    def test_interrupt_before_return_is_unsafe_to_resend(self) -> None:
+        def interrupt_after_start(
+            _sid: str,
+            _profile: object,
+            _message: str,
+            _window: str,
+            progress: object,
+        ) -> None:
+            progress.phase = "started"
+            raise KeyboardInterrupt()
+
+        replacements = self.replacements(Mock(side_effect=interrupt_after_start))
+        stderr = io.StringIO()
+
+        with patch.dict(MAIN.__globals__, replacements), redirect_stderr(stderr):
+            self.assertEqual(MAIN(), 130)
+
+        self.assertIn(
+            "delivery status is unavailable; do not resend", stderr.getvalue()
+        )
+
+    def test_detailed_delivery_interrupt_is_preserved(self) -> None:
+        replacements = self.replacements(
+            Mock(
+                side_effect=KeyboardInterrupt(
+                    "submit request was interrupted; delivery is ambiguous; "
+                    "do not resend"
+                )
+            )
+        )
+        stderr = io.StringIO()
+
+        with patch.dict(MAIN.__globals__, replacements), redirect_stderr(stderr):
+            self.assertEqual(MAIN(), 130)
+
+        self.assertIn("submit request was interrupted", stderr.getvalue())
+
+    def test_interrupt_during_success_report_confirms_delivery(self) -> None:
+        replacements = self.replacements(Mock(return_value=4))
+        replacements["report_success"] = Mock(side_effect=KeyboardInterrupt())
+        stderr = io.StringIO()
+
+        with patch.dict(MAIN.__globals__, replacements), redirect_stderr(stderr):
+            self.assertEqual(MAIN(), 130)
+
+        self.assertIn(
+            "delivery was confirmed; do not resend; success report interrupted",
+            stderr.getvalue(),
+        )
+
+    def test_broken_success_report_confirms_delivery(self) -> None:
+        replacements = self.replacements(Mock(return_value=4))
+        replacements["report_success"] = Mock(
+            side_effect=BrokenPipeError("stdout closed")
+        )
+        stderr = io.StringIO()
+
+        with patch.dict(MAIN.__globals__, replacements), redirect_stderr(stderr):
+            self.assertEqual(MAIN(), 1)
+
+        self.assertIn(
+            "delivery was confirmed; do not resend; success report failed",
+            stderr.getvalue(),
+        )
+
+    def test_interrupt_on_successful_inner_return_confirms_delivery(self) -> None:
+        replacements = self.replacements(Mock(return_value=4))
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        def interrupt_on_return(frame: object, event: str, _arg: object) -> object:
+            if getattr(frame, "f_code", None) is RUN_MAIN.__code__ and event == "return":
+                sys.settrace(None)
+                raise KeyboardInterrupt()
+            return interrupt_on_return
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                patch.dict(MAIN.__globals__, replacements),
+                patch("sys.stdout", new=stdout),
+                redirect_stderr(stderr),
+            ):
+                sys.settrace(interrupt_on_return)
+                self.assertEqual(MAIN(), 130)
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertEqual(stdout.getvalue(), '{"sent": 4}\n')
+        self.assertIn(
+            "delivery was confirmed; do not resend; success report interrupted",
+            stderr.getvalue(),
+        )
+
+
+class RetryTests(unittest.TestCase):
+    def test_transport_failure_is_not_retried(self) -> None:
+        send = Mock(side_effect=RuntimeError("transport failed"))
+        sleep = Mock()
+        replacements = {"send": send, "time": Mock(sleep=sleep)}
+
+        with patch.dict(SEND_WITH_RETRY.__globals__, replacements), self.assertRaises(
+            RuntimeError
+        ):
+            SEND_WITH_RETRY("session-id", PROFILES["codex"], "ping")
+
+        send.assert_called_once_with(
+            "session-id",
+            PROFILES["codex"],
+            "ping",
+            None,
+            "Chat from Claude: ping",
+            ANY,
+        )
+        sleep.assert_not_called()
+
+    def test_interrupt_during_normalisation_reports_no_write(self) -> None:
+        send = Mock()
+        progress = DELIVERY_PROGRESS()
+        replacements = {
+            "normalize": Mock(side_effect=KeyboardInterrupt()),
+            "send": send,
+        }
+
+        with (
+            patch.dict(SEND_WITH_RETRY.__globals__, replacements),
+            self.assertRaisesRegex(KeyboardInterrupt, "nothing was typed"),
+        ):
+            SEND_WITH_RETRY(
+                "session-id", PROFILES["codex"], "ping", progress=progress
+            )
+
+        send.assert_not_called()
+        self.assertEqual(progress.phase, "not_started")
+
+    def test_real_preflight_transport_failure_is_not_retried(self) -> None:
+        pane_text = Mock(side_effect=RuntimeError("control socket is unavailable"))
+        type_text = Mock()
+        sleep = Mock()
+        replacements = {
+            "pane_text": pane_text,
+            "type_text": type_text,
+            "time": Mock(sleep=sleep),
+        }
+
+        with (
+            patch.dict(SEND_WITH_RETRY.__globals__, replacements),
+            self.assertRaisesRegex(RuntimeError, "nothing was typed"),
+        ):
+            SEND_WITH_RETRY("session-id", PROFILES["codex"], "ping")
+
+        pane_text.assert_called_once()
+        type_text.assert_not_called()
+        sleep.assert_not_called()
+
+    def test_interrupt_during_retry_wait_reports_no_write(self) -> None:
+        send = Mock(side_effect=PROMPT_BLOCKED("occupied"))
+        sleep = Mock(side_effect=KeyboardInterrupt())
+        replacements = {"send": send, "time": Mock(sleep=sleep)}
+
+        with (
+            patch.dict(SEND_WITH_RETRY.__globals__, replacements),
+            redirect_stderr(io.StringIO()),
+            self.assertRaisesRegex(KeyboardInterrupt, "nothing was typed"),
+        ):
+            SEND_WITH_RETRY("session-id", PROFILES["codex"], "ping")
+
+    def test_interrupt_during_retry_diagnostic_reports_no_write(self) -> None:
+        progress = DELIVERY_PROGRESS()
+        send = Mock(side_effect=PROMPT_BLOCKED("occupied"))
+        replacements = {
+            "send": send,
+            "print": Mock(side_effect=KeyboardInterrupt()),
+        }
+
+        with (
+            patch.dict(SEND_WITH_RETRY.__globals__, replacements),
+            self.assertRaisesRegex(KeyboardInterrupt, "nothing was typed"),
+        ):
+            SEND_WITH_RETRY(
+                "session-id",
+                PROFILES["codex"],
+                "ping",
+                progress=progress,
+            )
+
+        send.assert_called_once()
+        self.assertEqual(progress.phase, "not_started")
+
+    def test_interrupt_across_pre_write_retry_handler_reports_no_write(self) -> None:
+        source, first_line = inspect.getsourcelines(SEND_WITH_RETRY)
+        loop_index = next(
+            index
+            for index, line in enumerate(source)
+            if line.strip().startswith("for attempt in range(")
+        )
+        handler_index = next(
+            index
+            for index, line in enumerate(source)
+            if line.strip() == "if attempt == RETRY_ATTEMPTS:"
+        )
+        outer_try_index = max(
+            index
+            for index, line in enumerate(source[:loop_index])
+            if line.strip() == "try:"
+        )
+        attempt_try_index = next(
+            index
+            for index, line in enumerate(source[loop_index + 1 :], loop_index + 1)
+            if line.strip() == "try:"
+        )
+
+        for name, target_index, target_hit, expected_sends in (
+            ("outer try header", outer_try_index, 1, 0),
+            ("attempt try header", attempt_try_index, 1, 0),
+            ("handler entry", handler_index, 1, 1),
+            ("loop hand-off", loop_index, 2, 1),
+        ):
+            with self.subTest(boundary=name):
+                target_line = first_line + target_index
+                send = Mock(side_effect=PROMPT_BLOCKED("occupied"))
+                observed_progress: list[object] = []
+                hits = 0
+
+                def run_retry(
+                    progress: object,
+                    _observed_progress: list[object] = observed_progress,
+                ) -> int:
+                    _observed_progress.append(progress)
+                    return SEND_WITH_RETRY(
+                        "session-id",
+                        PROFILES["codex"],
+                        "ping",
+                        progress=progress,
+                    )
+
+                def interrupt_at_boundary(
+                    frame: object,
+                    event: str,
+                    _arg: object,
+                    _target_line: int = target_line,
+                    _target_hit: int = target_hit,
+                ) -> object:
+                    nonlocal hits
+                    if (
+                        getattr(frame, "f_code", None) is SEND_WITH_RETRY.__code__
+                        and event == "line"
+                        and getattr(frame, "f_lineno", None) == _target_line
+                    ):
+                        hits += 1
+                        if hits == _target_hit:
+                            sys.settrace(None)
+                            raise KeyboardInterrupt()
+                    return interrupt_at_boundary
+
+                previous_trace = sys.gettrace()
+                stderr = io.StringIO()
+                try:
+                    with (
+                        patch.dict(
+                            MAIN.__globals__,
+                            {
+                                "run_main": run_retry,
+                                "send": send,
+                                "time": Mock(sleep=Mock()),
+                            },
+                        ),
+                        redirect_stderr(stderr),
+                    ):
+                        sys.settrace(interrupt_at_boundary)
+                        self.assertEqual(MAIN(), 130)
+                finally:
+                    sys.settrace(previous_trace)
+
+                self.assertIn("nothing was typed", stderr.getvalue())
+                self.assertEqual(send.call_count, expected_sends)
+                self.assertEqual(len(observed_progress), 1)
+                self.assertEqual(
+                    vars(observed_progress[0])["phase"], "not_started"
+                )
 
 
 class MessageInputTests(unittest.TestCase):
@@ -437,6 +2514,19 @@ class MessageInputTests(unittest.TestCase):
         self.assertTrue(args.stdin)
         self.assertIsNone(args.message_file)
 
+    def test_oversized_stdin_message_is_rejected(self) -> None:
+        stream = io.TextIOWrapper(
+            io.BytesIO(b"x" * (MAX_MESSAGE_BYTES + 2)), encoding="utf-8"
+        )
+
+        with (
+            patch.object(sys, "stdin", stream),
+            self.assertRaisesRegex(ValueError, str(MAX_MESSAGE_BYTES)),
+        ):
+            READ_MESSAGE(True, None)
+
+        self.assertEqual(stream.buffer.tell(), MAX_MESSAGE_BYTES + 1)
+
     def test_target_refusal_preserves_prepared_message(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             spool = Path(directory) / "spool"
@@ -451,11 +2541,15 @@ class MessageInputTests(unittest.TestCase):
                     message_file=name,
                     to="claude",
                     session=None,
+                    window=None,
                     target_command=None,
+                    queue=False,
                 )
+                resolve_target = Mock(side_effect=RuntimeError("no target"))
                 main_replacements = {
                     "parse_args": Mock(return_value=args),
-                    "resolve_session": Mock(side_effect=RuntimeError("no target")),
+                    "target_profile": Mock(return_value=CLAUDE_PROFILE),
+                    "resolve_target": resolve_target,
                 }
 
                 with (
@@ -464,6 +2558,9 @@ class MessageInputTests(unittest.TestCase):
                 ):
                     self.assertEqual(MAIN(), 1)
 
+                resolve_target.assert_called_once_with(
+                    None, None, CLAUDE_PROFILE
+                )
                 self.assertEqual(path.read_text(encoding="utf-8"), "message to retry")
 
 


### PR DESCRIPTION
A single 1,941-byte input event could reach Claude Code with 1,022 contiguous bytes missing, while sending the body and Return together could leave the complete body composed but unsent. The peer-chat recipe could not distinguish either result from delivery.

This keeps the existing `agtermctl session type --stdin` transport and separates body delivery from submission. Long text is sent as UTF-8-safe marked events capped at 197 bytes; every event and marker removal is checked against the visible source suffix, the final body must remain stable, Return is sent separately, and success requires a stable recognised empty composer. Cross-window target resolution pins the owning window and rejects blank selectors, every write rechecks the target process, and recovery removes only visible text attributable to the current send while requiring observable progress. Recovery must observe owned text before it can accept an empty composer, and delivery state changes only when the body transaction begins, so a pre-write retry interruption remains safe to classify. Failures after delivery starts are not retried. Codex receives Return by default for live steering, with `--queue` as the explicit Tab opt-in. The documented limits state that plain terminal read-back cannot distinguish a source space consumed at a visual wrap from a missing space at that boundary.

The README and both agent skills document setup, approval rules and failure semantics. The focused suite covers 128 paths across wrapping, periodic ambiguity, partial writes, stale dialogs, wrong targets, cleanup ownership, window changes, accepted and ambiguous submissions, blank selectors, and interrupt boundaries.

Verification:

- `AGTERMCTL=/definitely-missing-agtermctl python3 cookbook/two-agent-chat/test_peer_chat.py`
- `find cookbook -type f -name '*.py' -print0 | xargs -0 -r uvx ruff check --ignore EXE001`
- mutation checks for chunk receipt, stable cleanup progress, delayed body rendering, exact empty-composer acceptance, blank selector rejection and handler-entry and loop-hand-off interrupt classification
- 2,460 sequenced characters delivered byte for byte to Codex in a live split
- 2,400 sequenced characters delivered byte for byte to Claude Code in a live split
