### PR TITLE
fix(control): honour the pane aliases session.type, session.text and font accept

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -250,7 +250,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 
 - `session.type --pane` accepts `primary|left|top`, `split|right|bottom`, or `scratch`; omission defaults
   to primary for compatibility, not focused/on-screen. Read-back and the stable invalid-value error use
-  canonical `left|right|scratch` names.
+  canonical `left|right|scratch` names. The spelling is parsed ONCE, in the dispatcher, and the host takes
+  a `StatusPane`: `session.type`, `session.text` and `font.*` go through `parseSurfacePane`, so the aliases
+  resolve for a raw socket client too, and they keep their own `invalid pane: <value>` rejection while
+  `session.status`/`.restore` keep the pinned one. Never match a pane spelling in the app target.
   Hidden live scratch is addressable; missing panes error. Main alone bounded-polls (12 × 30ms) a newly
   unrealized session, with or without `select`, so `session.new --no-select` plus an immediate type does
   not race the mount+layout gap (#349). The probe precedes every sleep, so a realized session pays nothing

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -23,14 +23,13 @@ extension ControlServer {
     }
 
     /// Runs a font binding action (`font.inc`/`font.dec`/`font.reset`) on a pane of the target session; a
-    /// menu-driven change rides the same CELL_SIZE → persist path as the keybind. `pane` follows
-    /// `session.type`/`session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is the main pane
-    /// via `addressableSurface` (the pre-pane behavior, still reaching a promoted split survivor); `scratch`
-    /// is settable while hidden, its surface kept alive. An unknown value is rejected here as well as in the
-    /// CLI `validate()`, so a raw socket client can't bypass it, and a resolved-but-unrealized pane returns
-    /// `session not realized` rather than silently no-opping in the layout beat after the pane is shown.
+    /// menu-driven change rides the same CELL_SIZE → persist path as the keybind. `pane` arrives parsed by
+    /// the dispatcher, so no spelling reaches here: nil/`.left` is the main pane via `addressableSurface`
+    /// (the pre-pane behavior, still reaching a promoted split survivor); `.scratch` is settable while
+    /// hidden, its surface kept alive. A resolved-but-unrealized pane returns `session not realized` rather
+    /// than silently no-opping in the layout beat after the pane is shown.
     /// Only the surface currently in the main role persists its size; split-role and scratch changes stay live-only.
-    func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
+    func font(_ target: String?, window: String?, pane: StatusPane?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
             guard let session = store.session(withID: id) else {
@@ -38,20 +37,18 @@ extension ControlServer {
             }
             let chosen: (any TerminalSurface)?
             switch pane {
-            case nil, "left":
+            case nil, .left:
                 chosen = session.addressableSurface
-            case "right":
+            case .right:
                 guard let split = session.splitSurface else {
                     return ControlResponse(ok: false, error: "session has no split pane")
                 }
                 chosen = split
-            case "scratch":
+            case .scratch:
                 guard let scratch = session.scratchSurface else {
                     return ControlResponse(ok: false, error: "session has no scratch terminal")
                 }
                 chosen = scratch
-            case .some(let value):
-                return ControlResponse(ok: false, error: "invalid pane: \(value)")
             }
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
@@ -238,19 +235,17 @@ extension ControlServer {
                 // omitted = the ON-SCREEN surface (as `session.search` resolves it), never a pane hidden
                 // under the scratch.
                 chosen = session.onScreenSurface
-            case "left": chosen = session.surface
-            case "right":
+            case .left: chosen = session.surface
+            case .right:
                 guard let split = session.splitSurface else {
                     return ControlResponse(ok: false, error: "session has no split pane")
                 }
                 chosen = split
-            case "scratch":
+            case .scratch:
                 guard let scratch = session.scratchSurface else {
                     return ControlResponse(ok: false, error: "session has no scratch terminal")
                 }
                 chosen = scratch
-            // `session.text` accepts left|right|scratch, with no `other` toggle like `session.focus`.
-            case .some(let value): return ControlResponse(ok: false, error: "invalid pane: \(value)")
             }
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
@@ -272,8 +267,9 @@ extension ControlServer {
 
     /// A stable surface token wins over its baked role by resolving against the session's current slots.
     /// Empty or unknown tokens preserve the explicit pane fallback.
-    static func resolvedSessionTextPane(in session: Session, pane: String?, paneID: String?) -> String? {
-        paneID.flatMap { session.paneRole(forToken: $0)?.rawValue } ?? pane
+    static func resolvedSessionTextPane(in session: Session, pane: StatusPane?,
+                                        paneID: String?) -> StatusPane? {
+        paneID.flatMap { session.paneRole(forToken: $0) } ?? pane
     }
 
     /// Returns the addressed surface's zero-based cursor column. Takes `surface.zoom`'s target vocabulary —
@@ -481,11 +477,12 @@ extension ControlServer {
     /// previous session's auto-reset indicator, and rewrites recency. `quick.type` polls after `quick show`
     /// for the same reason. A call that succeeds on the first probe pays no wait at all; the sleeps below are
     /// only reached once that probe has already failed.
-    func injectText(_ text: String, into id: UUID, store: AppStore, select: Bool, pane: String?) async -> ControlResponse {
+    func injectText(_ text: String, into id: UUID, store: AppStore, select: Bool,
+                    pane: StatusPane?) async -> ControlResponse {
         switch pane {
-        case nil, "left":
+        case nil, .left:
             break
-        case "right":
+        case .right:
             guard let split = store.session(withID: id)?.splitSurface else {
                 return ControlResponse(ok: false, error: "session has no split pane")
             }
@@ -501,7 +498,7 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        case "scratch":
+        case .scratch:
             // as with `right`, a false `inject` (the ms after `session.scratch on`, before layout) reports
             // `session not realized` rather than silently dropping the keystrokes.
             guard let scratch = store.session(withID: id)?.scratchSurface else {
@@ -511,9 +508,6 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        // `session.type` accepts left|right|scratch, with no `other` toggle (mirroring `session.text`).
-        case .some(let value):
-            return ControlResponse(ok: false, error: "invalid pane: \(value)")
         }
         // main pane: inject if realized; a false return (view exists, libghostty surface not up yet) falls
         // through to the poll rather than returning a silent-drop false ok. This probe precedes the select

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -63,7 +63,7 @@ public protocol ControlActions {
     func readSurfaceCursor(_ target: String?, window: String?) -> ControlResponse
     func setDashboard(targets: [String], window: String?, close: Bool,
                       fontMode: DashboardFontMode, mru: Bool) -> ControlResponse
-    func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse
+    func font(_ target: String?, window: String?, pane: StatusPane?, action: String) -> ControlResponse
     func reloadKeymap() -> ControlResponse
     func listKeymap() -> ControlResponse
     func appIdentity() -> ControlResponse
@@ -475,6 +475,15 @@ public struct ControlDispatcher {
         parsePane(raw, error: "--pane must be left, right, or scratch") { StatusPane(controlName: $0) }
     }
 
+    /// The surface I/O selector (`session.type`, `session.text`, `font.*`). Same vocabulary as `parsePane`,
+    /// so the role and position aliases resolve, but the rejection keeps the per-command
+    /// `invalid pane: <value>` these three have answered since they shipped (#46, #90, #188) and which the
+    /// reference records as their difference from `session.status`/`.restore`. Unifying the wording is a
+    /// separate decision from parsing the value.
+    private func parseSurfacePane(_ raw: String?) -> PaneSelection<StatusPane> {
+        parsePane(raw, error: "invalid pane: \(raw ?? "")") { StatusPane(controlName: $0) }
+    }
+
     /// The `session.overlay.*` selector (`.open`/`.close`/`.result`/`.copy`/`.text`): absent keeps the
     /// session-wide overlay,
     /// `left`/`right` (and their `primary`/`split` aliases) scope to one pane, `scratch` is rejected — there
@@ -592,11 +601,16 @@ public struct ControlDispatcher {
                 return ControlResponse(ok: false, error: "session.type requires text")
             }
             if let rejection = nulRejection(text) { return rejection }
+            let pane: StatusPane?
+            switch parseSurfacePane(request.args?.pane) {
+            case .pane(let parsed): pane = parsed
+            case .rejected(let rejection): return rejection
+            }
             return await actions.typeSession(request.target, window: request.args?.window,
                                              options: ControlSessionTypeOptions(
                                                 text: text,
                                                 select: request.args?.select ?? false,
-                                                pane: request.args?.pane
+                                                pane: pane
                                              ))
         case .sessionCopy:
             return actions.copySessionSelection(request.target, window: request.args?.window)
@@ -685,14 +699,11 @@ public struct ControlDispatcher {
     private func dispatchAppCommand(_ request: ControlRequest) -> ControlResponse {
         switch request.cmd {
         case .fontInc:
-            return actions.font(request.target, window: request.args?.window,
-                                pane: request.args?.pane, action: "increase_font_size:1")
+            return dispatchFont(request, action: "increase_font_size:1")
         case .fontDec:
-            return actions.font(request.target, window: request.args?.window,
-                                pane: request.args?.pane, action: "decrease_font_size:1")
+            return dispatchFont(request, action: "decrease_font_size:1")
         case .fontReset:
-            return actions.font(request.target, window: request.args?.window,
-                                pane: request.args?.pane, action: "reset_font_size")
+            return dispatchFont(request, action: "reset_font_size")
         case .quick:
             return actions.setQuickTerminal(mode: request.args?.mode)
         case .keymapReload:
@@ -847,15 +858,29 @@ public struct ControlDispatcher {
         return .extent(all: all, lines: lines)
     }
 
+    /// The three `font.*` arms share one parse, so their pane vocabulary cannot drift apart.
+    private func dispatchFont(_ request: ControlRequest, action: String) -> ControlResponse {
+        switch parseSurfacePane(request.args?.pane) {
+        case .pane(let pane):
+            return actions.font(request.target, window: request.args?.window, pane: pane, action: action)
+        case .rejected(let rejection): return rejection
+        }
+    }
+
     private func dispatchSessionText(_ request: ControlRequest) -> ControlResponse {
         switch parseBufferExtent(request.args) {
         case .rejected(let response): return response
         case .extent(let all, let lines):
-            return actions.readSessionText(request.target, window: request.args?.window,
-                                           options: ControlSessionTextOptions(pane: request.args?.pane,
-                                                                              paneID: request.args?.paneID,
-                                                                              all: all,
-                                                                              lines: lines))
+            // the extent is checked first, so an `--all --lines` caller still gets that error before a pane one.
+            switch parseSurfacePane(request.args?.pane) {
+            case .rejected(let rejection): return rejection
+            case .pane(let pane):
+                return actions.readSessionText(request.target, window: request.args?.window,
+                                               options: ControlSessionTextOptions(pane: pane,
+                                                                                  paneID: request.args?.paneID,
+                                                                                  all: all,
+                                                                                  lines: lines))
+            }
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcherOptions.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcherOptions.swift
@@ -1,9 +1,11 @@
 public struct ControlSessionTypeOptions: Equatable, Sendable {
     public let text: String
     public let select: Bool
-    public let pane: String?
+    /// The parsed pane, nil for the main one. The dispatcher owns the spelling, so the role and position
+    /// aliases the CLI accepts resolve here rather than being matched again in the host.
+    public let pane: StatusPane?
 
-    public init(text: String, select: Bool, pane: String?) {
+    public init(text: String, select: Bool, pane: StatusPane?) {
         self.text = text
         self.select = select
         self.pane = pane
@@ -42,12 +44,13 @@ public struct ControlSessionBackgroundOptions: Equatable, Sendable {
 }
 
 public struct ControlSessionTextOptions: Equatable, Sendable {
-    public let pane: String?
+    /// The parsed pane, nil for the on-screen one. `paneID` still overrides it when the token resolves.
+    public let pane: StatusPane?
     public let paneID: String?
     public let all: Bool
     public let lines: Int?
 
-    public init(pane: String?, paneID: String? = nil, all: Bool, lines: Int?) {
+    public init(pane: StatusPane?, paneID: String? = nil, all: Bool, lines: Int?) {
         self.pane = pane
         self.paneID = paneID
         self.all = all
@@ -55,9 +58,9 @@ public struct ControlSessionTextOptions: Equatable, Sendable {
     }
 }
 
-/// `session.overlay.text`'s inputs. `pane` is the parsed `OverlayPane` rather than
-/// `ControlSessionTextOptions`' raw string: the overlay family takes only `left`/`right`, so the dispatcher
-/// resolves it and the host never re-parses a vocabulary it could widen by accident.
+/// `session.overlay.text`'s inputs. `pane` is an `OverlayPane` rather than `ControlSessionTextOptions`'
+/// `StatusPane`: the overlay family takes only `left`/`right`, `scratch` having no pane to cover. Both are
+/// parsed by the dispatcher, so the host never re-parses a vocabulary it could widen by accident.
 public struct ControlSessionOverlayTextOptions: Equatable, Sendable {
     public let pane: OverlayPane?
     public let all: Bool

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -739,10 +739,74 @@ struct ControlDispatcherTests {
                                                      args: ControlArgs(pane: "left")))
 
         #expect(actions.calls == [
-            .font(target: "session", window: nil, pane: "right", "decrease_font_size:1"),
-            .font(target: "session", window: "win", pane: "scratch", "increase_font_size:1"),
-            .font(target: "session", window: nil, pane: "left", "reset_font_size")
+            .font(target: "session", window: nil, pane: .right, "decrease_font_size:1"),
+            .font(target: "session", window: "win", pane: .scratch, "increase_font_size:1"),
+            .font(target: "session", window: nil, pane: .left, "reset_font_size")
         ])
+    }
+
+    // `validatePaneArgument` has always accepted the role and position aliases, but the app matched raw
+    // spellings, so `--pane split` validated on the client and then failed on the server. The parse lives in
+    // the dispatcher now, and these are the spellings it has to canonicalize for every pane-taking command.
+    @Test func paneTakingCommandsCanonicalizeTheAliases() async {
+        let aliases: [(String, StatusPane)] = [("left", .left), ("primary", .left), ("top", .left),
+                                               ("right", .right), ("split", .right), ("bottom", .right),
+                                               ("scratch", .scratch)]
+        for (spelling, expected) in aliases {
+            let actions = MockControlActions()
+            let dispatcher = ControlDispatcher(actions: actions)
+
+            _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionType, target: "s",
+                                                         args: ControlArgs(text: "x", pane: spelling)))
+            _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionText, target: "s",
+                                                         args: ControlArgs(pane: spelling)))
+            _ = await dispatcher.dispatch(ControlRequest(cmd: .fontInc, target: "s",
+                                                         args: ControlArgs(pane: spelling)))
+
+            #expect(actions.calls == [
+                .sessionType(target: "s", window: nil,
+                             ControlSessionTypeOptions(text: "x", select: false, pane: expected)),
+                .sessionText(target: "s", window: nil,
+                             ControlSessionTextOptions(pane: expected, all: false, lines: nil)),
+                .font(target: "s", window: nil, pane: expected, "increase_font_size:1")
+            ], "--pane \(spelling) must resolve to \(expected) on every command that takes it")
+        }
+    }
+
+    // a raw socket client runs no `validate()`, so the rejection is the dispatcher's. Parsing the value moved
+    // there, but the wording these three have answered since they shipped did not, so it stays
+    // `invalid pane: <value>` rather than `session.status`'s pinned string. The action must not be reached.
+    @Test func paneTakingCommandsRejectAnUnknownPaneWithoutCallingTheAction() async {
+        let requests: [ControlRequest] = [
+            ControlRequest(cmd: .sessionType, target: "s", args: ControlArgs(text: "x", pane: "middle")),
+            ControlRequest(cmd: .sessionText, target: "s", args: ControlArgs(pane: "middle")),
+            ControlRequest(cmd: .fontInc, target: "s", args: ControlArgs(pane: "middle")),
+            ControlRequest(cmd: .fontDec, target: "s", args: ControlArgs(pane: "middle")),
+            ControlRequest(cmd: .fontReset, target: "s", args: ControlArgs(pane: "middle"))
+        ]
+        for request in requests {
+            let actions = MockControlActions()
+            let dispatcher = ControlDispatcher(actions: actions)
+
+            let response = await dispatcher.dispatch(request)
+
+            #expect(response == ControlResponse(ok: false, error: "invalid pane: middle"),
+                    "\(request.cmd.rawValue) must answer its own pane rejection")
+            #expect(actions.calls.isEmpty, "\(request.cmd.rawValue) must not reach the action")
+        }
+    }
+
+    // the extent is parsed before the pane, so adding a pane error to an already-bad extent must not change
+    // which error a caller sees first. `session.overlay.text` pins the same order.
+    @Test func sessionTextReportsAnExtentErrorBeforeAPaneOne() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionText, target: "s", args: ControlArgs(pane: "middle", all: true, lines: 5)))
+
+        #expect(response == ControlResponse(ok: false, error: "use either --all or --lines, not both"))
+        #expect(actions.calls.isEmpty)
     }
 
     @Test func keymapAndConfigReloadWrapDiagnosticCounts() async {
@@ -926,7 +990,7 @@ struct ControlDispatcherTests {
         #expect(response == ControlResponse(ok: false, error: "session not realized"))
         #expect(actions.calls == [
             .sessionType(target: "session", window: "win",
-                         ControlSessionTypeOptions(text: "ls\n", select: true, pane: "scratch"))
+                         ControlSessionTypeOptions(text: "ls\n", select: true, pane: .scratch))
         ])
     }
 
@@ -1109,7 +1173,7 @@ struct ControlDispatcherTests {
         #expect(response == ControlResponse(ok: true, result: ControlResult(text: "line\n")))
         #expect(actions.calls == [
             .sessionText(target: "session", window: "win",
-                         ControlSessionTextOptions(pane: "scratch", paneID: "stable-token",
+                         ControlSessionTextOptions(pane: .scratch, paneID: "stable-token",
                                                    all: false, lines: 10))
         ])
     }

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -44,7 +44,7 @@ final class MockControlActions: ControlActions {
         case surfaceZoom(target: String?, window: String?, ControlToggleMode)
         case surfaceCursor(target: String?, window: String?)
         case dashboard(targets: [String], window: String?, close: Bool, fontMode: DashboardFontMode, mru: Bool)
-        case font(target: String?, window: String?, pane: String?, String)
+        case font(target: String?, window: String?, pane: StatusPane?, String)
         case keymapReload
         case keymapList
         case version
@@ -369,7 +369,7 @@ final class MockControlActions: ControlActions {
         return nextDashboardResponse
     }
 
-    func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
+    func font(_ target: String?, window: String?, pane: StatusPane?, action: String) -> ControlResponse {
         calls.append(.font(target: target, window: window, pane: pane, action))
         return nextFontResponse
     }

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -325,9 +325,9 @@ final class ControlServerSessionActionsTests: XCTestCase {
         let queued = queuePane(in: target, split: true)
         let (_, bare) = try addSession()
 
-        let shown = await server.injectText("ls\n", into: target.id, store: store, select: false, pane: "right")
+        let shown = await server.injectText("ls\n", into: target.id, store: store, select: false, pane: .right)
         let started = Date()
-        let absent = await server.injectText("ls\n", into: bare.id, store: store, select: false, pane: "right")
+        let absent = await server.injectText("ls\n", into: bare.id, store: store, select: false, pane: .right)
 
         XCTAssertEqual(shown.error, "session not realized")
         XCTAssertTrue(queued.granted)
@@ -350,7 +350,7 @@ final class ControlServerSessionActionsTests: XCTestCase {
             ("session.paste", false, { self.server.pasteSession($0.id.uuidString, window: nil) }),
             ("session.selectall", false, { self.server.selectAllSession($0.id.uuidString, window: nil) }),
             ("font.inc left", false, { self.server.font($0.id.uuidString, window: nil, pane: nil, action: "increase_font_size:1") }),
-            ("font.inc right", true, { self.server.font($0.id.uuidString, window: nil, pane: "right", action: "increase_font_size:1") }),
+            ("font.inc right", true, { self.server.font($0.id.uuidString, window: nil, pane: .right, action: "increase_font_size:1") }),
         ]
         for testCase in cases {
             let (store, target) = try addSession()
@@ -391,10 +391,10 @@ final class ControlServerSessionActionsTests: XCTestCase {
                                                   env: ["AGTERM_PANE_ID": "right-token"])
         session.hasSplit = true
 
-        XCTAssertEqual(ControlServer.resolvedSessionTextPane(in: session, pane: "left", paneID: "right-token"),
-                       "right")
-        XCTAssertEqual(ControlServer.resolvedSessionTextPane(in: session, pane: "scratch", paneID: "unknown"),
-                       "scratch", "an unknown token falls back to the explicit role")
+        XCTAssertEqual(ControlServer.resolvedSessionTextPane(in: session, pane: .left, paneID: "right-token"),
+                       .right)
+        XCTAssertEqual(ControlServer.resolvedSessionTextPane(in: session, pane: .scratch, paneID: "unknown"),
+                       .scratch, "an unknown token falls back to the explicit role")
     }
 
     func testTextPaneIDFollowsItsSurfaceAfterSwap() throws {
@@ -409,8 +409,8 @@ final class ControlServerSessionActionsTests: XCTestCase {
 
         XCTAssertNil(store.swapPanes(session.id))
 
-        XCTAssertEqual(ControlServer.resolvedSessionTextPane(in: session, pane: "left", paneID: "moving-token"),
-                       "right")
+        XCTAssertEqual(ControlServer.resolvedSessionTextPane(in: session, pane: .left, paneID: "moving-token"),
+                       .right)
     }
 
     // the same parked pane, one command over: `surfaceBindingAction`'s cast proves only that the SLOT is

--- a/agtermUITests/FontPaneUITests.swift
+++ b/agtermUITests/FontPaneUITests.swift
@@ -71,10 +71,18 @@ final class FontPaneUITests: ControlAPITestCase {
                        "should report no scratch terminal: \(response)")
     }
 
+    // the parse moved to the dispatcher, so this now answers before the app is reached — with the same
+    // wording, which is the point: a raw socket client runs no `validate()` and must see no change.
     func testFontRejectsInvalidPaneServerSide() throws {
         let response = try sendCommand(#"{"cmd":"font.dec","target":"active","args":{"pane":"middle"}}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "font pane:middle should fail server-side: \(response)")
         XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
+    }
+
+    // the aliases `validatePaneArgument` accepts used to validate on the client and then fail on the server.
+    func testFontAcceptsAPaneAlias() throws {
+        let response = try sendCommand(#"{"cmd":"font.reset","target":"active","args":{"pane":"primary"}}"#)
+        XCTAssertEqual(response["ok"] as? Bool, true, "font --pane primary should reach the main pane: \(response)")
     }
 
     // when the primary pane's shell exits, closePrimaryPane moves the split survivor into `surface` and nils

--- a/agtermUITests/SessionTypePaneUITests.swift
+++ b/agtermUITests/SessionTypePaneUITests.swift
@@ -48,9 +48,18 @@ final class SessionTypePaneUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
     }
 
+    // the parse moved to the dispatcher, so this now answers before the app is reached — with the same
+    // wording, which is the point: a raw socket client runs no `validate()` and must see no change.
     func testSessionTypeRejectsInvalidPaneServerSide() throws {
         let response = try sendCommand(#"{"cmd":"session.type","target":"active","args":{"text":"x","pane":"middle"}}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "session.type pane:middle should fail server-side: \(response)")
         XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
+    }
+
+    // the aliases `validatePaneArgument` accepts used to validate on the client and then fail on the server.
+    func testSessionTypeAcceptsAPaneAlias() throws {
+        let response = try sendCommand(typeRequest(text: "echo alias\n", target: "active", select: false,
+                                                   pane: "primary"))
+        XCTAssertEqual(response["ok"] as? Bool, true, "session.type --pane primary should reach main: \(response)")
     }
 }

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -438,7 +438,8 @@ error keeps those names for compatibility.
   `--pane left` types into the main pane (the default when omitted), `--pane right` into the split pane
   (errors with `session has no split pane` when the session has no split), `--pane scratch` into the
   session's scratch terminal even while it is hidden (`session has no scratch terminal` when none opened);
-  like `session text`, no `other` value. `--select` realizes the MAIN pane only — a split pane must
+  the role and position aliases (`primary`/`top`, `split`/`bottom`) resolve to the same panes; like
+  `session text`, no `other` value. `--select` realizes the MAIN pane only — a split pane must
   already exist. Also like `session text`, there is no overlay value: every `--pane` types into the surface
   UNDER a covering overlay, so the keystrokes reach the hidden shell and run there unseen until the overlay
   closes — the call still answers `ok`. That is deliberate: the panes stay drivable whatever is drawn over
@@ -464,7 +465,8 @@ error keeps those names for compatibility.
   are mutually exclusive and `--lines` must be > 0 — enforced server-side too). `--pane left` reads the
   main pane, `--pane right` the split pane (errors if the session has no split), `--pane scratch` the
   session's scratch terminal even while it is hidden (its buffer is kept alive; `session has no scratch
-  terminal` when none opened); omit `--pane` for the visible pane (the scratch terminal when it covers the
+  terminal` when none opened); the role and position aliases (`primary`/`top`, `split`/`bottom`) resolve to
+  the same panes; omit `--pane` for the visible pane (the scratch terminal when it covers the
   session, else the focused pane). `--pane-id` accepts the shell's stable `$AGTERM_PANE_ID`, resolves its
   current live slot and overrides `--pane` when found. An absent or unknown token falls back to `--pane`,
   then to the visible pane. Use it for a long-running watcher because `$AGTERM_PANE` is a spawn role and can
@@ -1101,7 +1103,8 @@ attention list, the title-bar bell, and attention navigation (`session go --to n
 reset the font size of a session pane. `--pane` picks which surface's font to change, like `session type`
 and `session text`: omitted or `left` is the main pane, `right` the split pane (errors with `session has
 no split pane` when the session has no split), `scratch` the session's scratch terminal (settable even
-while hidden). No `other` value. Only the MAIN pane's size is persisted across relaunch; a split/scratch
+while hidden). The role and position aliases (`primary`/`top`, `split`/`bottom`) resolve to the same panes.
+No `other` value. Only the MAIN pane's size is persisted across relaunch; a split/scratch
 pane's font change is live-only, matching a GUI cmd +/- on those panes. Read the resulting size back from
 `tree` — `fontSize` (main), `splitFontSize`, `scratchFontSize`, each in points and omitted when that pane
 isn't realized.


### PR DESCRIPTION
`.claude/rules/control-api.md:251` says `session.type --pane` accepts `primary|left|top`,
`split|right|bottom` or `scratch`, and the shared CLI `validatePaneArgument` does accept all of them.
The app then matched raw spellings, so an alias passed `validate()` on the client and was refused by
the server. Against the installed 0.26.0:

```
agtermctl session text --pane right   -> ok
agtermctl session text --pane split   -> invalid pane: split
agtermctl session text --pane bottom  -> invalid pane: bottom
agtermctl session text --pane primary -> invalid pane: primary
```

The same on `session.type` and on `font.inc`/`font.dec`/`font.reset`. `session.status` and
`session.restore` were never affected: they already parse the spelling in the dispatcher.

**The fix**

The spelling is parsed once, in the dispatcher, and the host actions take a `StatusPane`. Three
consequences past the aliases resolving:

- an unknown pane is unrepresentable in the app target, which is where the module boundary wants the
  parsing anyway. Three hand-rolled string switches lose their `invalid pane` arm.
- the aliases resolve for a raw socket client too, not only for callers coming through the CLI.
- the three `font.*` arms share one parse rather than three copies of the argument.

`session.text` keeps checking the extent before the pane, so `--all --lines` still reports the extent
error first. A test pins that ordering.

**Nothing else changes on the wire**

These three keep the `invalid pane: <value>` rejection they have answered since they shipped (#46,
#90, #188). `parseSurfacePane` carries that wording; `parsePane` keeps `session.status`'s pinned
`--pane must be left, right, or scratch`. I first unified them and backed that out: the reference
records the divergence deliberately, and it was written into it by `76c5f4b`, the commit that
introduced the pinned string for `session.status` in the first place. Unifying is a separate decision
and yours to make, not a side effect of parsing the value. The two UI tests that pin the wording are
unchanged except for one added alias case each.

**Verification**

`swift test` 2950 tests, `make test-app` 467, `swiftlint --strict` clean. Three new dispatcher tests
cover the seven spellings across `session.type`, `session.text` and `font.inc`, the rejection on all
five commands with the action never reached, and the extent-before-pane ordering.

Mutation matrix over the four behaviours, each caught by the test that should catch it and no others:

| mutation | alias test | rejection test | ordering test |
|---|---|---|---|
| `session.type` ignores the parsed pane | fails | passes | passes |
| `session.text` ignores the parsed pane | fails | passes | passes |
| `font.*` stops rejecting an unknown pane | fails | fails | passes |
| `session.text` parses the pane before the extent | passes | passes | fails |

Live run against a Debug build of this branch in an isolated instance (`AGTERM_STATE_DIR` +
`AGTERM_CONTROL_SOCKET`), ending with a raw socket client so the CLI's `validate()` is out of the way:

```
session text --pane split   -> ok: True
session type --pane split   -> ok: True
font inc --pane primary     -> ok: True
  PASS the typed text ran in the split

session.type   pane=middle  -> ok: False err: invalid pane: middle
session.text   pane=bottom  -> ok: True
font.reset     pane=middle  -> ok: False err: invalid pane: middle
session.text   pane=middle  -> ok: False err: invalid pane: middle
```

The `agtermUITests` suite is not run by CI and I have no way to execute it here, so its two edits are
read-only-verified: an added alias case each, and their existing rejection assertions untouched.

**Note on #529**

This touches `ControlDispatcher.swift` and `ControlServer+SurfaceIO.swift`, which #529
(`session.paste --pane`) also touches. Both branch off master; I will rebase whichever is second.
#529 already parses its own pane in the dispatcher, so after a rebase it joins `parseSurfacePane` or
keeps the pinned string, whichever you prefer. Its `--pane` is new, so no caller depends on either.
