### PR TITLE
fix(zmx): run a fresh live command as a create-only payload

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -637,9 +637,8 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         }
         // restore-running-command: feed the captured command line to the login shell as if typed, so it re-runs
         // and exits back to a prompt. Ordinary command surfaces keep the fields mutually exclusive because a
-        // command REPLACES the shell. A zmx-backed surface is the exception: its command is the attach client, and
-        // libghostty's initial input is what that client forwards into the daemon-side shell.
-        if command == nil || backedByZmx, let initialInput, let p = strdup(initialInput) {
+        // command REPLACES the shell.
+        if command == nil, let initialInput, let p = strdup(initialInput) {
             configCStrings.append(p)
             config.initial_input = UnsafePointer(p)
         }

--- a/agterm/Ghostty/LaunchSeed.swift
+++ b/agterm/Ghostty/LaunchSeed.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// What a pane spawns with: the exec `command`, the `initialInput` typed into a login shell, and whether a
 /// command's exit holds on libghostty's "press any key" prompt. `command` and `initialInput` are mutually
-/// exclusive except on a zmx-backed pane, whose command is the attach client.
+/// exclusive.
 struct LaunchSeed: Equatable {
     let command: String?
     let initialInput: String?

--- a/agterm/Ghostty/ZmxLaunch.swift
+++ b/agterm/Ghostty/ZmxLaunch.swift
@@ -94,21 +94,18 @@ enum ZmxLaunch {
                             denylist: Set<String>) -> SurfaceSeed? {
         guard case .wrapped(let configuration) = disposition else { return nil }
         let replay = session.takePendingForegroundCommand(pane: pane)
-        let creationCommand: String? = if session.wasRestored, replay == nil {
+        let creationCommand: String? = if replay == nil {
             switch pane {
             case .left: session.initialCommand
             case .right: session.splitInitialCommand
             case .scratch: nil
             }
         } else { nil }
-        let initialInput = pane == .left && !session.wasRestored
-            ? session.initialCommand.map { $0 + "\n" }
-            : nil
         return SurfaceSeed(
             command: ZmxSupport.attachCommand(
                 configuration, replaying: replay, creationCommand: creationCommand, denylist: denylist
             ),
-            initialInput: initialInput
+            initialInput: nil
         )
     }
 

--- a/agtermTests/SurfaceFactorySeedTests.swift
+++ b/agtermTests/SurfaceFactorySeedTests.swift
@@ -129,7 +129,7 @@ final class SurfaceFactorySeedTests: XCTestCase {
         }
     }
 
-    func testFreshWrappedPrimaryKeepsCreationInput() throws {
+    func testFreshWrappedPrimaryUsesCreateOnlyPayload() throws {
         let session = Session(initialCwd: "/tmp")
         session.initialCommand = "ssh example"
 
@@ -137,8 +137,24 @@ final class SurfaceFactorySeedTests: XCTestCase {
             disposition: .wrapped(configuration), session: session, pane: .left, denylist: []
         ))
 
-        XCTAssertEqual(seed.command, configuration.command)
-        XCTAssertEqual(seed.initialInput, "ssh example\n")
+        XCTAssertEqual(seed.command, ZmxSupport.attachCommand(
+            configuration, replaying: nil, creationCommand: "ssh example", denylist: []
+        ))
+        XCTAssertNil(seed.initialInput)
+    }
+
+    func testFreshWrappedSplitUsesCreateOnlyPayload() throws {
+        let session = Session(initialCwd: "/tmp")
+        session.splitInitialCommand = "watch date"
+
+        let seed = try XCTUnwrap(ZmxLaunch.surfaceSeed(
+            disposition: .wrapped(configuration), session: session, pane: .right, denylist: []
+        ))
+
+        XCTAssertEqual(seed.command, ZmxSupport.attachCommand(
+            configuration, replaying: nil, creationCommand: "watch date", denylist: []
+        ))
+        XCTAssertNil(seed.initialInput)
     }
 
     // MARK: - factory wiring

--- a/agtermUITests/ZmxLiveUITests.swift
+++ b/agtermUITests/ZmxLiveUITests.swift
@@ -59,18 +59,23 @@ final class ZmxLiveUITests: ControlAPITestCase {
     }
 
     private struct DaemonRow {
+        /// Mirrors ZmxDaemonObservation and ZmxDaemonState. Parsing through them rather than raw strings
+        /// is what makes a renamed value fail the reap instead of silently reading as not alive.
+        enum Observation: String { case running, unreadable, absent }
+        enum State: String { case claimed, orphan, unknown, conflicted, pendingClose, foreign }
+
         let daemon: String
-        let observation: String
-        let state: String
+        let observation: Observation
+        let state: State
         let sessionID: String?
         let pane: String?
 
-        var isAlive: Bool { observation == "running" || observation == "unreadable" }
+        var isAlive: Bool { observation == .running || observation == .unreadable }
 
         /// `ControlZmxError.killRefusal` accepts only a running, claimed row, so anything else is
         /// unreapable and belongs in the report rather than in a kill that is certain to be refused.
         var killTarget: (sessionID: String, pane: String)? {
-            guard observation == "running", state == "claimed", let sessionID, let pane else { return nil }
+            guard observation == .running, state == .claimed, let sessionID, let pane else { return nil }
             return (sessionID, pane)
         }
     }
@@ -111,7 +116,7 @@ final class ZmxLiveUITests: ControlAPITestCase {
             remaining = try daemonRows("zmx.list after cleanup", namespace: namespace).filter(\.isAlive)
         }
         guard remaining.isEmpty else {
-            let names = remaining.map { "\($0.daemon) (\($0.state)/\($0.observation))" }.joined(separator: ", ")
+            let names = remaining.map { "\($0.daemon) (\($0.state.rawValue)/\($0.observation.rawValue))" }.joined(separator: ", ")
             let errors = killErrors.isEmpty ? "" : "; kill errors: " + killErrors.joined(separator: ", ")
             throw cleanupFailure("daemons still alive after zmx.kill: \(names)\(errors)")
         }
@@ -133,12 +138,25 @@ final class ZmxLiveUITests: ControlAPITestCase {
               endpoint["socketDirectory"] as? String == namespace else {
             throw cleanupFailure("\(context): the endpoint is not this test's namespace")
         }
-        return (zmx["entries"] as? [[String: Any]] ?? []).map { entry in
-            DaemonRow(daemon: entry["daemon"] as? String ?? "?",
-                      observation: entry["observation"] as? String ?? "",
-                      state: entry["state"] as? String ?? "",
-                      sessionID: entry["sessionID"] as? String,
-                      pane: entry["pane"] as? String)
+        guard let entries = zmx["entries"] as? [[String: Any]] else {
+            throw cleanupFailure("\(context): the inventory carries no entries array")
+        }
+        return try entries.map { entry in
+            guard let daemon = entry["daemon"] as? String, let rawObservation = entry["observation"] as? String,
+                  let rawState = entry["state"] as? String else {
+                throw cleanupFailure("\(context): an entry lacks daemon, observation or state: \(entry)")
+            }
+            guard let observation = DaemonRow.Observation(rawValue: rawObservation),
+                  let state = DaemonRow.State(rawValue: rawState) else {
+                throw cleanupFailure("\(context): \(daemon) reports observation \(rawObservation) and state "
+                    + "\(rawState), one of which this test does not know")
+            }
+            let sessionID = entry["sessionID"] as? String
+            let pane = entry["pane"] as? String
+            guard state != .claimed || (sessionID != nil && pane != nil) else {
+                throw cleanupFailure("\(context): claimed daemon \(daemon) carries no sessionID or pane")
+            }
+            return DaemonRow(daemon: daemon, observation: observation, state: state, sessionID: sessionID, pane: pane)
         }
     }
 

--- a/agtermUITests/ZmxLiveUITests.swift
+++ b/agtermUITests/ZmxLiveUITests.swift
@@ -15,7 +15,7 @@ final class ZmxLiveUITests: ControlAPITestCase {
         if let cleanupError { throw cleanupError }
     }
 
-    func testBundledZmxBacksPrimaryAndSplitAndTypesInitialCommandOnce() throws {
+    func testBundledZmxBacksPrimaryAndSplitAndRunsLongCreationCommandOnce() throws {
         let sessionID = try activeSessionID()
         XCTAssertTrue(poll(until: self.isBacked(sessionID, expectedPanes: ["left"]), timeout: 20),
                       "the primary pane should report real zmx backing")
@@ -26,18 +26,21 @@ final class ZmxLiveUITests: ControlAPITestCase {
         XCTAssertTrue(poll(until: self.isBacked(sessionID, expectedPanes: ["left", "right"]), timeout: 20),
                       "both panes and the session aggregate should report zmx backing")
 
-        let marker = stateDir.appendingPathComponent("initial-input.txt")
+        let marker = stateDir.appendingPathComponent("creation-command.txt")
+        let padding = String(repeating: "x", count: 2_048)
+        let command = "payload='\(padding)'; printf x >> '\(marker.path)'"
+        XCTAssertGreaterThan(command.utf8.count, 1_024)
         let request = try JSONSerialization.data(withJSONObject: [
             "cmd": "session.new",
-            "args": ["command": "printf x >> \(marker.path)"],
+            "args": ["command": command],
         ])
         let created = try sendCommand(String(decoding: request, as: UTF8.self))
         XCTAssertEqual(created["ok"] as? Bool, true)
         XCTAssertTrue(poll(until: (try? String(contentsOf: marker, encoding: .utf8)) == "x", timeout: 20),
-                      "initial_input should reach the daemon shell")
+                      "the create-only payload should bypass the pty input cap")
         RunLoop.current.run(until: Date().addingTimeInterval(1))
         XCTAssertEqual(try String(contentsOf: marker, encoding: .utf8), "x",
-                       "initial_input must be delivered exactly once")
+                       "the create-only payload must run exactly once")
     }
 
     private func isBacked(_ sessionID: String, expectedPanes: Set<String>) -> Bool {

--- a/agtermUITests/ZmxLiveUITests.swift
+++ b/agtermUITests/ZmxLiveUITests.swift
@@ -58,9 +58,21 @@ final class ZmxLiveUITests: ControlAPITestCase {
         return expectedPanes.isSubset(of: backed)
     }
 
-    private struct PaneDaemon {
-        let sessionID: String
-        let pane: String
+    private struct DaemonRow {
+        let daemon: String
+        let observation: String
+        let state: String
+        let sessionID: String?
+        let pane: String?
+
+        var isAlive: Bool { observation == "running" || observation == "unreadable" }
+
+        /// `ControlZmxError.killRefusal` accepts only a running, claimed row, so anything else is
+        /// unreapable and belongs in the report rather than in a kill that is certain to be refused.
+        var killTarget: (sessionID: String, pane: String)? {
+            guard observation == "running", state == "claimed", let sessionID, let pane else { return nil }
+            return (sessionID, pane)
+        }
     }
 
     /// Ends this run's daemons through the app's own `zmx.kill` instead of signalling them from the test
@@ -75,35 +87,40 @@ final class ZmxLiveUITests: ControlAPITestCase {
             throw cleanupFailure("refusing to reap: the test namespace resolved to the default one")
         }
 
-        // right before left: the split attached through the session the primary's daemon leads
-        for daemon in try liveDaemons("zmx.list before cleanup", namespace: namespace)
-            .sorted(by: { $0.pane > $1.pane }) {
+        var killErrors: [String] = []
+        // right before left: killing the primary promotes the split, since closePrimaryPane assigns
+        // paneIdentity from splitPaneIdentity, so a right entry captured before that stops resolving
+        let alive = try daemonRows("zmx.list before cleanup", namespace: namespace).filter(\.isAlive)
+        for row in alive.sorted(by: { ($0.pane ?? "") > ($1.pane ?? "") }) {
+            guard let target = row.killTarget else { continue }
             let request = try JSONSerialization.data(withJSONObject: [
                 "cmd": "zmx.kill",
-                "target": daemon.sessionID,
-                "args": ["pane": daemon.pane, "force": true],
+                "target": target.sessionID,
+                "args": ["pane": target.pane, "force": true],
             ])
             let response = try sendCommand(String(decoding: request, as: UTF8.self))
-            guard response["ok"] as? Bool == true else {
-                throw cleanupFailure("zmx.kill \(daemon.sessionID):\(daemon.pane) refused: \(response)")
+            if response["ok"] as? Bool != true {
+                killErrors.append("\(row.daemon): \(response["error"] ?? response)")
             }
         }
 
-        var remaining = try liveDaemons("zmx.list after cleanup", namespace: namespace)
+        var remaining = try daemonRows("zmx.list after cleanup", namespace: namespace).filter(\.isAlive)
         let deadline = Date().addingTimeInterval(20)
         while !remaining.isEmpty, Date() < deadline {
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-            remaining = try liveDaemons("zmx.list after cleanup", namespace: namespace)
+            remaining = try daemonRows("zmx.list after cleanup", namespace: namespace).filter(\.isAlive)
         }
         guard remaining.isEmpty else {
-            throw cleanupFailure("\(remaining.count) daemon(s) still running after zmx.kill")
+            let names = remaining.map { "\($0.daemon) (\($0.state)/\($0.observation))" }.joined(separator: ", ")
+            let errors = killErrors.isEmpty ? "" : "; kill errors: " + killErrors.joined(separator: ", ")
+            throw cleanupFailure("daemons still alive after zmx.kill: \(names)\(errors)")
         }
     }
 
-    /// The running daemons this test owns. Fails closed rather than reaping anything it cannot name: an
-    /// incomplete inventory, an endpoint outside this test's namespace, or a running row that is not a
-    /// claimed pane all abort the cleanup instead of widening it.
-    private func liveDaemons(_ context: String, namespace: String) throws -> [PaneDaemon] {
+    /// Every daemon in this test's namespace. The endpoint and inventory checks are the safety boundary
+    /// and still fail closed; past them a row is reported rather than dropped, so an unreapable daemon
+    /// surfaces in the post-kill deadline instead of being filtered out of both passes.
+    private func daemonRows(_ context: String, namespace: String) throws -> [DaemonRow] {
         let response = try sendCommand(#"{"cmd":"zmx.list"}"#)
         guard response["ok"] as? Bool == true,
               let zmx = (response["result"] as? [String: Any])?["zmx"] as? [String: Any] else {
@@ -116,16 +133,13 @@ final class ZmxLiveUITests: ControlAPITestCase {
               endpoint["socketDirectory"] as? String == namespace else {
             throw cleanupFailure("\(context): the endpoint is not this test's namespace")
         }
-        return try (zmx["entries"] as? [[String: Any]] ?? [])
-            .filter { $0["observation"] as? String == "running" }
-            .map { entry in
-                guard entry["state"] as? String == "claimed",
-                      let sessionID = entry["sessionID"] as? String,
-                      let pane = entry["pane"] as? String else {
-                    throw cleanupFailure("\(context): running daemon \(entry["daemon"] ?? "?") is unclaimed")
-                }
-                return PaneDaemon(sessionID: sessionID, pane: pane)
-            }
+        return (zmx["entries"] as? [[String: Any]] ?? []).map { entry in
+            DaemonRow(daemon: entry["daemon"] as? String ?? "?",
+                      observation: entry["observation"] as? String ?? "",
+                      state: entry["state"] as? String ?? "",
+                      sessionID: entry["sessionID"] as? String,
+                      pane: entry["pane"] as? String)
+        }
     }
 
     private func cleanupFailure(_ message: String) -> Error {

--- a/agtermUITests/ZmxLiveUITests.swift
+++ b/agtermUITests/ZmxLiveUITests.swift
@@ -8,9 +8,9 @@ final class ZmxLiveUITests: ControlAPITestCase {
     override var enablesZmxForUITest: Bool { true }
 
     override func tearDown() async throws {
-        app?.terminate()
         var cleanupError: Error?
-        do { try killTestDaemons() } catch { cleanupError = error }
+        do { try reapTestDaemons() } catch { cleanupError = error }
+        app?.terminate()
         try await super.tearDown()
         if let cleanupError { throw cleanupError }
     }
@@ -58,48 +58,77 @@ final class ZmxLiveUITests: ControlAPITestCase {
         return expectedPanes.isSubset(of: backed)
     }
 
-    private func killTestDaemons() throws {
+    private struct PaneDaemon {
+        let sessionID: String
+        let pane: String
+    }
+
+    /// Ends this run's daemons through the app's own `zmx.kill` instead of signalling them from the test
+    /// runner, which cannot signal what the app spawned: zmx reports that `kill(2)` EPERM as
+    /// `PermissionDenied` and every run leaks its daemons. `session.close` is not a substitute because
+    /// `paneFinalizer` discards the kill result, so it can drop the model while the daemon survives.
+    private func reapTestDaemons() throws {
         guard let stateDir else { return }
-        let zmxDir = ZmxSupport.socketDirectory(forStateDirectory: stateDir.path)
-        let names = try runZmx(["ls", "--short"], directory: zmxDir)
-            .split(whereSeparator: \.isNewline).map(String.init).filter { !$0.isEmpty }
-        guard !names.isEmpty else { return }
-        _ = try runZmx(["kill"] + names + ["--force"], directory: zmxDir)
+        let namespace = ZmxSupport.socketDirectory(forStateDirectory: stateDir.path)
+        let dailyDriver = ZmxSupport.socketDirectory(forStateDirectory: PersistenceStore.defaultDirectory.path)
+        guard namespace != dailyDriver else {
+            throw cleanupFailure("refusing to reap: the test namespace resolved to the default one")
+        }
+
+        // right before left: the split attached through the session the primary's daemon leads
+        for daemon in try liveDaemons("zmx.list before cleanup", namespace: namespace)
+            .sorted(by: { $0.pane > $1.pane }) {
+            let request = try JSONSerialization.data(withJSONObject: [
+                "cmd": "zmx.kill",
+                "target": daemon.sessionID,
+                "args": ["pane": daemon.pane, "force": true],
+            ])
+            let response = try sendCommand(String(decoding: request, as: UTF8.self))
+            guard response["ok"] as? Bool == true else {
+                throw cleanupFailure("zmx.kill \(daemon.sessionID):\(daemon.pane) refused: \(response)")
+            }
+        }
+
+        var remaining = try liveDaemons("zmx.list after cleanup", namespace: namespace)
+        let deadline = Date().addingTimeInterval(20)
+        while !remaining.isEmpty, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            remaining = try liveDaemons("zmx.list after cleanup", namespace: namespace)
+        }
+        guard remaining.isEmpty else {
+            throw cleanupFailure("\(remaining.count) daemon(s) still running after zmx.kill")
+        }
     }
 
-    private func runZmx(_ arguments: [String], directory: String) throws -> String {
-        let process = Process()
-        process.executableURL = try zmxURL()
-        process.arguments = arguments
-        var environment = ProcessInfo.processInfo.environment
-        environment["ZMX_DIR"] = directory
-        process.environment = environment
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = output
-        try process.run()
-        process.waitUntilExit()
-        let text = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
-        guard process.terminationStatus == 0 else {
-            throw NSError(domain: "ZmxLiveUITests", code: Int(process.terminationStatus),
-                          userInfo: [NSLocalizedDescriptionKey: text])
+    /// The running daemons this test owns. Fails closed rather than reaping anything it cannot name: an
+    /// incomplete inventory, an endpoint outside this test's namespace, or a running row that is not a
+    /// claimed pane all abort the cleanup instead of widening it.
+    private func liveDaemons(_ context: String, namespace: String) throws -> [PaneDaemon] {
+        let response = try sendCommand(#"{"cmd":"zmx.list"}"#)
+        guard response["ok"] as? Bool == true,
+              let zmx = (response["result"] as? [String: Any])?["zmx"] as? [String: Any] else {
+            throw cleanupFailure("\(context) failed: \(response)")
         }
-        return text
+        guard zmx["inventoryComplete"] as? Bool == true else {
+            throw cleanupFailure("\(context): the inventory is incomplete")
+        }
+        guard let endpoint = zmx["endpoint"] as? [String: Any],
+              endpoint["socketDirectory"] as? String == namespace else {
+            throw cleanupFailure("\(context): the endpoint is not this test's namespace")
+        }
+        return try (zmx["entries"] as? [[String: Any]] ?? [])
+            .filter { $0["observation"] as? String == "running" }
+            .map { entry in
+                guard entry["state"] as? String == "claimed",
+                      let sessionID = entry["sessionID"] as? String,
+                      let pane = entry["pane"] as? String else {
+                    throw cleanupFailure("\(context): running daemon \(entry["daemon"] ?? "?") is unclaimed")
+                }
+                return PaneDaemon(sessionID: sessionID, pane: pane)
+            }
     }
 
-    private func zmxURL() throws -> URL {
-        if let products = ProcessInfo.processInfo.environment["BUILT_PRODUCTS_DIR"] {
-            return URL(fileURLWithPath: products).appendingPathComponent("agterm.app/Contents/MacOS/zmx")
-        }
-        var directory = Bundle(for: type(of: self)).bundleURL
-        while directory.path != "/", directory.lastPathComponent != "Debug" {
-            directory.deleteLastPathComponent()
-        }
-        let url = directory.appendingPathComponent("agterm.app/Contents/MacOS/zmx")
-        guard FileManager.default.isExecutableFile(atPath: url.path) else {
-            throw NSError(domain: "ZmxLiveUITests", code: 1,
-                          userInfo: [NSLocalizedDescriptionKey: "bundled zmx not found at \(url.path)"])
-        }
-        return url
+    private func cleanupFailure(_ message: String) -> Error {
+        NSError(domain: "ZmxLiveUITests", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
     }
 }

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -163,8 +163,9 @@ agtermctl session new --cwd ~/proj --name worker \
 ```
 
 In Fresh shells and Re-run commands modes, the session closes when this command exits unless `--wait` holds
-the final output. In Live sessions mode the command is typed into the persistent shell only on first creation;
-the shell stays open after it exits and `--wait` adds no hold prompt. After a clean quit, a missing daemon
+the final output. In Live sessions mode the command is a create-only zmx payload, which bypasses the 1,024-byte
+PTY input cap. A surviving daemon ignores the payload; a new daemon runs it, then starts the persistent shell.
+The shell stays open after it exits and `--wait` adds no hold prompt. After a clean quit, a missing daemon
 replays the captured running command inside a new persistent shell. The exclusions above start a fresh shell.
 
 `session type` drives an ALREADY-RUNNING program — it is not a launcher. Its keystrokes land in a line

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -360,8 +360,9 @@ buys nothing. A caller with no tree uses `version`.
   so you can read a build/test/deploy's final output or an early failure that would otherwise flash and
   vanish. In Re-run commands mode it persists across restart (unlike an overlay's live-only `--wait`),
   so a restored command session that starts its command again also holds; read it back on `tree`'s
-  `commandWait`. Live sessions mode types the command into the persistent zmx shell only on first creation.
-  The shell stays open when it exits, and `--wait` adds no hold prompt. After a clean quit, a missing daemon
+  `commandWait`. Live sessions mode passes the command as a create-only zmx payload, which bypasses the
+  1,024-byte PTY input cap. A surviving daemon ignores the payload; a new daemon runs it, then starts the persistent
+  shell. The shell stays open when it exits, and `--wait` adds no hold prompt. After a clean quit, a missing daemon
   is recreated running whatever that pane's foreground command was; if the command had already exited, or the
   quit never happened, the pane comes back as a fresh shell.
   The command is persisted (`SessionSnapshot.initialCommand`) and starts again on restore in Re-run commands

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -351,11 +351,13 @@ buys nothing. A caller with no tree uses `version`.
   existing one or creates it when absent (idempotent). `--command` runs that command as the session's
   process instead of the login shell (no echoed command line; the session closes when the command
   exits). It runs argv-style (tokenized, quotes respected, but NO shell), so shell operators (`;`,
-  `&&`, `$VAR`, redirects, globs) are not interpreted. In Live sessions mode it is a create-only zmx
-  payload run through a login shell instead, so shell operators do work there. It inherits the app's GUI `PATH` (the launchd
+  `&&`, `$VAR`, redirects, globs) are not interpreted, and it inherits the app's GUI `PATH` (the launchd
   default — no `/opt/homebrew/bin`), so a bare Homebrew or other non-default binary fails with exit 127.
   Wrap in a login shell for both — `--command "zsh -lc 'htop'"` — or give an absolute path
-  (`/opt/homebrew/bin/htop`).
+  (`/opt/homebrew/bin/htop`). All of that describes Fresh shells and Re-run commands. In Live sessions
+  mode the command is instead a create-only zmx payload the persistent shell runs as a login shell, so
+  shell operators are interpreted, the `PATH` is that shell's rather than the launchd default, and the
+  session stays open after the command exits.
   `--wait` (only with `--command`, else an error) HOLDS the session open after the command exits —
   showing libghostty's press-any-key prompt with the final output intact instead of closing immediately —
   so you can read a build/test/deploy's final output or an early failure that would otherwise flash and

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -351,7 +351,8 @@ buys nothing. A caller with no tree uses `version`.
   existing one or creates it when absent (idempotent). `--command` runs that command as the session's
   process instead of the login shell (no echoed command line; the session closes when the command
   exits). It runs argv-style (tokenized, quotes respected, but NO shell), so shell operators (`;`,
-  `&&`, `$VAR`, redirects, globs) are not interpreted, and it inherits the app's GUI `PATH` (the launchd
+  `&&`, `$VAR`, redirects, globs) are not interpreted. In Live sessions mode it is a create-only zmx
+  payload run through a login shell instead, so shell operators do work there. It inherits the app's GUI `PATH` (the launchd
   default — no `/opt/homebrew/bin`), so a bare Homebrew or other non-default binary fails with exit 127.
   Wrap in a login shell for both — `--command "zsh -lc 'htop'"` — or give an absolute path
   (`/opt/homebrew/bin/htop`).

--- a/site/commands.html
+++ b/site/commands.html
@@ -906,6 +906,8 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">;</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">&amp;&amp;</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">$VAR</span>, redirects and globs are not interpreted.
+                In <em>Live sessions</em> mode the command is a create-only zmx payload run through a login shell instead, so
+                shell operators do work there.
                 It also inherits the app's GUI
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> (the launchd default — no
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/opt/homebrew/bin</span>), so a bare Homebrew binary

--- a/site/commands.html
+++ b/site/commands.html
@@ -906,14 +906,16 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">;</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">&amp;&amp;</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">$VAR</span>, redirects and globs are not interpreted.
-                In <em>Live sessions</em> mode the command is a create-only zmx payload run through a login shell instead, so
-                shell operators do work there.
                 It also inherits the app's GUI
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> (the launchd default — no
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">/opt/homebrew/bin</span>), so a bare Homebrew binary
                 fails with exit 127. Use an absolute path, or wrap it:
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #f2b45c; white-space: nowrap">--command "zsh -lc 'htop'"</span>. The
                 command is persisted and runs again when a restored session launches in rerun mode.
+                All of that describes <em>Fresh shells</em> and <em>Re-run commands</em>. In <em>Live sessions</em> mode the
+                command is instead a create-only zmx payload the persistent shell runs as a login shell, so shell operators are
+                interpreted, the <span style="font-family: &quot;JetBrains Mono&quot;, monospace">PATH</span> is that shell's
+                rather than the launchd default, and the session stays open after the command exits.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--no-select</span> creates the session in the

--- a/site/docs.html
+++ b/site/docs.html
@@ -3193,8 +3193,9 @@ command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' stop"
                 Reattach restores usable text, TUI state, and normal colors, but its synthesized screen does not retain inline images,
                 earlier OSC 133 prompt markers, program-changed palette entries, or hyperlink metadata already attached to cells.
                 New output after reattach behaves normally. In live mode,
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">session new --command</span> types the
-                command into the persistent shell only when the pane is first created. The session stays open when that command exits,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">session new --command</span> passes the
+                command as a create-only zmx payload, which bypasses the 1,024-byte PTY input cap. A surviving daemon ignores the payload;
+                a new daemon runs it, then starts the persistent shell. The session stays open when that command exits,
                 so <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--wait</span> adds no hold prompt. After
                 a clean quit, a missing daemon replays the captured running command inside a new persistent shell; the exclusions above
                 start a fresh shell.


### PR DESCRIPTION
a `session new --command` longer than 1024 bytes is silently truncated and never submitted in 0.26.0, so every scheduled auto-review sits at a shell prompt holding a half-typed prompt.

**what happens**

a freshly created live pane took its command through libghostty `initial_input`. The zmx attach client forwards that into its outer pty before it switches the pty to raw mode, and macOS keeps only `MAX_CANON` (1024) bytes in the canonical line buffer. The tail is dropped along with the trailing newline, so the command arrives incomplete and unsubmitted. Reproduced with `forkpty`: a 2049-byte write returns 2049, exactly 1024 survive, no newline.

the route came in with `a0af4086`, which added `|| backedByZmx` to the `initial_input` guard. Before that a `--command` was exec'd as the surface process with no length limit.

**the fix**

pass a fresh pane's command through zmx's create-only argv path, the route a restored pane already used, and drop the `backedByZmx` exception. A surviving daemon ignores the payload and a new one runs it, so it still runs exactly once. This bypasses the 1024-byte pty cap, though `ARG_MAX` still bounds it.

a fresh split pane now gets its command this way too. It previously got neither `initialInput` (primary only) nor `creationCommand` (restored only), so in live mode it ran nothing at all.

**verified**

isolated instance in live mode, a 2092-byte command, marker written once. 2947 host-free tests, strict SwiftLint, and the live UI test with a 2048-byte payload asserting exactly-once.

**also here**

`ZmxLiveUITests` teardown killed daemons by running zmx from the XCUITest runner, which cannot signal what the app spawned, so zmx returned `PermissionDenied` and every run leaked its daemons. It now reaps through the app's own `zmx.kill`, refusing to act unless the inventory is complete and the endpoint is the test's own namespace, and never the default one. Unreapable rows are reported rather than filtered out of both passes.
