### PR TITLE
feat(control): let session.paste address a pane

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -286,7 +286,11 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   and an unrealized pane is `session not realized` — `readSelection` cannot tell the two apart, and copy is
   select-all's read-back, so both name that state the same way. It stays on the PANE while an overlay covers
   it, so a selection made inside one is `session.overlay.copy`'s, not this command's.
-  `session.paste` and `.selectall` run Ghostty bindings on main. They use
+  `session.paste` and `.selectall` run Ghostty bindings through one arm. `session.paste` takes `--pane`
+  so its `session.text` read-back can name the same pane; the dispatcher parses it into `StatusPane`
+  (`session.status`'s `parsePane`, so the role and position aliases resolve and a raw client gets the same
+  pinned rejection) and the arm takes the parsed value, never a spelling. `.selectall` stays on main, its
+  `session.copy` read-back having no pane either. Omitted, and for select-all always, the pane is
   `Session.addressableSurface = surface ?? splitSurface`, never focus-aware `activeSurface`, so select-all
   and copy share one pane. Read paste through text and select-all through copy.
 - Keep standard SwiftUI Edit routing. `GhosttySurfaceView` implements Copy/Paste/Select All and validation;

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -4,13 +4,36 @@ import agtermCore
 /// `ControlServer` arms that reach into a live `GhosttySurfaceView` — font size, selection copy, background
 /// watermark, buffer read, in-terminal search, text injection. Split out for the swiftlint size limit.
 extension ControlServer {
-    /// Runs a libghostty binding action on the target's addressable surface — a SPECIFIC one, unlike the menu
-    /// path's focused pane. Shared by `session.paste`/`session.selectall`; `Session.addressableSurface` owns
-    /// which pane that resolves to. An empty slot and a parked view whose surface never came up are one state
-    /// to a caller: "session not realized".
-    private func surfaceBindingAction(_ target: String?, window: String?, action: String) -> ControlResponse {
+    /// Runs a libghostty binding action on a pane of the target session — a SPECIFIC one, unlike the menu
+    /// path's focused pane. Shared by `session.paste`/`session.selectall`. `pane` arrives parsed by the
+    /// dispatcher, so no spelling reaches here: nil (`session.selectall` always, `session.paste` without
+    /// `--pane`) and `.left` are the main pane via `addressableSurface`, which keeps the pre-pane behavior and
+    /// still reaches a promoted split survivor; `.scratch` resolves while hidden, its surface kept alive. An
+    /// empty slot and a parked view whose surface never came up are one state to a caller: "session not
+    /// realized".
+    private func surfaceBindingAction(_ target: String?, window: String?, pane: StatusPane?,
+                                      action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
-            guard let surface = store.session(withID: id)?.addressableSurface as? GhosttySurfaceView else {
+            // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
+            guard let session = store.session(withID: id) else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            let chosen: (any TerminalSurface)?
+            switch pane {
+            case nil, .left:
+                chosen = session.addressableSurface
+            case .right:
+                guard let split = session.splitSurface else {
+                    return ControlResponse(ok: false, error: "session has no split pane")
+                }
+                chosen = split
+            case .scratch:
+                guard let scratch = session.scratchSurface else {
+                    return ControlResponse(ok: false, error: "session has no scratch terminal")
+                }
+                chosen = scratch
+            }
+            guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             surface.expediteSpawn()
@@ -66,15 +89,17 @@ extension ControlServer {
     }
 
     /// The ⌘V / Edit ▸ Paste analogue (`session.paste`): the same libghostty `paste_from_clipboard` the
-    /// keyboard takes, so bracketed paste applies and no OSC-52 prompt appears. Read back with `session.text`.
-    func pasteSession(_ target: String?, window: String?) -> ControlResponse {
-        surfaceBindingAction(target, window: window, action: "paste_from_clipboard")
+    /// keyboard takes, so bracketed paste applies and no OSC-52 prompt appears. `pane` addresses the same
+    /// three panes `session.text` reads, so the documented paste-then-read-back pair resolves one pane on both
+    /// halves instead of writing main and reading the split.
+    func pasteSession(_ target: String?, window: String?, pane: StatusPane?) -> ControlResponse {
+        surfaceBindingAction(target, window: window, pane: pane, action: "paste_from_clipboard")
     }
 
     /// Selects the target session's entire terminal buffer (`session.selectall`, the ⌘A / Edit ▸ Select All
     /// analogue); read the resulting selection back with `session.copy`.
     func selectAllSession(_ target: String?, window: String?) -> ControlResponse {
-        surfaceBindingAction(target, window: window, action: "select_all")
+        surfaceBindingAction(target, window: window, pane: nil, action: "select_all")
     }
 
     /// Returns the surface's current selection text in the response, NOT to the system clipboard (automation

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -81,7 +81,7 @@ public protocol ControlActions {
     func readQuickText(all: Bool, lines: Int?) async -> ControlResponse
     func typeSession(_ target: String?, window: String?, options: ControlSessionTypeOptions) async -> ControlResponse
     func copySessionSelection(_ target: String?, window: String?) -> ControlResponse
-    func pasteSession(_ target: String?, window: String?) -> ControlResponse
+    func pasteSession(_ target: String?, window: String?, pane: StatusPane?) -> ControlResponse
     func selectAllSession(_ target: String?, window: String?) -> ControlResponse
     func searchSession(_ target: String?, window: String?,
                        text: String?, to: String?) async -> ControlResponse
@@ -601,7 +601,11 @@ public struct ControlDispatcher {
         case .sessionCopy:
             return actions.copySessionSelection(request.target, window: request.args?.window)
         case .sessionPaste:
-            return actions.pasteSession(request.target, window: request.args?.window)
+            switch parsePane(request.args?.pane) {
+            case .pane(let parsed):
+                return actions.pasteSession(request.target, window: request.args?.window, pane: parsed)
+            case .rejected(let rejection): return rejection
+            }
         case .sessionSelectAll:
             return actions.selectAllSession(request.target, window: request.args?.window)
         case .sessionSearch:

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -330,11 +330,15 @@ struct Session: ParsableCommand {
 
     struct Paste: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Paste the system clipboard into a session (like ⌘V).")
+        @Option(name: .long, help: "Which pane to paste into: primary/left/top, split/right/bottom, or scratch (even when hidden). Defaults to primary.") var pane: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
+        func validate() throws { try validatePaneArgument(pane) }
+
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .sessionPaste, target: target.target, args: options.withWindow())
+            ControlRequest(cmd: .sessionPaste, target: target.target,
+                           args: options.withWindow(pane.map { ControlArgs(pane: $0) }))
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -965,7 +965,51 @@ struct ControlDispatcherTests {
             cmd: .sessionPaste, target: "session", args: ControlArgs(window: "win")))
 
         #expect(response == ControlResponse(ok: true, result: ControlResult(id: "session")))
-        #expect(actions.calls == [.sessionPaste(target: "session", window: "win")])
+        #expect(actions.calls == [.sessionPaste(target: "session", window: "win", pane: nil)])
+    }
+
+    // an omitted `pane` must stay nil rather than becoming a default: the action reads nil as the main pane
+    // through `addressableSurface`, which is what every pre-`--pane` caller got.
+    @Test func sessionPasteRoutesPane() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionPasteResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionPaste, target: "session", args: ControlArgs(pane: "right")))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(actions.calls == [.sessionPaste(target: "session", window: nil, pane: .right)])
+    }
+
+    // the aliases the CLI's `validate()` accepts have to reach the surface, so the pane is parsed HERE rather
+    // than matched as a spelling in the app: `session paste --pane split` used to validate and then fail.
+    @Test func sessionPasteAcceptsThePaneAliases() async {
+        for (spelling, expected) in [("primary", StatusPane.left), ("top", .left),
+                                     ("split", .right), ("bottom", .right), ("scratch", .scratch)] {
+            let actions = MockControlActions()
+            let dispatcher = ControlDispatcher(actions: actions)
+            actions.nextSessionPasteResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+            _ = await dispatcher.dispatch(ControlRequest(
+                cmd: .sessionPaste, target: "session", args: ControlArgs(pane: spelling)))
+
+            #expect(actions.calls == [.sessionPaste(target: "session", window: nil, pane: expected)],
+                    "--pane \(spelling) must resolve to \(expected)")
+        }
+    }
+
+    // a raw socket client runs no `validate()`, so the rejection is the dispatcher's, and it is the same
+    // pinned string the CLI throws. The action must not be reached.
+    @Test func sessionPasteRejectsAnUnknownPaneWithoutCallingTheAction() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionPaste, target: "session", args: ControlArgs(pane: "other")))
+
+        #expect(response == ControlResponse(ok: false, error: "--pane must be left, right, or scratch"))
+        #expect(actions.calls.isEmpty)
     }
 
     @Test func sessionSelectAllRoutesTargetAndWindow() async {

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -69,7 +69,7 @@ final class MockControlActions: ControlActions {
         case quickText(all: Bool, lines: Int?)
         case sessionType(target: String?, window: String?, ControlSessionTypeOptions)
         case sessionCopy(target: String?, window: String?)
-        case sessionPaste(target: String?, window: String?)
+        case sessionPaste(target: String?, window: String?, pane: StatusPane?)
         case sessionSelectAll(target: String?, window: String?)
         case sessionSearch(target: String?, window: String?, text: String?, to: String?)
         case overlayOpen(target: String?, window: String?, ControlSessionOverlayOpenOptions)
@@ -496,8 +496,8 @@ final class MockControlActions: ControlActions {
         return nextSessionCopyResponse
     }
 
-    func pasteSession(_ target: String?, window: String?) -> ControlResponse {
-        calls.append(.sessionPaste(target: target, window: window))
+    func pasteSession(_ target: String?, window: String?, pane: StatusPane?) -> ControlResponse {
+        calls.append(.sessionPaste(target: target, window: window, pane: pane))
         return nextSessionPasteResponse
     }
 

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -515,6 +515,28 @@ struct CommandsTests {
         #expect(try request(["session", "paste", "--target", "9f3c"]) == ControlRequest(cmd: .sessionPaste, target: "9f3c"))
     }
 
+    @Test func sessionPasteWithPane() throws {
+        let expected = ControlRequest(cmd: .sessionPaste, target: "9f3c", args: ControlArgs(pane: "right"))
+        #expect(try request(["session", "paste", "--pane", "right", "--target", "9f3c"]) == expected)
+    }
+
+    @Test func sessionPasteWithScratchPane() throws {
+        let expected = ControlRequest(cmd: .sessionPaste, target: "active", args: ControlArgs(pane: "scratch"))
+        #expect(try request(["session", "paste", "--pane", "scratch"]) == expected)
+    }
+
+    // the CLI validates the spelling and passes it through raw; `ControlDispatcher` turns it into a
+    // `StatusPane`, which is what makes the alias reach the surface.
+    @Test func sessionPasteThreadsAPaneAliasRaw() throws {
+        let expected = ControlRequest(cmd: .sessionPaste, target: "active", args: ControlArgs(pane: "split"))
+        #expect(try request(["session", "paste", "--pane", "split"]) == expected)
+    }
+
+    @Test func sessionPasteRejectsUnknownPane() {
+        // `other` is a session.focus mode, not a pasteable pane.
+        #expect(validationMessage(["session", "paste", "--pane", "other"]) == "--pane must be left, right, or scratch")
+    }
+
     @Test func sessionSelectAllDefaultsActive() throws {
         #expect(try request(["session", "select-all"]) == ControlRequest(cmd: .sessionSelectAll, target: "active"))
     }

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -347,7 +347,7 @@ final class ControlServerSessionActionsTests: XCTestCase {
 
     func testSynchronousMutatorsExpediteAQueuedPane() throws {
         let cases: [(name: String, split: Bool, run: (Session) -> ControlResponse)] = [
-            ("session.paste", false, { self.server.pasteSession($0.id.uuidString, window: nil) }),
+            ("session.paste", false, { self.server.pasteSession($0.id.uuidString, window: nil, pane: nil) }),
             ("session.selectall", false, { self.server.selectAllSession($0.id.uuidString, window: nil) }),
             ("font.inc left", false, { self.server.font($0.id.uuidString, window: nil, pane: nil, action: "increase_font_size:1") }),
             ("font.inc right", true, { self.server.font($0.id.uuidString, window: nil, pane: "right", action: "increase_font_size:1") }),
@@ -424,13 +424,44 @@ final class ControlServerSessionActionsTests: XCTestCase {
         target.surface = parked
         XCTAssertFalse(parked.isRealized, "a detached view never runs createSurface, which is the point here")
 
-        let paste = server.pasteSession(target.id.uuidString, window: nil)
+        let paste = server.pasteSession(target.id.uuidString, window: nil, pane: nil)
         XCTAssertFalse(paste.ok, "session.paste pasted nothing and must not report a false ok")
         XCTAssertEqual(paste.error, "session not realized")
 
         let selectAll = server.selectAllSession(target.id.uuidString, window: nil)
         XCTAssertFalse(selectAll.ok, "session.selectall selected nothing and must not report a false ok")
         XCTAssertEqual(selectAll.error, "session not realized")
+    }
+
+    // the pane has to reach the SURFACE, not just the action. `addressableSurface` is `surface ?? splitSurface`,
+    // so a fixture with only the split slot filled grants the same permit either way: main has to be filled
+    // too before granting the split's permit proves anything.
+    func testPasteIntoTheSplitExpeditesTheSplitPane() throws {
+        let (store, target) = try addSession()
+        store.setSplitVisibility(target.id, shown: true)
+        target.surface = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        let queued = queuePane(in: target, split: true)
+
+        let response = server.pasteSession(target.id.uuidString, window: nil, pane: .right)
+
+        XCTAssertEqual(response.error, "session not realized")
+        XCTAssertTrue(queued.granted, "session.paste --pane right must grant the SPLIT pane, not the main one")
+    }
+
+    // a pane that parses but is not laid out is refused in the same words `session.type` uses, so a caller
+    // scripting one pane gets one answer whichever command it reaches for. An unknown SPELLING cannot get
+    // here: the dispatcher parses `--pane` into `StatusPane` and rejects the rest.
+    func testPasteRejectsPanesTheSessionDoesNotHave() throws {
+        let (store, target) = try addSession()
+        let id = target.id.uuidString
+
+        XCTAssertEqual(server.pasteSession(id, window: nil, pane: .right).error, "session has no split pane")
+        XCTAssertEqual(server.pasteSession(id, window: nil, pane: .scratch).error,
+                       "session has no scratch terminal")
+        // with the split shown, `right` is a pane again: the refusal above was about the layout.
+        store.setSplitVisibility(target.id, shown: true)
+        _ = queuePane(in: target, split: true)
+        XCTAssertEqual(server.pasteSession(id, window: nil, pane: .right).error, "session not realized")
     }
 
     // `session.copy` is `session.selectall`'s documented read-back, so the pair has to name this state the

--- a/cookbook/annotate-claude-replies/README.md
+++ b/cookbook/annotate-claude-replies/README.md
@@ -110,7 +110,7 @@ An overlay's command runs through `sh -c` with the app's **GUI** `PATH`, which h
 
 `session overlay open --block` exits with the program's own status, so a non-zero code can equally mean agterm refused before revdiff ever ran. Reading only the code turns "overlay already open" into a meaningless "exited with 1", so the script reads the reply text as well.
 
-Putting the notes at the prompt needs `session paste`, because `session type` sends a real Return for every newline and multi-line text would submit itself line by line. `session paste` reads the system clipboard, so the script saves what is on it, pastes, and puts it back. It also has no `--pane` and always targets the session's main pane, so a note taken in a split or scratch pane falls back to typing a one-line pointer at the notes file instead.
+Putting the notes at the prompt needs `session paste`, because `session type` sends a real Return for every newline and multi-line text would submit itself line by line. `session paste` reads the system clipboard, so the script saves what is on it, pastes, and puts it back. The script calls it without `--pane`, so the paste targets the session's main pane, and a note taken in a split or scratch pane falls back to typing a one-line pointer at the notes file instead.
 
 ## Limits
 

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -326,7 +326,8 @@ omitted when expanded).
   keystroke does; another pane's glyph, an `active` one, and an empty payload are left alone.
 - `session copy` — print the session's selected text (does NOT touch the system clipboard).
 - `session paste` — paste the system clipboard into the session (the socket analogue of ⌘V; read it back with
-  `session text`).
+  `session text`). `--pane left|right|scratch` picks the pane, with the usual role and position aliases;
+  omitted is the main pane.
 - `session select-all` — select the session's entire terminal buffer (the socket analogue of ⌘A; read the
   selection back with `session copy`).
 - `session text [--all] [--lines N] [--pane left|right|scratch] [--pane-id TOKEN]`: print the session buffer

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -606,6 +606,15 @@ printf 'deploy staging' | pbcopy
 agtermctl session paste --target "$other"   # lands at the prompt, not submitted
 ```
 
+`--pane` picks which pane it lands in, so multi-line text can reach a split or the scratch terminal
+without `session type` submitting it line by line:
+
+```bash
+pbcopy < notes.md
+agtermctl session paste --pane right --target "$other"
+agtermctl session text --pane right --target "$other" --json | jq -r '.result.text' | tail -3
+```
+
 ## Read a session's buffer as text
 
 `session text` returns the terminal buffer as plain text in `result.text` — the visible screen by

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -450,10 +450,16 @@ error keeps those names for compatibility.
   selection → `no selection` error. Selection is readable on any realized session regardless of focus, but
   always from the main PANE — a selection made in a covering overlay is `session overlay copy`'s, not this
   command's. A never-shown session → `session not realized`, as with `session select-all`.
-- `session paste [--target] [--window W]` — paste the system clipboard (`NSPasteboard.general`) into the
-  session's main pane, the socket analogue of ⌘V / Edit ▸ Paste. Runs libghostty's `paste_from_clipboard`
-  (bracketed paste, no prompt), so the text lands at the prompt without auto-submitting. Read it back with
-  `session text`. A never-shown session → `session not realized`.
+- `session paste [--pane left|right|scratch] [--target] [--window W]` — paste the system clipboard
+  (`NSPasteboard.general`) into a pane of the session, the socket analogue of ⌘V / Edit ▸ Paste. Runs
+  libghostty's `paste_from_clipboard` (bracketed paste, no prompt), so the text lands at the prompt without
+  auto-submitting. `--pane` (canonical `left`|`right`|`scratch`; role and position aliases above are also
+  accepted) picks the pane: `right` is the split pane (`session has no split pane` when there is none),
+  `scratch` the scratch terminal even while hidden (`session has no scratch terminal` when none opened);
+  omitted and `left` are the main pane, which still reaches a promoted split survivor. An unparseable value
+  is `--pane must be left, right, or scratch`, rejected in the dispatcher so a raw socket client gets it too.
+  Read it back with `session text --pane` naming the same pane. A never-shown session →
+  `session not realized`.
 - `session select-all [--target] [--window W]` — select the session's entire terminal buffer (main pane),
   the socket analogue of ⌘A / Edit ▸ Select All (libghostty `select_all`). Read the resulting selection
   back with `session copy`. A never-shown session → `session not realized`.

--- a/site/commands.html
+++ b/site/commands.html
@@ -1109,17 +1109,24 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session paste [--target T] [--window W]
+                agtermctl session paste [--pane left|right|scratch] [--target T] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.paste</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
-                Paste the system clipboard into the session's main pane — the socket analogue of ⌘V / Edit ▸ Paste. It runs
+                Paste the system clipboard into a pane of the session — the socket analogue of ⌘V / Edit ▸ Paste. It runs
                 libghostty's <span style="font-family: &quot;JetBrains Mono&quot;, monospace">paste_from_clipboard</span> as a
                 bracketed paste with no prompt, so the text lands at the prompt <em>without auto-submitting</em>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                Read it back with <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session text</span>. A never-shown
-                session gives <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session not realized</span>.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--pane</span> picks the pane:
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">right</span> is the split pane,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">scratch</span> the scratch terminal even while hidden;
+                omitted is the main pane. The role and position aliases
+                (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">primary</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">top</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">bottom</span>)
+                are accepted too. Read it back with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session text --pane</span> naming the same
+                pane. A never-shown session gives <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session not realized</span>.
               </p>
             </div>
 


### PR DESCRIPTION
`session.paste` was main-pane only, while its documented read-back `session.text` takes `--pane`. So
scripting a split meant writing one pane and reading another, and multi-line text could not reach a
split or scratch pane: `session.type` sends a real Return per newline, which submits it line by line.

The repo already records the gap. `cookbook/annotate-claude-replies` falls back to typing a one-line
pointer at the notes file when the chord fires in a split or scratch pane, and its README says why:
"It also has no `--pane` and always targets the session's main pane".

**The shape**

`--pane` is parsed in the dispatcher, through the same `parsePane` that `session.status` and
`session.restore` use, and the app action takes the parsed `StatusPane`. Three consequences:

- the role and position aliases the shared `validatePaneArgument` already accepts now resolve, so
  `session paste --pane split` works. Worth knowing, and the reason I did it this way: they do not
  resolve on the surface I/O commands that match raw spellings in the app target. On master today
  `session text --pane split` validates and then answers `invalid pane: split`, and `session.type`
  and `font.*` carry the same switch. That is pre-existing and this PR leaves it alone. Happy to send
  the family fix separately.
- an unparseable value answers the pinned `--pane must be left, right, or scratch`, the same string
  the CLI throws, so a raw socket client running no `validate()` is answered identically.
- an unknown pane is unrepresentable in the app target, which is where the module boundary wants the
  parsing anyway.

A pane that parses but is not laid out is refused in `session.type`'s words: `session has no split
pane`, `session has no scratch terminal`.

Omitted keeps `addressableSurface`, so existing callers behave exactly as before and a promoted split
survivor is still reached. Without the flag the CLI sends no `args`, which is why the two existing CLI
tests for `session paste` pass unchanged.

**What it leaves alone**

- `session.selectall` shares the binding arm and stays main-only. Its read-back `session.copy` has no
  pane either, and the pair has to resolve one surface.
- No `--pane-id`. Among the surface I/O commands it is on `session.text` alone, and paste follows
  `session.type` and `font`, which take the role only.
- The cookbook recipe still calls paste without `--pane`. Switching it would raise the recipe's
  minimum agterm version to an unreleased one, and that number is yours to set. Its README sentence
  is corrected to describe the recipe rather than the API. Happy to send the recipe change as a
  follow-up.
- `CHANGELOG.md` untouched, per CONTRIBUTING.

**Verification**

`make test` 2954 tests, `make test-app` 469, `swiftlint --strict` clean.

Mutation check: with the action ignoring its `pane`, `testPasteIntoTheSplitExpeditesTheSplitPane` and
`testPasteRejectsPanesTheSessionDoesNotHave` fail. The split test needs the main slot filled to mean
anything, since `addressableSurface` is `surface ?? splitSurface`, and a fixture with only the split
filled grants the same spawn permit either way.

Live run against a Debug build of this branch in an isolated instance (`AGTERM_STATE_DIR` +
`AGTERM_CONTROL_SOCKET`), ending with a raw socket client so the CLI's `validate()` is out of the way:

```
--pane split -> ok: True        # answered `invalid pane: split` before this change
  PASS alias landed in the split
  PASS right landed
  PASS main landed
  PASS main free of the split markers
raw pane='other'  -> ok: False err: --pane must be left, right, or scratch
raw pane='bottom' -> ok: True
```

The pasted text sits at the target pane's prompt unsubmitted, which is what `session.paste` promises.
