### PR TITLE
scope session.hud placement to a pane

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -394,6 +394,11 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   and session close tear a HUD down. `overlay.result` refuses with `OverlayHudError.noResult` because
   `overlayActive` alone would answer the misleading "overlay still running", and `overlay.resize` takes a
   percent but refuses `--full` (`OverlayHudError.fullResize`), which would cover the session it describes.
+- `hud.open` and `hud.update` accept `--pane` plus `--pane-id` with `session.restore`'s resolution rule: a
+  live stable token wins over the role fallback, while an unknown token without a fallback errors. The
+  resolved pane identity is stored, so swap and promotion move the HUD with its shell. A hidden target keeps
+  the HUD alive but unmounted; destroying the target closes it. Open refuses a pane the deck does not render.
+  Omission keeps the existing session-detail coordinate space. This is still one last-writer-wins HUD.
 - Zoom narrows on the same predicate: `isActive`'s shared `uncovered` and its `.scratch`/`.overlay` arms,
   `isAvailable`'s `.overlay` arm, `isVisible`, and `paneVisible`. Widen `uncovered` and narrow the `.overlay`
   arm together or no case is active and the documented-unreachable `?? .primary` fallback runs. The explicit
@@ -401,7 +406,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - A HUD sizes each axis separately, through `HudLayout.panelSize` into one `HudPanelSize` that travels
   store-to-deck: width from the box's columns, height from its rows. One percent across both made every
   panel as tall as it was wide, which is a square box around two lines of text, so `OverlayPanelStyle`
-  carries `widthFraction`/`heightFraction` and only a PROGRAM overlay sets them equal.
+  carries `widthFraction`/`heightFraction` and only a PROGRAM overlay sets them equal. A pane-scoped HUD
+  takes both dimensions, its anchor offsets, and the edge margin from the deck pane host's live bounds.
+  The pane hosts publish those bounds in the session detail coordinate space. Never derive them from
+  `splitRatio` or the terminal surface frame: the ratio is observation-ignored and the surface moves on zoom.
 - `--size-percent` reaches the WIDTH alone, on open and on `overlay.resize` — the text wraps at
   `HudLayout.maxColumns`, not at the panel, so a resize changes no rows — and the height takes no caller
   override at all. Every HUD WIDTH passes `HudLayout.clampSizePercent` (10...80), the caller's included, so
@@ -442,7 +450,8 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   foreground, and tracking the LATEST update unlike `backgroundColor`);
   `position` and `spinner` always report the effective value, defaults included — `spinner` names the STYLE
   and spells a static panel `HudSpinner.noneName`, which the dispatcher accepts back as "no spinner" so a
-  caller can round-trip what `tree` gave it. HUD state is poll-only.
+  caller can round-trip what `tree` gave it. `pane` names the targeted identity's current role and is omitted
+  for session-wide placement. HUD state is poll-only.
   `openOverlay`/`closeOverlay` emit no `scheduleTreeChanged()` and neither does a HUD, so document no event.
 - The panel is a pty running bundled `Resources/hud/hud.sh`, spawned `autoFocus: false` with
   `AGTERM_HUD_FILE` as its only HUD-SPECIFIC variable (the surface still inherits the session environment

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -346,8 +346,9 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   Promotion moves the right pane's overlay into the left slot without rebuilding its surface, so that
   surface's callbacks resolve their pane through `Session.paneOverlayRole(of:)`, never a captured one.
   Read back `paneOverlays`, ordered left-then-right.
-- Both full and floating use one always-present `overlayPanel` at z3. Gate content inside its
-  `GeometryReader`; never change the `sessionDetail`/HSplitView shape or pane modifiers on overlay state.
+- Both full and floating use one always-present `overlayPanel` in `sessionDetail`'s overlay preference
+  layer. Gate content inside its `GeometryReader`; never change the `sessionDetail`/HSplitView shape or
+  pane modifiers on overlay state.
   Full is translucent/chromeless and hides panes; floating is opaque/framed over visible panes with an
   internal click catcher. Value-only resizing must not reparent the Metal surface.
 - Handle `GHOSTTY_ACTION_SHOW_CHILD_EXITED`. Return true for immediate close, false for wait; process-exit
@@ -399,6 +400,8 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   resolved pane identity is stored, so swap and promotion move the HUD with its shell. A hidden target keeps
   the HUD alive but unmounted; destroying the target closes it. Open refuses a pane the deck does not render.
   Omission keeps the existing session-detail coordinate space. This is still one last-writer-wins HUD.
+  `ControlActions` retains the original session-wide methods and defaults the placement-carrying overloads
+  to them, so an `agterm-linux` conformer owes no source change until it adopts pane placement.
 - Zoom narrows on the same predicate: `isActive`'s shared `uncovered` and its `.scratch`/`.overlay` arms,
   `isAvailable`'s `.overlay` arm, `isVisible`, and `paneVisible`. Widen `uncovered` and narrow the `.overlay`
   arm together or no case is active and the documented-unreachable `?? .primary` fallback runs. The explicit

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -166,7 +166,8 @@ paths:
   background pane would abandon whichever view is really composing.
 - Never change the `sessionDetail` ZStack shape for per-session toggles; doing so rehosts `NSSplitView`
   into the titlebar. Search bar is a `detailPane` top-trailing overlay, above deck, scratch, and overlays.
-  Overlay panel stays an always-present `sessionDetail` sibling whose internal content changes.
+  Overlay panel stays in an always-present `sessionDetail` overlay preference layer whose internal
+  content changes.
 - The boundary is the arranged subview, not what it contains. Inside one, a constant-shape ZStack may swap
   children and change modifier values freely: a real NSView mounting and unmounting there held the divider
   across repeated toggles, both focus states, and a 0.85 ratio. That is what makes per-pane chrome — the

--- a/agterm/Control/ControlServer+Hud.swift
+++ b/agterm/Control/ControlServer+Hud.swift
@@ -7,8 +7,12 @@ import agtermCore
 /// `ControlDispatcher+Hud`; this layer supplies the three things agtermCore cannot resolve — the bundled
 /// helper's path, the terminal font's cell size, and live geometry, plus the body file the helper reads.
 extension ControlServer {
+    func openHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
+        openHud(target, window: window, spec: spec, placement: ControlHudPlacement())
+    }
+
     func openHud(_ target: String?, window: String?, spec: HudSpec,
-                 placement: ControlHudPlacement = ControlHudPlacement()) -> ControlResponse {
+                 placement: ControlHudPlacement) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session")
@@ -17,14 +21,17 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "hud helper is not bundled in this build")
             }
             let paneIdentity: UUID?
+            let pane: OverlayPane?
             switch self.resolveHudPlacement(placement, in: session, requireVisible: true) {
-            case .resolved(let identity): paneIdentity = identity
+            case .resolved(let identity, let targetPane):
+                paneIdentity = identity
+                pane = targetPane
             case .rejected(let response): return response
             }
             let file = Self.bodyFile(for: id)
             // measured ONCE and threaded through: the sizing and the header describe the same panel, and
             // both a font lookup and a pane-geometry union would otherwise run twice per command.
-            let metrics = self.paneMetrics(for: session, pane: self.hudPane(for: paneIdentity, in: session))
+            let metrics = self.paneMetrics(for: session, pane: pane)
             // open FIRST, write second: replacing a live HUD tears its surface down, and that teardown
             // deletes the body file at this same per-session path — writing first would lose it. The
             // header's grid also comes from the size the store RESOLVED, which only exists after this call.
@@ -46,8 +53,12 @@ extension ControlServer {
     /// Rewrites the live HUD's body and re-sizes the panel in place, repainting with no re-spawn per
     /// `HudLayout.renderedBody`. A failed write rolls the store back, as `openHud` does with `closeHud`:
     /// the panel still paints the old message, and `tree` must not claim the new one.
+    func updateHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
+        updateHud(target, window: window, spec: spec, placement: ControlHudPlacement())
+    }
+
     func updateHud(_ target: String?, window: String?, spec: HudSpec,
-                   placement: ControlHudPlacement = ControlHudPlacement()) -> ControlResponse {
+                   placement: ControlHudPlacement) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             // `hudActive` is the occupancy question, asked once and separately from the mutation below, so
             // a store that refused for another reason cannot come back as `noHud`.
@@ -57,12 +68,15 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: OverlayHudError.noHud)
             }
             let paneIdentity: UUID?
+            let pane: OverlayPane?
             switch self.resolveHudPlacement(placement, in: session, requireVisible: false) {
-            case .resolved(let identity): paneIdentity = identity
+            case .resolved(let identity, let targetPane):
+                paneIdentity = identity
+                pane = targetPane
             case .rejected(let response): return response
             }
             let previousPaneIdentity = session.hudPaneIdentity
-            let metrics = self.paneMetrics(for: session, pane: self.hudPane(for: paneIdentity, in: session))
+            let metrics = self.paneMetrics(for: session, pane: pane)
             store.updateHud(id, spec: spec, size: HudLayout.panelSize(for: spec, pane: metrics),
                             paneIdentity: paneIdentity)
             guard self.writeHudBody(session, pane: metrics) else {
@@ -93,9 +107,10 @@ extension ControlServer {
     /// shifts the centering by about a column, as the estimated cell already can.
     private static let windowPadding = (horizontal: 8.0, vertical: 6.0)
 
-    /// Cell size from the configured font and pane size from the deck-frame cache. Before the cache fills, a
-    /// deck-hosted surface supplies the same bounds; zoom and dashboard hosts are excluded. libghostty reports
-    /// no cell metrics, so the estimated cell may still differ by a column. An unmeasured session takes the cap.
+    /// Cell size comes from the configured font. A scoped call reads the deck-frame cache, falling back to its
+    /// deck-hosted surface before the preference arrives; zoom and dashboard hosts are excluded. An unscoped
+    /// call unions the live pane frames, so a hidden focused split contributes its one maximized surface.
+    /// libghostty reports no cell metrics; an unmeasured session takes the cap.
     func paneMetrics(for session: Session, pane: OverlayPane? = nil) -> PaneMetrics {
         let cell = Self.cellSize(family: settingsModel.settings.fontFamily,
                                  size: session.fontSize ?? GhosttyApp.shared.baseFontSize)
@@ -126,7 +141,7 @@ extension ControlServer {
     }
 
     private enum HudPlacementResolution {
-        case resolved(UUID?)
+        case resolved(identity: UUID?, pane: OverlayPane?)
         case rejected(ControlResponse)
     }
 
@@ -143,27 +158,20 @@ extension ControlServer {
                 return .rejected(ControlResponse(ok: false, error: "unknown pane id: \(token)"))
             }
         }
-        guard let pane else { return .resolved(nil) }
+        guard let pane else { return .resolved(identity: nil, pane: nil) }
         if requireVisible, !session.rendersPane(pane) {
             return .rejected(ControlResponse(ok: false, error: PaneOverlayError.paneNotVisible))
         }
         switch pane {
         case .left:
-            return .resolved(session.paneIdentity)
+            return .resolved(identity: session.paneIdentity, pane: .left)
         case .right:
             guard let identity = session.splitPaneIdentity else {
                 let error = requireVisible ? PaneOverlayError.paneNotVisible : "session has no split"
                 return .rejected(ControlResponse(ok: false, error: error))
             }
-            return .resolved(identity)
+            return .resolved(identity: identity, pane: .right)
         }
-    }
-
-    private func hudPane(for identity: UUID?, in session: Session) -> OverlayPane? {
-        guard let identity else { return nil }
-        if session.paneIdentity == identity { return .left }
-        if session.splitPaneIdentity == identity { return .right }
-        return nil
     }
 
     /// One cell of `family` at `size`: the horizontal advance of a digit (every glyph advances the same in

--- a/agterm/Control/ControlServer+Hud.swift
+++ b/agterm/Control/ControlServer+Hud.swift
@@ -5,10 +5,10 @@ import agtermCore
 
 /// App-side host for `session.hud.*`. Validation, error text and response shape stay in
 /// `ControlDispatcher+Hud`; this layer supplies the three things agtermCore cannot resolve — the bundled
-/// helper's path, the terminal font's cell size, and the pane's live geometry — plus the body file the
-/// helper reads.
+/// helper's path, the terminal font's cell size, and live geometry, plus the body file the helper reads.
 extension ControlServer {
-    func openHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
+    func openHud(_ target: String?, window: String?, spec: HudSpec,
+                 placement: ControlHudPlacement = ControlHudPlacement()) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session")
@@ -16,15 +16,21 @@ extension ControlServer {
             guard let command = Self.helperCommand() else {
                 return ControlResponse(ok: false, error: "hud helper is not bundled in this build")
             }
+            let paneIdentity: UUID?
+            switch self.resolveHudPlacement(placement, in: session, requireVisible: true) {
+            case .resolved(let identity): paneIdentity = identity
+            case .rejected(let response): return response
+            }
             let file = Self.bodyFile(for: id)
             // measured ONCE and threaded through: the sizing and the header describe the same panel, and
             // both a font lookup and a pane-geometry union would otherwise run twice per command.
-            let metrics = self.paneMetrics(for: session)
+            let metrics = self.paneMetrics(for: session, pane: self.hudPane(for: paneIdentity, in: session))
             // open FIRST, write second: replacing a live HUD tears its surface down, and that teardown
             // deletes the body file at this same per-session path — writing first would lose it. The
             // header's grid also comes from the size the store RESOLVED, which only exists after this call.
             guard store.openHud(id, command: command, spec: spec, file: file,
-                                size: HudLayout.panelSize(for: spec, pane: metrics)) else {
+                                size: HudLayout.panelSize(for: spec, pane: metrics),
+                                paneIdentity: paneIdentity) else {
                 return ControlResponse(ok: false, error: "overlay already open")
             }
             // the rolled-back HUD never realized a surface, and a replaced predecessor's file sits at this
@@ -40,7 +46,8 @@ extension ControlServer {
     /// Rewrites the live HUD's body and re-sizes the panel in place, repainting with no re-spawn per
     /// `HudLayout.renderedBody`. A failed write rolls the store back, as `openHud` does with `closeHud`:
     /// the panel still paints the old message, and `tree` must not claim the new one.
-    func updateHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
+    func updateHud(_ target: String?, window: String?, spec: HudSpec,
+                   placement: ControlHudPlacement = ControlHudPlacement()) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             // `hudActive` is the occupancy question, asked once and separately from the mutation below, so
             // a store that refused for another reason cannot come back as `noHud`.
@@ -49,11 +56,19 @@ extension ControlServer {
                   let previousHeight = session.hudHeightPercent else {
                 return ControlResponse(ok: false, error: OverlayHudError.noHud)
             }
-            let metrics = self.paneMetrics(for: session)
-            store.updateHud(id, spec: spec, size: HudLayout.panelSize(for: spec, pane: metrics))
+            let paneIdentity: UUID?
+            switch self.resolveHudPlacement(placement, in: session, requireVisible: false) {
+            case .resolved(let identity): paneIdentity = identity
+            case .rejected(let response): return response
+            }
+            let previousPaneIdentity = session.hudPaneIdentity
+            let metrics = self.paneMetrics(for: session, pane: self.hudPane(for: paneIdentity, in: session))
+            store.updateHud(id, spec: spec, size: HudLayout.panelSize(for: spec, pane: metrics),
+                            paneIdentity: paneIdentity)
             guard self.writeHudBody(session, pane: metrics) else {
                 store.updateHud(id, spec: previous,
-                                size: HudPanelSize(widthPercent: previousSize, heightPercent: previousHeight))
+                                size: HudPanelSize(widthPercent: previousSize, heightPercent: previousHeight),
+                                paneIdentity: previousPaneIdentity)
                 return ControlResponse(ok: false, error: OverlayHudError.writeFailed)
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
@@ -78,26 +93,77 @@ extension ControlServer {
     /// shifts the centering by about a column, as the estimated cell already can.
     private static let windowPadding = (horizontal: 8.0, vertical: 6.0)
 
-    /// Cell size from the CONFIGURED terminal font (the session's own size override, else the Settings
-    /// base) and pane size from the surfaces currently laid out. libghostty reports no cell metrics —
-    /// `GHOSTTY_ACTION_CELL_SIZE` discards its payload — so this measurement may round differently from the
-    /// cell it actually renders. That divergence is ACCEPTED, not corrected: the min/max clamp only bounds
-    /// the percentage, so a wider real cell overruns the helper's centering by a column or two. A session
-    /// with nothing on screen measures zero and takes the clamp's maximum.
-    func paneMetrics(for session: Session) -> PaneMetrics {
+    /// Cell size from the configured font and pane size from the deck-frame cache. Before the cache fills, a
+    /// deck-hosted surface supplies the same bounds; zoom and dashboard hosts are excluded. libghostty reports
+    /// no cell metrics, so the estimated cell may still differ by a column. An unmeasured session takes the cap.
+    func paneMetrics(for session: Session, pane: OverlayPane? = nil) -> PaneMetrics {
         let cell = Self.cellSize(family: settingsModel.settings.fontFamily,
                                  size: session.fontSize ?? GhosttyApp.shared.baseFontSize)
-        // the panel is laid out over the whole detail area, so the pane is the union of the laid-out panes:
-        // a hidden-but-focused split shows one pane maximized, and only the one in a window measures right.
-        let frames = [session.surface, session.splitSurface]
-            .compactMap { $0 as? GhosttySurfaceView }
-            .filter { $0.window != nil }
-            .map { $0.convert($0.bounds, to: nil) }
-        let area = frames.dropFirst().reduce(frames.first ?? .zero) { $0.union($1) }
+        let size: (width: Double, height: Double)
+        if let pane, let frame = session.hudPaneFrames[pane] {
+            size = (frame.width, frame.height)
+        } else if let pane {
+            let surface = pane == .left ? session.surface : session.splitSurface
+            if let view = surface as? GhosttySurfaceView,
+               view.window != nil, !view.suppressFocusChange {
+                let frame = view.convert(view.bounds, to: nil)
+                size = (frame.width, frame.height)
+            } else {
+                size = (0, 0)
+            }
+        } else {
+            let frames = [session.surface, session.splitSurface]
+                .compactMap { $0 as? GhosttySurfaceView }
+                .filter { $0.window != nil }
+                .map { $0.convert($0.bounds, to: nil) }
+            let area = frames.dropFirst().reduce(frames.first ?? .zero) { $0.union($1) }
+            size = (area.width, area.height)
+        }
         return PaneMetrics(cellWidth: cell.width, cellHeight: cell.height,
-                           paneWidth: area.width, paneHeight: area.height,
+                           paneWidth: size.width, paneHeight: size.height,
                            paddingWidth: Self.windowPadding.horizontal,
                            paddingHeight: Self.windowPadding.vertical)
+    }
+
+    private enum HudPlacementResolution {
+        case resolved(UUID?)
+        case rejected(ControlResponse)
+    }
+
+    private func resolveHudPlacement(_ placement: ControlHudPlacement, in session: Session,
+                                     requireVisible: Bool) -> HudPlacementResolution {
+        var pane = placement.pane
+        if let token = placement.paneID, !token.isEmpty {
+            if let resolved = session.paneRole(forToken: token) {
+                guard resolved != .scratch else {
+                    return .rejected(ControlResponse(ok: false, error: "hud pane must be left or right"))
+                }
+                pane = resolved == .left ? .left : .right
+            } else if pane == nil {
+                return .rejected(ControlResponse(ok: false, error: "unknown pane id: \(token)"))
+            }
+        }
+        guard let pane else { return .resolved(nil) }
+        if requireVisible, !session.rendersPane(pane) {
+            return .rejected(ControlResponse(ok: false, error: PaneOverlayError.paneNotVisible))
+        }
+        switch pane {
+        case .left:
+            return .resolved(session.paneIdentity)
+        case .right:
+            guard let identity = session.splitPaneIdentity else {
+                let error = requireVisible ? PaneOverlayError.paneNotVisible : "session has no split"
+                return .rejected(ControlResponse(ok: false, error: error))
+            }
+            return .resolved(identity)
+        }
+    }
+
+    private func hudPane(for identity: UUID?, in session: Session) -> OverlayPane? {
+        guard let identity else { return nil }
+        if session.paneIdentity == identity { return .left }
+        if session.splitPaneIdentity == identity { return .right }
+        return nil
     }
 
     /// One cell of `family` at `size`: the horizontal advance of a digit (every glyph advances the same in

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -88,7 +88,8 @@ extension ControlServer: ControlActions {
             guard store.resizeOverlay(id, sizePercent: sizePercent) else {
                 return ControlResponse(ok: false, error: "no overlay")
             }
-            if hud, let session, !self.writeHudBody(session, pane: self.paneMetrics(for: session)) {
+            if hud, let session,
+               !self.writeHudBody(session, pane: self.paneMetrics(for: session, pane: session.hudTargetPane)) {
                 store.resizeOverlay(id, sizePercent: previousSize)
                 return ControlResponse(ok: false, error: OverlayHudError.writeFailed)
             }

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -241,9 +241,9 @@ extension WindowContentView {
         }
     }
 
-    /// The overlay — FULL, FLOATING, or a HUD — rendered IN-DECK as ONE ALWAYS-PRESENT sibling of each
-    /// session's `sessionDetail` ZStack, its content gated INSIDE the GeometryReader so the child count never
-    /// changes (the constant-shape rule). All three share this one surface host, so `session.overlay.resize`
+    /// FULL, FLOATING, and HUD overlays render in `sessionDetail`'s always-present preference layer. Content
+    /// is gated INSIDE the GeometryReader so the ZStack shape never changes. All three share one surface, so
+    /// `session.overlay.resize`
     /// switching full<->% only re-flows the frame and never re-parents the NSView (which would blank its
     /// Metal drawable). `OverlayPanelStyle` supplies every per-occupant parameter, so the chain below is the
     /// same chain whichever one is up.
@@ -256,7 +256,9 @@ extension WindowContentView {
         GeometryReader { geo in
             let detailFrame = CGRect(origin: .zero, size: geo.size)
             let paneFrame = session.hudTargetPane.flatMap { paneFrames[$0] }.map { CGRect($0) }
-            let scopedHudVisible = session.hudPaneIdentity == nil || paneFrame != nil
+            let scopedHudVisible = OverlayPanelStyle.hudCanMount(
+                paneIdentity: session.hudPaneIdentity, paneFrameAvailable: paneFrame != nil
+            )
             let layoutFrame = session.hudActive ? (paneFrame ?? detailFrame) : detailFrame
             let panelFrame = style.panelFrame(in: layoutFrame)
             ZStack {
@@ -450,6 +452,11 @@ struct OverlayPanelStyle: Equatable {
                                  cornerRadius: hudCornerRadius, borderOpacity: hudBorderOpacity,
                                  shadowRadius: 0, backdrop: false, interactive: false,
                                  position: session.hudSpec?.position ?? .center)
+    }
+
+    /// A session-wide HUD needs no pane frame; a scoped HUD mounts only while its target pane is laid out.
+    static func hudCanMount(paneIdentity: UUID?, paneFrameAvailable: Bool) -> Bool {
+        paneIdentity == nil || paneFrameAvailable
     }
 
     /// The panel's offset from the pane's center, positive downward. A `top`/`bottom` anchor holds

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -13,6 +13,18 @@ enum PaneHostIdentity {
     }
 }
 
+private struct PaneHostCoordinateSpace: Hashable {
+    let sessionID: UUID
+}
+
+private struct HudPaneFramesPreferenceKey: PreferenceKey {
+    static let defaultValue = HudPaneFrames()
+
+    static func reduce(value: inout HudPaneFrames, nextValue: () -> HudPaneFrames) {
+        value.merge(nextValue())
+    }
+}
+
 /// `WindowContentView`'s detail deck: every session's terminal content — panes, split, scratch, and both
 /// overlay kinds — plus the inactive-pane mute.
 extension WindowContentView {
@@ -90,8 +102,8 @@ extension WindowContentView {
             // change this modifier (constant shape). Floating leaves the panes hit-testable;
             // `overlayPanel`'s transparent catcher absorbs the clicks around it.
             .allowsHitTesting(deckInteractive && !hideForOverlay)
-            // the scratch renders in-deck above the hidden pane(s), BELOW the ephemeral overlay (zIndex 1 vs
-            // `overlayPanel`'s 3), and hides under a FULL overlay like they do: under window translucency
+            // the scratch renders above the hidden pane(s) and below the overlay preference layer. It hides
+            // under a FULL overlay like they do: under window translucency
             // every surface background renders fully transparent, so a visible scratch would show THROUGH it.
             // A FLOATING panel's opaque backing needs no such hiding.
             if session.scratchActive, deckHostsSurface(session: session, surface: .scratch) {
@@ -106,10 +118,13 @@ extension WindowContentView {
                     .id("\(session.id.uuidString)-scratch")
                     .zIndex(1)
             }
-            // renders IN-DECK per session, so its program runs even when the session isn't active;
-            // `overlayPanel` owns the constant-shape rule.
-            overlayPanel(session: session, isActive: focusable, onScreen: deckInteractive && isActive)
-                .zIndex(3)
+        }
+        .coordinateSpace(.named(PaneHostCoordinateSpace(sessionID: session.id)))
+        .overlayPreferenceValue(HudPaneFramesPreferenceKey.self) { frames in
+            overlayPanel(session: session, isActive: focusable,
+                         onScreen: deckInteractive && isActive, paneFrames: frames)
+                .onAppear { cachePaneFrames(frames, for: session) }
+                .onChange(of: frames) { _, value in cachePaneFrames(value, for: session) }
         }
         // on PROGRAM overlay close refocus the topmost remaining surface via `topmostSurface` — never a pane
         // hidden under the scratch. One makeFirstResponder loses the race with the overlay's teardown/re-host,
@@ -213,6 +228,17 @@ extension WindowContentView {
             }
             paneOverlayPanel(session: session, pane: pane, focused: focused, gates: gates)
         }
+        .background {
+            GeometryReader { geo in
+                let rect = geo.frame(in: .named(PaneHostCoordinateSpace(sessionID: session.id)))
+                let frame = HudPaneFrame(x: Double(rect.minX), y: Double(rect.minY),
+                                         width: Double(rect.width), height: Double(rect.height))
+                Color.clear.preference(
+                    key: HudPaneFramesPreferenceKey.self,
+                    value: pane == .left ? HudPaneFrames(left: frame) : HudPaneFrames(right: frame)
+                )
+            }
+        }
     }
 
     /// The overlay — FULL, FLOATING, or a HUD — rendered IN-DECK as ONE ALWAYS-PRESENT sibling of each
@@ -221,14 +247,21 @@ extension WindowContentView {
     /// switching full<->% only re-flows the frame and never re-parents the NSView (which would blank its
     /// Metal drawable). `OverlayPanelStyle` supplies every per-occupant parameter, so the chain below is the
     /// same chain whichever one is up.
-    @ViewBuilder private func overlayPanel(session: Session, isActive: Bool, onScreen: Bool) -> some View {
+    @ViewBuilder private func overlayPanel(session: Session, isActive: Bool, onScreen: Bool,
+                                           paneFrames: HudPaneFrames) -> some View {
         let style = OverlayPanelStyle.resolve(session)
         // a HUD is passive: it neither takes first responder nor absorbs the clicks around it, so the panel
         // stays inert as a whole and the session underneath keeps both.
         let live = isActive && style.interactive
         GeometryReader { geo in
+            let detailFrame = CGRect(origin: .zero, size: geo.size)
+            let paneFrame = session.hudTargetPane.flatMap { paneFrames[$0] }.map { CGRect($0) }
+            let scopedHudVisible = session.hudPaneIdentity == nil || paneFrame != nil
+            let layoutFrame = session.hudActive ? (paneFrame ?? detailFrame) : detailFrame
+            let panelFrame = style.panelFrame(in: layoutFrame)
             ZStack {
-                if session.overlayActive, deckHostsSurface(session: session, surface: .overlay) {
+                if session.overlayActive, !session.hudActive || scopedHudVisible,
+                   deckHostsSurface(session: session, surface: .overlay) {
                     // absorbs clicks AROUND a floating panel so they can't reach the hit-testable panes and
                     // steal the overlay's first responder (the full variant hides the panes anyway), and
                     // carries the backdrop mute: a floating panel leaves the session live behind it, so the
@@ -246,8 +279,7 @@ extension WindowContentView {
                                  makeSurface: { makeOverlaySurface($0, nil) },
                                  isActive: live, deckVisible: live, viewOnly: !style.interactive,
                                  onScreen: onScreen)
-                        .frame(width: geo.size.width * style.widthFraction,
-                               height: geo.size.height * style.heightFraction)
+                        .frame(width: panelFrame.width, height: panelFrame.height)
                         // floating = opaque backing + frame + shadow so it reads as a distinct window over the
                         // still-visible session; full = translucent and chromeless (libghostty draws only the
                         // terminal, so the window backing shows through); a HUD keeps the backing but drops
@@ -260,8 +292,7 @@ extension WindowContentView {
                                 .strokeBorder(Color.white.opacity(style.borderOpacity), lineWidth: 1)
                         )
                         .shadow(radius: style.shadowRadius)
-                        .offset(x: style.horizontalOffset(paneWidth: geo.size.width),
-                                y: style.verticalOffset(paneHeight: geo.size.height))
+                        .position(x: panelFrame.midX, y: panelFrame.midY)
                         // a replacement (HUD→HUD, HUD→program) keeps `overlayActive` true across the swap, so
                         // without the generation SwiftUI reuses the host: `makeNSView` never re-runs and
                         // `updateNSView` hits a torn-down view with `overlaySurface` nil.
@@ -273,6 +304,12 @@ extension WindowContentView {
         // with no overlay up this is an empty full-frame GeometryReader; keep it inert so it never
         // intercepts clicks meant for the pane(s).
         .allowsHitTesting(live && session.overlayActive && deckHostsSurface(session: session, surface: .overlay))
+    }
+
+    private func cachePaneFrames(_ frames: HudPaneFrames, for session: Session) {
+        var cached = session.hudPaneFrames
+        cached.merge(frames)
+        if cached != session.hudPaneFrames { session.hudPaneFrames = cached }
     }
 
     /// ONE split pane's overlay, always FULL-PANE (no size percent, no framed chrome — a floating variant
@@ -432,6 +469,15 @@ struct OverlayPanelStyle: Equatable {
         Self.offset(along: paneWidth, fraction: widthFraction, band: position.horizontalBand)
     }
 
+    /// Applies the panel's size and anchor inside one session or pane bounds rect.
+    func panelFrame(in pane: CGRect) -> CGRect {
+        let size = CGSize(width: pane.width * widthFraction, height: pane.height * heightFraction)
+        let center = CGPoint(x: pane.midX + horizontalOffset(paneWidth: pane.width),
+                             y: pane.midY + verticalOffset(paneHeight: pane.height))
+        return CGRect(x: center.x - size.width / 2, y: center.y - size.height / 2,
+                      width: size.width, height: size.height)
+    }
+
     /// One axis' travel: half the free room left after the panel and its edge margin, signed by the band.
     private static func offset(along extent: CGFloat, fraction: CGFloat,
                                band: HudPosition.Band) -> CGFloat {
@@ -442,6 +488,13 @@ struct OverlayPanelStyle: Equatable {
         case .leading: return -free
         case .trailing: return free
         }
+    }
+}
+
+private extension CGRect {
+    init(_ frame: HudPaneFrame) {
+        self.init(x: CGFloat(frame.x), y: CGFloat(frame.y),
+                  width: CGFloat(frame.width), height: CGFloat(frame.height))
     }
 }
 

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -174,6 +174,8 @@ extension AppStore {
     /// resets `splitFocused`, else it points the collapsed view at the gone pane.
     public func closeSplit(_ sessionID: UUID, alreadyFinalized: UUID? = nil) {
         guard let session = session(withID: sessionID) else { return }
+        if let splitIdentity = session.splitPaneIdentity,
+           session.hudPaneIdentity == splitIdentity { closeHud(sessionID) }
         // through the ownership projection, not the raw identity: a remote split's daemon is on another
         // machine and this finalizer only ever kills local ones
         if let splitPaneIdentity = session.splitPaneIdentity, splitPaneIdentity != alreadyFinalized,
@@ -224,6 +226,7 @@ extension AppStore {
             closeSession(sessionID, alreadyFinalized: alreadyFinalized)
             return
         }
+        if session.hudPaneIdentity == session.paneIdentity { closeHud(sessionID) }
         let priorPrimary = session.surface // the exiting pane, torn down below; scopes the search reset
         priorPrimary?.teardown()
         survivor.promoteToPrimaryPane()
@@ -372,12 +375,13 @@ extension AppStore {
     /// A live HUD is REPLACED (torn down and re-opened, so the helper picks up the new file), a live
     /// PROGRAM overlay refuses. False for an unknown session or an occupied program slot. NOT persisted.
     @discardableResult public func openHud(_ sessionID: UUID, command: String, spec: HudSpec, file: String,
-                                           size: HudPanelSize) -> Bool {
+                                           size: HudPanelSize, paneIdentity: UUID? = nil) -> Bool {
         guard openOverlay(sessionID, command: command,
                           sizePercent: HudLayout.clampSizePercent(size.widthPercent),
                           backgroundColor: spec.backgroundColor),
               let session = session(withID: sessionID) else { return false }
         session.hudSpec = spec
+        session.hudPaneIdentity = paneIdentity
         session.hudFile = file
         session.hudHeightPercent = size.heightPercent
         return true
@@ -391,10 +395,12 @@ extension AppStore {
     /// dropped. Only a replacing `openHud` changes the color, and the read-back keeps naming what the panel
     /// actually paints. False with no HUD up, which is the only failure: `resizeOverlay` refuses an empty
     /// slot alone, and a live HUD occupies one.
-    @discardableResult public func updateHud(_ sessionID: UUID, spec: HudSpec, size: HudPanelSize) -> Bool {
+    @discardableResult public func updateHud(_ sessionID: UUID, spec: HudSpec, size: HudPanelSize,
+                                             paneIdentity: UUID? = nil) -> Bool {
         guard let session = session(withID: sessionID), let live = session.hudSpec,
               session.hudActive else { return false }
         session.hudSpec = spec.withBackgroundColor(live.backgroundColor)
+        session.hudPaneIdentity = paneIdentity
         session.hudHeightPercent = size.heightPercent
         resizeOverlay(sessionID, sizePercent: size.widthPercent)
         return true

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -362,7 +362,8 @@ public final class AppStore {
                               spinner: spec.spinner?.rawValue ?? HudSpinner.noneName,
                               backgroundColor: spec.backgroundColor, textColor: spec.textColor,
                               sizePercent: session.overlaySizePercent,
-                              heightPercent: session.hudHeightPercent, position: spec.position.rawValue)
+                              heightPercent: session.hudHeightPercent, position: spec.position.rawValue,
+                              pane: session.hudTargetPane?.rawValue)
     }
 
     /// Creates a workspace and appends it. With `revealNewWorkspace` (the default) and the filter ON, the new

--- a/agtermCore/Sources/agtermCore/ControlActionsDefaults.swift
+++ b/agtermCore/Sources/agtermCore/ControlActionsDefaults.swift
@@ -3,9 +3,8 @@ import Foundation
 // Default `ControlActions` implementations, kept out of `ControlDispatcher.swift` so that file stays
 // inside the 1000-line limit.
 public extension ControlActions {
-    /// Defaults so a conformer outside this repo — the `agterm-linux` fork consumes `agtermCore` as a
-    /// library — keeps building when a Mac-only command joins the protocol. Each refuses by name rather
-    /// than answering an empty success, which would be indistinguishable from a working command.
+    /// Defaults keep outside conformers building when the shared protocol grows. Mac-only commands refuse
+    /// by name rather than answering an empty success; compatibility overloads delegate to the older form.
     func readRestoreMode() -> ControlResponse {
         ControlResponse(ok: false, error: ControlActionsUnsupported.message("restore.mode"))
     }
@@ -51,5 +50,17 @@ public extension ControlActions {
 
     func setSessionContext(_: String?, window _: String?, context _: String?) -> ControlResponse {
         ControlResponse(ok: false, error: ControlActionsUnsupported.message("session.context"))
+    }
+
+    /// `agterm-linux` may implement the original session-wide HUD methods. New dispatchers preserve that
+    /// behavior when the host has not adopted pane placement yet.
+    func openHud(_ target: String?, window: String?, spec: HudSpec,
+                 placement _: ControlHudPlacement) -> ControlResponse {
+        openHud(target, window: window, spec: spec)
+    }
+
+    func updateHud(_ target: String?, window: String?, spec: HudSpec,
+                   placement _: ControlHudPlacement) -> ControlResponse {
+        updateHud(target, window: window, spec: spec)
     }
 }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Hud.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Hud.swift
@@ -2,22 +2,29 @@ import Foundation
 
 extension ControlDispatcher {
     /// Validates host-free HUD arguments before the host measures the terminal font, writes the rendered
-    /// message file, and takes the session's overlay slot. Only text, color, percent, and position are
-    /// checked here; slot occupancy and sizing need the store and stay app-side.
+    /// message file, and takes the session's overlay slot. Text, color, percent, position, and pane spelling
+    /// are checked here; slot occupancy, pane identity, and sizing need the store and stay app-side.
     func dispatchHudCommand(_ request: ControlRequest) -> ControlResponse {
         if request.cmd == .sessionHudClose {
             return actions.closeHud(request.target, window: request.args?.window)
         }
         // open and update validate identically — an update replaces the whole spec — so only the effect differs
-        let post: (String?, String?, HudSpec) -> ControlResponse
+        let post: (String?, String?, HudSpec, ControlHudPlacement) -> ControlResponse
         switch request.cmd {
         case .sessionHudOpen: post = actions.openHud
         case .sessionHudUpdate: post = actions.updateHud
         default: preconditionFailure("dispatchHudCommand called for \(request.cmd.rawValue)")
         }
+        let pane: OverlayPane?
+        switch parsePane(request.args?.pane, error: "--pane must be left or right",
+                         parse: { OverlayPane(controlName: $0) }) {
+        case .pane(let parsed): pane = parsed
+        case .rejected(let response): return response
+        }
+        let placement = ControlHudPlacement(pane: pane, paneID: request.args?.paneID)
         switch parseHudSpec(request) {
         case .rejected(let response): return response
-        case .spec(let spec): return post(request.target, request.args?.window, spec)
+        case .spec(let spec): return post(request.target, request.args?.window, spec, placement)
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -101,10 +101,12 @@ public protocol ControlActions {
     /// Post a message panel over the session, occupying the same overlay slot a program overlay uses. The
     /// dispatcher validated the text, color, percent, and position; the host measures the terminal font,
     /// renders the message to a file, and drives the store.
+    func openHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse
     func openHud(_ target: String?, window: String?, spec: HudSpec,
                  placement: ControlHudPlacement) -> ControlResponse
     /// Replace a live panel's text in place — same surface, no respawn. `spec.backgroundColor` cannot change
     /// here, the surface having read it once at creation.
+    func updateHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse
     func updateHud(_ target: String?, window: String?, spec: HudSpec,
                    placement: ControlHudPlacement) -> ControlResponse
     func closeHud(_ target: String?, window: String?) -> ControlResponse

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -101,10 +101,12 @@ public protocol ControlActions {
     /// Post a message panel over the session, occupying the same overlay slot a program overlay uses. The
     /// dispatcher validated the text, color, percent, and position; the host measures the terminal font,
     /// renders the message to a file, and drives the store.
-    func openHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse
+    func openHud(_ target: String?, window: String?, spec: HudSpec,
+                 placement: ControlHudPlacement) -> ControlResponse
     /// Replace a live panel's text in place — same surface, no respawn. `spec.backgroundColor` cannot change
     /// here, the surface having read it once at creation.
-    func updateHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse
+    func updateHud(_ target: String?, window: String?, spec: HudSpec,
+                   placement: ControlHudPlacement) -> ControlResponse
     func closeHud(_ target: String?, window: String?) -> ControlResponse
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -193,6 +193,18 @@ public struct ControlSessionStatusUpdate: Equatable, Sendable {
     }
 }
 
+/// The optional pane coordinate space for a HUD. The dispatcher parses `pane`; the app resolves `paneID`
+/// against live surfaces first and uses `pane` only as its fallback.
+public struct ControlHudPlacement: Equatable, Sendable {
+    public let pane: OverlayPane?
+    public let paneID: String?
+
+    public init(pane: OverlayPane? = nil, paneID: String? = nil) {
+        self.pane = pane
+        self.paneID = paneID
+    }
+}
+
 /// The three forms of the `session.restore` per-pane restore-command override, from the wire tokens
 /// `set` / `none` / `clear`. `pinNone` is not spelled `none`: a bare `case none` makes the compiler warn
 /// "assuming you mean Optional<T>.none" in an Optional context, which the dispatcher's parse step is.

--- a/agtermCore/Sources/agtermCore/ControlProjection.swift
+++ b/agtermCore/Sources/agtermCore/ControlProjection.swift
@@ -61,10 +61,13 @@ public struct ControlHudNode: Codable, Sendable, Equatable {
     /// the accepted `top`/`bottom` aliases, so a caller reads one spelling whichever he sent. Always present,
     /// including the `center` default, so a caller who omitted it never has to know what the default is.
     public let position: String
+    /// The pane currently carrying the stable HUD target, nil/omitted for session-wide placement.
+    public let pane: String?
 
     public init(message: String, detail: String? = nil, spinner: String = HudSpinner.noneName,
                 backgroundColor: String? = nil, textColor: String? = nil,
-                sizePercent: Int? = nil, heightPercent: Int? = nil, position: String) {
+                sizePercent: Int? = nil, heightPercent: Int? = nil, position: String,
+                pane: String? = nil) {
         self.message = message
         self.detail = detail
         self.spinner = spinner
@@ -73,6 +76,7 @@ public struct ControlHudNode: Codable, Sendable, Equatable {
         self.sizePercent = sizePercent
         self.heightPercent = heightPercent
         self.position = position
+        self.pane = pane
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -186,8 +186,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// Which split pane to focus for `session.focus` (`left`|`right`|`other`, `other` toggles); to read for
     /// `session.text` (`left`|`right`, omitted = the focused pane, no `other`); `session.type` injects into
     /// (`left`|`right`, omitted = left/main); set `session.status` (`left`|`right`|`scratch`, omitted =
-    /// `left`/main, parsed to `StatusPane`); and `session.restore` pins (same `StatusPane` spelling, omitted
-    /// = `left`/main, `scratch` rejected app-side).
+    /// `left`/main, parsed to `StatusPane`); `session.restore` pins (same `StatusPane` spelling, omitted
+    /// = `left`/main, `scratch` rejected app-side); and `session.hud.open`/`.update` use as optional placement
+    /// bounds (`left`/`right` only, omitted = the whole session detail area).
     ///
     /// The `session.overlay.*` family (`.open`/`.close`/`.result`/`.copy`/`.text`) scopes to ONE pane with
     /// it, parsed to `OverlayPane`, which
@@ -197,12 +198,12 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// unaffected. A pane overlay is always full-pane, so
     /// `--pane` conflicts with `session.overlay.open --size-percent` and `session.overlay.resize` refuses it.
     public var pane: String?
-    /// A surface's STABLE spawn token for `session.status`/`session.restore`/`session.text --pane-id` (the
-    /// shell's baked `AGTERM_PANE_ID`, forwarded by the agent-status hook). Resolving it against the session's
+    /// A surface's STABLE spawn token for `session.status`/`session.restore`/`session.text`/`session.hud.*`
+    /// (the shell's baked `AGTERM_PANE_ID`, forwarded by the agent-status hook). Resolving it against the session's
     /// live surfaces OVERRIDES the stale role `pane`, so a call from a moved pane reaches the CURRENT slot;
     /// empty/unknown falls back to `pane`. Opaque — validated only by resolving.
-    /// `session.restore` diverges: an unresolvable token with NO explicit `pane` errors there rather than
-    /// silently using `left`, since a wrong restore pin persists. See `Session.paneRole(forToken:)`, #199.
+    /// `session.restore` and `session.hud.*` diverge: an unresolvable token with NO explicit `pane` errors
+    /// rather than silently choosing session-wide or main placement. See `Session.paneRole(forToken:)`, #199.
     public var paneID: String?
     /// Absolute primary-pane split fraction (0...1) for `session.resize`, clamped server-side to
     /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.
@@ -248,7 +249,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// both dimensions; omitted gives the default full-pane overlay. Also the new size for
     /// `session.overlay.resize` (mutually exclusive with `full`), and the caller's OVERRIDE of the HUD panel's
     /// app-measured WIDTH for `session.hud.open`/`.update` — a HUD is always floating, so omitting it sizes the
-    /// panel from the message rather than covering the pane, and its height is measured either way.
+    /// panel from the message rather than covering its session or pane bounds, and its height is measured either way.
     public var sizePercent: Int?
     /// For `session.overlay.resize`, requests the full-pane (translucent, session-hidden) overlay — the way
     /// to switch a floating overlay back to full. Mutually exclusive with `sizePercent`.

--- a/agtermCore/Sources/agtermCore/Hud.swift
+++ b/agtermCore/Sources/agtermCore/Hud.swift
@@ -271,12 +271,7 @@ public struct HudPaneFrames: Equatable, Sendable {
         self.right = right
     }
 
-    public subscript(_ pane: OverlayPane) -> HudPaneFrame? {
-        get { pane == .left ? left : right }
-        set {
-            if pane == .left { left = newValue } else { right = newValue }
-        }
-    }
+    public subscript(_ pane: OverlayPane) -> HudPaneFrame? { pane == .left ? left : right }
 
     public mutating func merge(_ other: HudPaneFrames) {
         if let left = other.left { self.left = left }

--- a/agtermCore/Sources/agtermCore/Hud.swift
+++ b/agtermCore/Sources/agtermCore/Hud.swift
@@ -244,6 +244,46 @@ public struct PaneMetrics: Equatable, Sendable {
     }
 }
 
+/// One deck pane host's bounds in its session detail coordinate space. Double-backed so the app can cache
+/// live SwiftUI geometry without importing CoreGraphics into agtermCore.
+public struct HudPaneFrame: Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+}
+
+/// The live deck frames emitted by the pane hosts. A preference reduction builds a fresh value for drawing;
+/// `Session` also keeps the last non-empty frames so a hidden pane's HUD can still update its paint grid.
+public struct HudPaneFrames: Equatable, Sendable {
+    public var left: HudPaneFrame?
+    public var right: HudPaneFrame?
+
+    public init(left: HudPaneFrame? = nil, right: HudPaneFrame? = nil) {
+        self.left = left
+        self.right = right
+    }
+
+    public subscript(_ pane: OverlayPane) -> HudPaneFrame? {
+        get { pane == .left ? left : right }
+        set {
+            if pane == .left { left = newValue } else { right = newValue }
+        }
+    }
+
+    public mutating func merge(_ other: HudPaneFrames) {
+        if let left = other.left { self.left = left }
+        if let right = other.right { self.right = right }
+    }
+}
+
 /// The panel's share of the pane on each axis. The two are measured separately — a HUD is a couple of lines
 /// of text, so one percent across both made every panel as tall as it was wide — and travel together from
 /// `HudLayout.panelSize` through the store to the deck, so no layer can hold half a size.

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -332,6 +332,22 @@ public final class Session: Identifiable {
     /// a HUD is a message about work in flight and means nothing after a relaunch.
     public var hudSpec: HudSpec?
 
+    /// Stable identity of the pane whose bounds scope the HUD, nil for the session detail bounds. The identity
+    /// follows its shell through pane swaps and split-survivor promotion.
+    public var hudPaneIdentity: UUID?
+
+    /// Last live bounds emitted by each deck pane host. Ignored by observation because the drawing path takes
+    /// the current preference value directly; control commands use this cache only for message measurement.
+    @ObservationIgnored public var hudPaneFrames = HudPaneFrames()
+
+    /// The target identity's current role, nil for session-wide placement or a destroyed target.
+    public var hudTargetPane: OverlayPane? {
+        guard let hudPaneIdentity else { return nil }
+        if paneIdentity == hudPaneIdentity { return .left }
+        if splitPaneIdentity == hudPaneIdentity { return .right }
+        return nil
+    }
+
     /// Path to the rendered-message file the HUD helper re-reads each tick (`AGTERM_HUD_FILE`); `discardHudBody`
     /// deletes it. Per SESSION, so an update rewrites the path the running helper already opened.
     /// `@ObservationIgnored`: the surface factory, the HUD commands and `overlay close` read it, and none of
@@ -346,6 +362,7 @@ public final class Session: Identifiable {
     public func discardHudBody() {
         if let hudFile { try? FileManager.default.removeItem(atPath: hudFile) }
         hudSpec = nil
+        hudPaneIdentity = nil
         hudFile = nil
         hudHeightPercent = nil
     }

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -784,6 +784,10 @@ struct Session: ParsableCommand {
                 and never covers the session. Height always follows the message.
                 """)
             var sizePercent: Int?
+            @Option(name: .long, help: "Anchor inside primary/left/top or split/right/bottom; omit for the whole session.")
+            var pane: String?
+            @Option(name: .customLong("pane-id"), help: "Stable pane token ($AGTERM_PANE_ID); overrides --pane when it resolves.")
+            var paneID: String?
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions
 
@@ -795,6 +799,7 @@ struct Session: ParsableCommand {
                 try Hud.validatePosition(position)
                 try Hud.validateSpinnerStyle(spinnerStyle)
                 try Session.validateSizePercent(sizePercent)
+                try Overlay.validatePane(pane)
             }
 
             func makeRequest() throws -> ControlRequest {
@@ -802,12 +807,13 @@ struct Session: ParsableCommand {
                                args: options.withWindow(ControlArgs(
                                    sizePercent: sizePercent, message: message, detail: detail,
                                    spinner: Hud.spinnerValue(spinner: spinner, style: spinnerStyle),
-                                   color: backgroundColor, textColor: textColor, position: position)))
+                                   pane: pane, paneID: paneID, color: backgroundColor,
+                                   textColor: textColor, position: position)))
             }
         }
 
         /// Repaints the live panel in place. An update replaces the whole message, so every argument it
-        /// accepts must be repeated to survive — including `--spinner` and `--text-color`.
+        /// accepts must be repeated to survive, including `--spinner`, `--text-color`, and pane scope.
         /// `--background-color` is deliberately absent: the surface reads it once at creation, so only a
         /// fresh `hud` can change it, while the text color rides the header the helper re-reads every tick.
         struct Update: RequestCommand {
@@ -830,6 +836,10 @@ struct Session: ParsableCommand {
                 and never covers the session. Height always follows the message.
                 """)
             var sizePercent: Int?
+            @Option(name: .long, help: "Anchor inside primary/left/top or split/right/bottom; omit to return to whole-session placement.")
+            var pane: String?
+            @Option(name: .customLong("pane-id"), help: "Stable pane token ($AGTERM_PANE_ID); repeat it on update to keep pane scope.")
+            var paneID: String?
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions
 
@@ -838,6 +848,7 @@ struct Session: ParsableCommand {
                 try Hud.validatePosition(position)
                 try Hud.validateSpinnerStyle(spinnerStyle)
                 try Session.validateSizePercent(sizePercent)
+                try Overlay.validatePane(pane)
             }
 
             func makeRequest() throws -> ControlRequest {
@@ -845,7 +856,7 @@ struct Session: ParsableCommand {
                                args: options.withWindow(ControlArgs(
                                    sizePercent: sizePercent, message: message, detail: detail,
                                    spinner: Hud.spinnerValue(spinner: spinner, style: spinnerStyle),
-                                   textColor: textColor, position: position)))
+                                   pane: pane, paneID: paneID, textColor: textColor, position: position)))
             }
         }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreHudTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreHudTests.swift
@@ -11,14 +11,122 @@ struct AppStoreHudTests {
         let spec = HudSpec(message: "gathering options", detail: "scanning 400 files", spinner: .braille,
                            backgroundColor: "#2a1a3a", textColor: "#e0e0e0", sizePercent: 35,
                            position: .topCenter)
-        store.openHud(session.id, command: "hud.sh", spec: spec, file: "/tmp/hud", size: HudPanelSize(widthPercent: 35, heightPercent: 12))
+        store.openHud(session.id, command: "hud.sh", spec: spec, file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 35, heightPercent: 12),
+                      paneIdentity: session.paneIdentity)
 
         let node = try #require(store.controlTree().workspaces[0].sessions.first)
 
         #expect(node.hud == ControlHudNode(message: "gathering options", detail: "scanning 400 files",
                                            spinner: "braille", backgroundColor: "#2a1a3a",
                                            textColor: "#e0e0e0", sizePercent: 35,
-                                           heightPercent: 12, position: "top-center"))
+                                           heightPercent: 12, position: "top-center", pane: "left"))
+    }
+
+    @Test func paneReadBackFollowsTheStableIdentityAcrossRoleChanges() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        let target = UUID()
+        session.splitPaneIdentity = target
+        session.hasSplit = true
+        session.isSplit = true
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "working"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8), paneIdentity: target)
+
+        #expect(store.controlTree().workspaces[0].sessions[0].hud?.pane == "right")
+
+        session.paneIdentity = target
+        session.splitPaneIdentity = UUID()
+        #expect(store.controlTree().workspaces[0].sessions[0].hud?.pane == "left")
+    }
+
+    @Test func closingTheTargetPaneClosesItsHudButPreservesAnotherPanesHud() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        let splitIdentity = UUID()
+        session.splitPaneIdentity = splitIdentity
+        session.hasSplit = true
+        session.isSplit = true
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "split"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8), paneIdentity: splitIdentity)
+
+        store.closeSplit(session.id)
+        #expect(!session.hudActive)
+
+        session.splitPaneIdentity = UUID()
+        session.hasSplit = true
+        session.isSplit = true
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "primary"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8), paneIdentity: session.paneIdentity)
+        store.closeSplit(session.id)
+        #expect(session.hudActive)
+        #expect(session.hudTargetPane == .left)
+    }
+
+    @Test func closingAnAbsentSplitDoesNotCloseASessionWideHud() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "working"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8))
+
+        store.closeSplit(session.id)
+
+        #expect(session.hudActive)
+        #expect(session.hudPaneIdentity == nil)
+    }
+
+    @Test func hidingTheTargetPaneKeepsTheHudForItsReturn() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        let target = UUID()
+        session.splitPaneIdentity = target
+        session.hasSplit = true
+        session.isSplit = true
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "working"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8), paneIdentity: target)
+
+        store.toggleSplit(session.id)
+        #expect(session.hudActive)
+        #expect(session.hudTargetPane == .right)
+        #expect(!session.rendersPane(.right))
+
+        store.toggleSplit(session.id)
+        #expect(session.hudActive)
+        #expect(session.rendersPane(.right))
+    }
+
+    @Test func primaryExitClosesItsHudAndPreservesASurvivorHud() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        session.surface = SpySurface()
+        session.splitSurface = SpySurface()
+        session.hasSplit = true
+        session.isSplit = true
+        let splitIdentity = UUID()
+        session.splitPaneIdentity = splitIdentity
+
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "primary"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8),
+                      paneIdentity: session.paneIdentity)
+        store.closePrimaryPane(session.id)
+        #expect(!session.hudActive)
+
+        session.splitSurface = SpySurface()
+        session.hasSplit = true
+        session.isSplit = true
+        let nextSplitIdentity = UUID()
+        session.splitPaneIdentity = nextSplitIdentity
+        store.openHud(session.id, command: "hud.sh", spec: HudSpec(message: "survivor"), file: "/tmp/hud",
+                      size: HudPanelSize(widthPercent: 30, heightPercent: 8), paneIdentity: nextSplitIdentity)
+        store.closePrimaryPane(session.id)
+        #expect(session.hudActive)
+        #expect(session.hudPaneIdentity == nextSplitIdentity)
+        #expect(session.hudTargetPane == .left)
     }
 
     /// A caller who sent an alias reads the canonical anchor back, which is what makes it an alias rather

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneSwapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneSwapTests.swift
@@ -211,6 +211,19 @@ struct AppStorePaneSwapTests {
         #expect(fixture.split.assignedRoles == [.primary])
     }
 
+    @Test func paneScopedHudFollowsItsStableIdentityThroughSwap() {
+        let fixture = makeSeededSession()
+        let target = fixture.session.paneIdentity
+        fixture.store.openHud(fixture.session.id, command: "hud.sh", spec: HudSpec(message: "working"),
+                              file: "/tmp/hud", size: HudPanelSize(widthPercent: 30, heightPercent: 8),
+                              paneIdentity: target)
+
+        #expect(fixture.session.hudTargetPane == .left)
+        #expect(fixture.store.swapPanes(fixture.session.id) == nil)
+        #expect(fixture.session.hudPaneIdentity == target)
+        #expect(fixture.session.hudTargetPane == .right)
+    }
+
     @Test func swapUsesCwdFallbacks() {
         let fixture = makeSeededSession()
         fixture.session.currentCwd = nil

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherHudTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherHudTests.swift
@@ -166,7 +166,7 @@ struct ControlDispatcherHudTests {
 
             #expect(response?.error == nil)
             let call = try #require(actions.calls.first)
-            guard case let .hudOpen(_, _, spec) = call else { Issue.record("not a hud open"); return }
+            guard case let .hudOpen(_, _, spec, _) = call else { Issue.record("not a hud open"); return }
             #expect(spec.position == HudPosition.parse(raw))
         }
     }
@@ -195,7 +195,7 @@ struct ControlDispatcherHudTests {
             args: ControlArgs(message: "done", textColor: "#7ec07e", position: "bottom-right")))
 
         let call = try #require(actions.calls.first)
-        guard case let .hudUpdate(_, _, spec) = call else { Issue.record("not a hud update"); return }
+        guard case let .hudUpdate(_, _, spec, _) = call else { Issue.record("not a hud update"); return }
         #expect(spec.textColor == "#7ec07e")
         #expect(spec.position == .bottomRight)
     }
@@ -224,7 +224,7 @@ struct ControlDispatcherHudTests {
                                                      args: ControlArgs(message: "working",
                                                                        spinner: style.rawValue)))
 
-        guard case let .hudOpen(_, _, spec) = try #require(actions.calls.first) else {
+        guard case let .hudOpen(_, _, spec, _) = try #require(actions.calls.first) else {
             Issue.record("expected session.hud.open host call")
             return
         }
@@ -241,7 +241,7 @@ struct ControlDispatcherHudTests {
                                                      args: ControlArgs(message: "working",
                                                                        spinner: HudSpinner.noneName)))
 
-        guard case let .hudOpen(_, _, spec) = try #require(actions.calls.first) else {
+        guard case let .hudOpen(_, _, spec, _) = try #require(actions.calls.first) else {
             Issue.record("expected session.hud.open host call")
             return
         }
@@ -265,7 +265,8 @@ struct ControlDispatcherHudTests {
         let call = try #require(actions.calls.first)
         #expect(call == .hudOpen(target: "session-id", window: "window-id",
                                  HudSpec(message: "gathering options", detail: "scanning 400 files", spinner: .bar,
-                                         backgroundColor: "#112233", sizePercent: 40, position: .topCenter)))
+                                         backgroundColor: "#112233", sizePercent: 40, position: .topCenter),
+                                 ControlHudPlacement()))
     }
 
     @Test func updateRoutesParsedSpecAndReturnsHostResponse() async throws {
@@ -283,7 +284,39 @@ struct ControlDispatcherHudTests {
         #expect(response == expected)
         let call = try #require(actions.calls.first)
         #expect(call == .hudUpdate(target: "session-id", window: nil,
-                                   HudSpec(message: "still working", detail: "312 of 400", position: .bottomCenter)))
+                                   HudSpec(message: "still working", detail: "312 of 400", position: .bottomCenter),
+                                   ControlHudPlacement()))
+    }
+
+    @Test func paneAndPaneIDRouteToOpenAndUpdate() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        _ = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionHudOpen, args: ControlArgs(message: "working", pane: "split", paneID: "stable-token")
+        ))
+        _ = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionHudUpdate, args: ControlArgs(message: "done", pane: "top", paneID: "next-token")
+        ))
+
+        #expect(actions.calls == [
+            .hudOpen(target: nil, window: nil, HudSpec(message: "working"),
+                     ControlHudPlacement(pane: .right, paneID: "stable-token")),
+            .hudUpdate(target: nil, window: nil, HudSpec(message: "done"),
+                       ControlHudPlacement(pane: .left, paneID: "next-token")),
+        ])
+    }
+
+    @Test func invalidPaneIsRejectedBeforeTheHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionHudOpen, args: ControlArgs(message: "working", pane: "scratch")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "--pane must be left or right"))
+        #expect(actions.calls.isEmpty)
     }
 
     @Test func omittedPositionSpinnerAndOverridesTakeTheirDefaults() async throws {
@@ -293,7 +326,7 @@ struct ControlDispatcherHudTests {
         _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionHudOpen, args: ControlArgs(message: "working")))
 
         let call = try #require(actions.calls.first)
-        guard case let .hudOpen(_, _, spec) = call else {
+        guard case let .hudOpen(_, _, spec, placement) = call else {
             Issue.record("expected session.hud.open host call")
             return
         }
@@ -302,6 +335,7 @@ struct ControlDispatcherHudTests {
         #expect(spec.detail == nil)
         #expect(spec.backgroundColor == nil)
         #expect(spec.sizePercent == nil)
+        #expect(placement == ControlHudPlacement())
     }
 
     @Test(arguments: HudPosition.allCases)
@@ -315,7 +349,7 @@ struct ControlDispatcherHudTests {
         ))
 
         let call = try #require(actions.calls.first)
-        guard case let .hudOpen(_, _, spec) = call else {
+        guard case let .hudOpen(_, _, spec, _) = call else {
             Issue.record("expected session.hud.open host call")
             return
         }

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -207,7 +207,8 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionHudOpen, target: "9f3c",
                            args: ControlArgs(sizePercent: 40, message: "gathering options",
                                              detail: "scanning 400 files", spinner: "braille",
-                                             window: "win", color: "#2a1a3a", position: "top")),
+                                             window: "win", pane: "right", paneID: "stable-token",
+                                             color: "#2a1a3a", position: "top")),
             ControlRequest(cmd: .sessionHudUpdate, target: "9f3c",
                            args: ControlArgs(message: "almost there", detail: "12 left", position: "bottom")),
             ControlRequest(cmd: .sessionHudClose, target: "9f3c"),
@@ -215,6 +216,17 @@ struct ControlProtocolTests {
         for request in cases {
             #expect(try roundTrip(request) == request)
         }
+    }
+
+    @Test func hudReadBackRoundTripsItsCurrentPaneAndOmitsSessionWideScope() throws {
+        let paneHud = ControlHudNode(message: "working", sizePercent: 30, heightPercent: 8,
+                                     position: "bottom-right", pane: "right")
+        let paneData = try JSONEncoder().encode(paneHud)
+        #expect(try JSONDecoder().decode(ControlHudNode.self, from: paneData) == paneHud)
+
+        let sessionHud = ControlHudNode(message: "working", position: "center")
+        let json = String(decoding: try JSONEncoder().encode(sessionHud), as: UTF8.self)
+        #expect(!json.contains("pane"))
     }
 
     @Test func sessionHudRawStringsMapToCommands() throws {

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -544,10 +544,18 @@ final class MockControlActions: ControlActions {
         return nextOverlayTextResponse
     }
 
+    func openHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
+        openHud(target, window: window, spec: spec, placement: ControlHudPlacement())
+    }
+
     func openHud(_ target: String?, window: String?, spec: HudSpec,
                  placement: ControlHudPlacement) -> ControlResponse {
         calls.append(.hudOpen(target: target, window: window, spec, placement))
         return nextHudOpenResponse
+    }
+
+    func updateHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
+        updateHud(target, window: window, spec: spec, placement: ControlHudPlacement())
     }
 
     func updateHud(_ target: String?, window: String?, spec: HudSpec,

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -78,8 +78,8 @@ final class MockControlActions: ControlActions {
         case overlayResult(target: String?, window: String?, pane: OverlayPane?)
         case overlayCopy(target: String?, window: String?, pane: OverlayPane?)
         case overlayText(target: String?, window: String?, ControlSessionOverlayTextOptions)
-        case hudOpen(target: String?, window: String?, HudSpec)
-        case hudUpdate(target: String?, window: String?, HudSpec)
+        case hudOpen(target: String?, window: String?, HudSpec, ControlHudPlacement)
+        case hudUpdate(target: String?, window: String?, HudSpec, ControlHudPlacement)
         case hudClose(target: String?, window: String?)
         case sessionBackground(target: String?, window: String?, ControlSessionBackgroundOptions)
         case sessionText(target: String?, window: String?, ControlSessionTextOptions)
@@ -544,13 +544,15 @@ final class MockControlActions: ControlActions {
         return nextOverlayTextResponse
     }
 
-    func openHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
-        calls.append(.hudOpen(target: target, window: window, spec))
+    func openHud(_ target: String?, window: String?, spec: HudSpec,
+                 placement: ControlHudPlacement) -> ControlResponse {
+        calls.append(.hudOpen(target: target, window: window, spec, placement))
         return nextHudOpenResponse
     }
 
-    func updateHud(_ target: String?, window: String?, spec: HudSpec) -> ControlResponse {
-        calls.append(.hudUpdate(target: target, window: window, spec))
+    func updateHud(_ target: String?, window: String?, spec: HudSpec,
+                   placement: ControlHudPlacement) -> ControlResponse {
+        calls.append(.hudUpdate(target: target, window: window, spec, placement))
         return nextHudUpdateResponse
     }
 

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -1144,6 +1144,20 @@ struct CommandsTests {
         #expect(built.args?.sizePercent == nil)
         #expect(built.args?.color == nil)
         #expect(built.args?.textColor == nil)
+        #expect(built.args?.pane == nil && built.args?.paneID == nil)
+    }
+    @Test func sessionHudOpenAndUpdateCarryPaneIdentitySelectors() throws {
+        let open = try request(["session", "hud", "wait", "--pane", "right", "--pane-id", "stable-token"])
+        let update = try request(["session", "hud", "update", "done", "--pane", "left", "--pane-id", "stable-token"])
+        #expect(open.args?.pane == "right" && open.args?.paneID == "stable-token")
+        #expect(update.args?.pane == "left" && update.args?.paneID == "stable-token")
+    }
+
+    @Test(arguments: ["scratch", "middle"])
+    func sessionHudRejectsInvalidPane(_ pane: String) {
+        let error = "--pane must be left or right"
+        #expect(validationMessage(["session", "hud", "wait", "--pane", pane]) == error)
+        #expect(validationMessage(["session", "hud", "update", "done", "--pane", pane]) == error)
     }
 
     /// The CLI must take everything the socket does, so a caller can echo back what `tree` handed him and a

--- a/agtermCore/Tests/agtermctlKitTests/HudCommandHelpTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/HudCommandHelpTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import agtermctlKit
+
+struct HudCommandHelpTests {
+    @Test func updateHelpSaysOmissionClearsPaneScope() {
+        let help = Session.Hud.Update.helpMessage(columns: 200)
+
+        #expect(help.contains("omit to return to whole-session placement"))
+        #expect(help.contains("repeat it on update to keep pane scope"))
+    }
+}

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -695,7 +695,7 @@ final class ControlServerSessionActionsTests: XCTestCase {
         XCTAssertEqual(metrics.paneHeight, 0)
     }
 
-    func testHudPaneOpenRejectsHiddenPaneAndUnknownIdentity() throws {
+    func testHudPaneOpenRejectionsAndMissingSplitUpdate() throws {
         let (_, session) = try makeHudSession()
         session.hasSplit = true
         session.isSplit = false
@@ -710,6 +710,13 @@ final class ControlServerSessionActionsTests: XCTestCase {
                                      placement: ControlHudPlacement(paneID: "missing-token"))
         XCTAssertEqual(unknown.error, "unknown pane id: missing-token")
         XCTAssertFalse(session.hudActive)
+
+        session.hasSplit = false
+        session.splitPaneIdentity = nil
+        XCTAssertTrue(server.openHud(session.id.uuidString, window: nil, spec: HudSpec(message: "open")).ok)
+        let noSplit = server.updateHud(session.id.uuidString, window: nil, spec: HudSpec(message: "update"),
+                                       placement: ControlHudPlacement(pane: .right))
+        XCTAssertEqual(noSplit.error, "session has no split")
     }
 
     func testHiddenPaneHudCanUpdateAndReturnsWhenThePaneIsShown() throws {

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -634,6 +634,137 @@ final class ControlServerSessionActionsTests: XCTestCase {
         XCTAssertEqual(session.overlaySizePercent, 25)
     }
 
+    func testHudPaneIDOverridesTheRoleAndUsesThePaneHostMetrics() throws {
+        let (store, session) = try makeHudSession()
+        let rightIdentity = UUID()
+        session.splitPaneIdentity = rightIdentity
+        session.hasSplit = true
+        session.isSplit = true
+        session.surface = SessionRestoreTestSurface(paneToken: "left-token")
+        session.splitSurface = SessionRestoreTestSurface(paneToken: "right-token")
+        session.hudPaneFrames = HudPaneFrames(
+            left: HudPaneFrame(x: 0, y: 0, width: 100, height: 600),
+            right: HudPaneFrame(x: 104, y: 0, width: 1_000, height: 600)
+        )
+        let spec = HudSpec(message: String(repeating: "x", count: 60))
+
+        let response = server.openHud(session.id.uuidString, window: nil, spec: spec,
+                                      placement: ControlHudPlacement(pane: .left, paneID: "right-token"))
+
+        XCTAssertTrue(response.ok, response.error ?? "")
+        XCTAssertEqual(session.hudPaneIdentity, rightIdentity)
+        XCTAssertEqual(store.controlTree().workspaces[0].sessions.last?.hud?.pane, "right")
+        let rightSize = HudLayout.panelSize(for: spec, pane: server.paneMetrics(for: session, pane: .right))
+        let leftSize = HudLayout.panelSize(for: spec, pane: server.paneMetrics(for: session, pane: .left))
+        XCTAssertEqual(session.overlaySizePercent, rightSize.widthPercent)
+        XCTAssertNotEqual(rightSize.widthPercent, leftSize.widthPercent)
+    }
+
+    func testHudPaneMetricsFallBackToADeckHostedSurfaceBeforeTheFrameCacheFills() throws {
+        let (_, session) = try makeHudSession()
+        let surface = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 640, height: 480),
+                              styleMask: [], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = surface
+        session.surface = surface
+        session.hudPaneFrames = HudPaneFrames()
+        addTeardownBlock { window.orderOut(nil) }
+
+        let metrics = server.paneMetrics(for: session, pane: .left)
+
+        XCTAssertEqual(metrics.paneWidth, 640, accuracy: 0.001)
+        XCTAssertEqual(metrics.paneHeight, 480, accuracy: 0.001)
+    }
+
+    func testHudPaneMetricsDoNotUseAZoomOrDashboardHostedSurface() throws {
+        let (_, session) = try makeHudSession()
+        let surface = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 640, height: 480),
+                              styleMask: [], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = surface
+        surface.suppressFocusChange = true
+        session.surface = surface
+        session.hudPaneFrames = HudPaneFrames()
+        addTeardownBlock { window.orderOut(nil) }
+
+        let metrics = server.paneMetrics(for: session, pane: .left)
+
+        XCTAssertEqual(metrics.paneWidth, 0)
+        XCTAssertEqual(metrics.paneHeight, 0)
+    }
+
+    func testHudPaneOpenRejectsHiddenPaneAndUnknownIdentity() throws {
+        let (_, session) = try makeHudSession()
+        session.hasSplit = true
+        session.isSplit = false
+        session.splitPaneIdentity = UUID()
+
+        let hidden = server.openHud(session.id.uuidString, window: nil, spec: HudSpec(message: "working"),
+                                    placement: ControlHudPlacement(pane: .right))
+        XCTAssertEqual(hidden.error, PaneOverlayError.paneNotVisible)
+        XCTAssertFalse(session.hudActive)
+
+        let unknown = server.openHud(session.id.uuidString, window: nil, spec: HudSpec(message: "working"),
+                                     placement: ControlHudPlacement(paneID: "missing-token"))
+        XCTAssertEqual(unknown.error, "unknown pane id: missing-token")
+        XCTAssertFalse(session.hudActive)
+    }
+
+    func testHiddenPaneHudCanUpdateAndReturnsWhenThePaneIsShown() throws {
+        let (store, session) = try makeHudSession()
+        let rightIdentity = UUID()
+        session.splitPaneIdentity = rightIdentity
+        session.hasSplit = true
+        session.isSplit = true
+
+        XCTAssertTrue(server.openHud(session.id.uuidString, window: nil, spec: HudSpec(message: "first"),
+                                     placement: ControlHudPlacement(pane: .right)).ok)
+        store.toggleSplit(session.id)
+        XCTAssertFalse(session.rendersPane(.right))
+
+        let updated = server.updateHud(session.id.uuidString, window: nil, spec: HudSpec(message: "second"),
+                                       placement: ControlHudPlacement(pane: .right))
+        XCTAssertTrue(updated.ok, updated.error ?? "")
+        XCTAssertTrue(session.hudActive)
+        XCTAssertEqual(session.hudPaneIdentity, rightIdentity)
+
+        store.toggleSplit(session.id)
+        XCTAssertTrue(session.rendersPane(.right))
+        XCTAssertEqual(store.controlTree().workspaces[0].sessions.last?.hud?.pane, "right")
+    }
+
+    func testHudUpdateReplacesPaneScopeAndUnknownIDUsesTheRoleFallback() throws {
+        let (_, session) = try makeHudSession()
+        let rightIdentity = UUID()
+        session.splitPaneIdentity = rightIdentity
+        session.hasSplit = true
+        session.isSplit = true
+
+        XCTAssertTrue(server.openHud(session.id.uuidString, window: nil, spec: HudSpec(message: "first"),
+                                     placement: ControlHudPlacement(pane: .right)).ok)
+        let fallback = server.updateHud(session.id.uuidString, window: nil, spec: HudSpec(message: "second"),
+                                        placement: ControlHudPlacement(pane: .right, paneID: "unknown"))
+        XCTAssertTrue(fallback.ok, fallback.error ?? "")
+        XCTAssertEqual(session.hudPaneIdentity, rightIdentity)
+
+        let sessionWide = server.updateHud(session.id.uuidString, window: nil, spec: HudSpec(message: "third"))
+        XCTAssertTrue(sessionWide.ok, sessionWide.error ?? "")
+        XCTAssertNil(session.hudPaneIdentity)
+    }
+
+    func testScratchPaneIDCannotAnchorAHud() throws {
+        let (_, session) = try makeHudSession()
+        session.scratchSurface = SessionRestoreTestSurface(paneToken: "scratch-token")
+
+        let response = server.openHud(session.id.uuidString, window: nil, spec: HudSpec(message: "working"),
+                                      placement: ControlHudPlacement(paneID: "scratch-token"))
+
+        XCTAssertEqual(response.error, "hud pane must be left or right")
+        XCTAssertFalse(session.hudActive)
+    }
+
     // a hud must never cover the session it is about, which is why `overlay resize --full` is refused; a
     // caller's 100 is the same state by another door, so it takes the same bound.
     func testAnOversizedCallerRequestIsBoundedRatherThanCoveringThePane() throws {

--- a/agtermTests/HudDeckGatesTests.swift
+++ b/agtermTests/HudDeckGatesTests.swift
@@ -253,4 +253,10 @@ final class HudDeckGatesTests: XCTestCase {
         XCTAssertEqual(panel.maxY, 720, accuracy: 0.001)
         XCTAssertTrue(pane.contains(panel))
     }
+
+    func testHudMountEligibilityDistinguishesSessionWideFromHiddenPaneScope() {
+        XCTAssertTrue(OverlayPanelStyle.hudCanMount(paneIdentity: nil, paneFrameAvailable: false))
+        XCTAssertFalse(OverlayPanelStyle.hudCanMount(paneIdentity: UUID(), paneFrameAvailable: false))
+        XCTAssertTrue(OverlayPanelStyle.hudCanMount(paneIdentity: UUID(), paneFrameAvailable: true))
+    }
 }

--- a/agtermTests/HudDeckGatesTests.swift
+++ b/agtermTests/HudDeckGatesTests.swift
@@ -239,4 +239,18 @@ final class HudDeckGatesTests: XCTestCase {
         let style = OverlayPanelStyle.resolve(hudSession(position: .centerLeft, sizePercent: 95))
         XCTAssertEqual(style.horizontalOffset(paneWidth: 1000), 0)
     }
+
+    func testPanelFrameUsesThePaneRectForSizeAndAnchor() {
+        let style = OverlayPanelStyle.resolve(hudSession(position: .bottomRight,
+                                                         sizePercent: 80, heightPercent: 20))
+        let pane = CGRect(x: 500, y: 0, width: 500, height: 800)
+
+        let panel = style.panelFrame(in: pane)
+
+        XCTAssertEqual(panel.width, 400, accuracy: 0.001)
+        XCTAssertEqual(panel.height, 160, accuracy: 0.001)
+        XCTAssertEqual(panel.maxX, 950, accuracy: 0.001)
+        XCTAssertEqual(panel.maxY, 720, accuracy: 0.001)
+        XCTAssertTrue(pane.contains(panel))
+    }
 }

--- a/agtermUITests/ControlHudUITests.swift
+++ b/agtermUITests/ControlHudUITests.swift
@@ -105,6 +105,34 @@ final class ControlHudUITests: ControlAPITestCase {
         XCTAssertEqual(second["error"] as? String, "no hud")
     }
 
+    func testPaneHudReadsBackItsTargetSurvivesHideAndClosesWithThePane() throws {
+        let session = try activeSessionID()
+        try assertOK(sendCommand(request(command: "session.split", target: session, args: ["mode": "on"])))
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10))
+        try assertOK(openHud(message: "split work", pane: "right"))
+        XCTAssertEqual(try XCTUnwrap(pollHud(session, message: "split work"))["pane"] as? String, "right")
+
+        try assertOK(sendCommand(request(command: "session.focus", target: session, args: ["pane": "left"])))
+        try assertOK(sendCommand(request(command: "session.split", target: session, args: ["mode": "off"])))
+        XCTAssertEqual(try XCTUnwrap(pollHud(session, message: "split work"))["pane"] as? String, "right")
+
+        try assertOK(sendCommand(request(command: "session.split.close", target: session)))
+        XCTAssertTrue(poll(until: hudNode(session) == nil, timeout: 10))
+    }
+
+    func testHudPaneIDOverridesTheRoleAndFollowsItsShellThroughSwap() throws {
+        let session = try activeSessionID()
+        try assertOK(sendCommand(request(command: "session.split", target: session, args: ["mode": "on"])))
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10))
+        let rightToken = try readPaneToken(target: session, pane: "right")
+
+        try assertOK(openHud(message: "right agent", pane: "left", paneID: rightToken))
+        XCTAssertEqual(try XCTUnwrap(pollHud(session, message: "right agent"))["pane"] as? String, "right")
+
+        try assertOK(sendCommand(request(command: "session.swap", target: session)))
+        XCTAssertTrue(poll(until: self.hudNode(session)?["pane"] as? String == "left", timeout: 10))
+    }
+
     /// THE defining property, and the only place it can be observed: with a HUD up — and after a click on
     /// the panel — the real keyboard must still reach the session's own shell. Nothing below can see this;
     /// the deck predicates are pure functions with no view of first responder, so all of `HudDeckGatesTests`
@@ -154,13 +182,16 @@ final class ControlHudUITests: ControlAPITestCase {
 
     private func openHud(message: String, detail: String? = nil, spinner: String? = nil,
                          position: String? = nil, textColor: String? = nil,
-                         sizePercent: Int? = nil) throws -> [String: Any] {
+                         sizePercent: Int? = nil, pane: String? = nil,
+                         paneID: String? = nil) throws -> [String: Any] {
         var args: [String: Any] = ["message": message]
         if let detail { args["detail"] = detail }
         if let spinner { args["spinner"] = spinner }
         if let position { args["position"] = position }
         if let textColor { args["textColor"] = textColor }
         if let sizePercent { args["sizePercent"] = sizePercent }
+        if let pane { args["pane"] = pane }
+        if let paneID { args["paneID"] = paneID }
         return try sendCommand(request(command: "session.hud.open", args: args))
     }
 
@@ -193,6 +224,20 @@ final class ControlHudUITests: ControlAPITestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.1))
         } while Date() < deadline
         return nil
+    }
+
+    private func readPaneToken(target: String, pane: String) throws -> String {
+        let tag = "HUD-\(UUID().uuidString.prefix(8))"
+        let needle = "\(tag)-42["
+        let buffer = try pollPaneText(target: target, pane: pane, contains: needle, retype: {
+            _ = try self.sendCommand(self.typeRequest(
+                text: "printf '\(tag)-%s[%s]\\n' \"$((6*7))\" \"$AGTERM_PANE_ID\"\n",
+                target: target, select: false, pane: pane))
+        })
+        let text = try XCTUnwrap(buffer)
+        let regex = try NSRegularExpression(pattern: NSRegularExpression.escapedPattern(for: needle) + "([-0-9A-Fa-f]+)\\]")
+        let match = try XCTUnwrap(regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)))
+        return String(text[try XCTUnwrap(Range(match.range(at: 1), in: text))])
     }
 
     private func request(command: String, target: String? = nil, args: [String: Any]? = nil) -> String {

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -79,10 +79,11 @@ A **window** is the top level: a named bundle rendered in its own on-screen macO
 holds a tree of **workspaces**, each holding **sessions**. A session has a primary shell and can also
 have: a **split** pane (a second shell side by side), a **scratch** terminal (a third full-coverage
 shell, toggled like the split), and an ephemeral **overlay** (runs one program on top, then vanishes).
-An overlay covers the whole session, or with `--pane left|right` exactly one split pane, leaving the
-    sibling pane visible and usable. The same session-wide slot also holds a **HUD** (`session hud`), a small
-    passive panel carrying a message instead of a program. A HUD can use the whole session or one pane as its
-    placement bounds; the session keeps focus and stays typable under it.
+An overlay covers the whole session, or with `--pane left|right` exactly one split pane, leaving
+the sibling pane visible and usable. The same session-wide slot also holds a **HUD**
+(`session hud`), a small passive panel carrying a message instead of a program. A HUD can use the
+whole session or one pane as its placement bounds. The session keeps focus and stays typable
+under it.
 One slot, so a session shows either a HUD or a program overlay, never both. Separately, the app has one
 **quick terminal** (a scratch shell in a floating panel at 90% of the focused screen capped at 1100x700,
 or whatever share Settings sets instead; not part of the tree and not owned by a window).

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -80,8 +80,9 @@ holds a tree of **workspaces**, each holding **sessions**. A session has a prima
 have: a **split** pane (a second shell side by side), a **scratch** terminal (a third full-coverage
 shell, toggled like the split), and an ephemeral **overlay** (runs one program on top, then vanishes).
 An overlay covers the whole session, or with `--pane left|right` exactly one split pane, leaving the
-sibling pane visible and usable. The same session-wide slot also holds a **HUD** (`session hud`), a small
-passive panel carrying a message instead of a program: the session keeps focus and stays typable under it.
+    sibling pane visible and usable. The same session-wide slot also holds a **HUD** (`session hud`), a small
+    passive panel carrying a message instead of a program. A HUD can use the whole session or one pane as its
+    placement bounds; the session keeps focus and stays typable under it.
 One slot, so a session shows either a HUD or a program overlay, never both. Separately, the app has one
 **quick terminal** (a scratch shell in a floating panel at 90% of the focused screen capped at 1100x700,
 or whatever share Settings sets instead; not part of the tree and not owned by a window).
@@ -210,7 +211,7 @@ overlay resize` for a record-then-restore zoom), `paneOverlays` (the panes cover
 `["left"]`, `["right"]` or `["left","right"]`, omitted when neither is; the read side of `session overlay
 open --pane`, independent of the session-wide `overlay` flag),
 `hud` (the message panel occupying the session-wide slot — `{message, detail?, spinner, backgroundColor?,
-textColor?, sizePercent?, heightPercent?, position}`, the two percents being the panel's width and height
+textColor?, sizePercent?, heightPercent?, position, pane?}`, the two percents being the panel's width and height
 shares — omitted when none is up; the read side of `session hud`. `position` and `spinner`
 always report the EFFECTIVE value, `center` and a static panel's `none` included, so a caller who omitted
 them never has to know the defaults; `spinner` names the STYLE, so `none` is what a caller echoes back to
@@ -424,8 +425,8 @@ omitted when expanded).
   `--background-color` gives the overlay pane its own solid color, independent of the session's. An
   overlay is a real terminal (pty), which is also how you **display an image inline** — via the bundled
   `scripts/show-image.sh` (see below).
-- `session hud [open] <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N]` ·
-  `session hud update <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--text-color #rrggbb] [--size-percent N]` ·
+- `session hud [open] <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N] [--pane P] [--pane-id ID]` ·
+  `session hud update <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--text-color #rrggbb] [--size-percent N] [--pane P] [--pane-id ID]` ·
   `session hud close` — post a small **passive** panel over the session saying what you are doing
   ("gathering options…"). Unlike an overlay it takes no input and steals nothing: the session keeps first
   responder, the user keeps typing, and the terminal behind it is neither dimmed nor click-blocked. Use it
@@ -440,13 +441,17 @@ omitted when expanded).
   (default `center`), the same set `session background` takes; every anchor off center holds a fixed margin
   off that pane edge automatically, so a corner keeps the panel out of the text the user is reading. The
   bare `top`/`bottom` are still accepted for `top-center`/`bottom-center`, and the read-back reports the
-  canonical anchor. The panel is sized from the message on both axes —
+  canonical anchor. `--pane primary|left|top|split|right|bottom` makes that pane the coordinate space for
+  the anchor, size cap, and margin. `--pane-id "$AGTERM_PANE_ID"` follows the same shell after pane swaps or
+  promotion and overrides `--pane` when it resolves. An unknown token needs a `--pane` fallback. Open refuses
+  a pane that is not visible. Hiding a target keeps the HUD alive until the pane returns; closing it closes
+  the HUD. The panel is sized from the message on both axes:
   width from the longest line, height from the number of them — so a title and a subtitle give a wide, short
   panel, not a square one. `--size-percent N` (1-100) overrides the WIDTH only, bounded to 10-80% of the
   pane, since a message must never cover the session it is about, so a requested 100 reads back as 80. The
   height always follows the message. `--text-color` colors the panel's TEXT and `--background-color` its
   backing, independently. `session hud update` repaints in place with no re-spawn and no blink,
-  and REPLACES the whole spec — repeat `--detail`/`--spinner`/`--text-color` to keep them, since an omitted
+  and REPLACES the whole spec. Repeat `--detail`/`--spinner`/`--text-color`/`--pane`/`--pane-id` to keep them, since an omitted
   one drops. It takes no `--background-color`: the surface reads that once at creation, so only a fresh
   `session hud` changes it and `tree` keeps reporting the creation color across updates, while the text color rides
   the panel's body file and an update recolors it in place. Message and detail are capped at 256 characters and reject control characters, newline included.

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -947,8 +947,19 @@ choice=$(printf '%s\n' "$branches" | agtermctl pick --prompt "Check out which br
 agtermctl session hud close --target "$me"
 ```
 
+In a split, keep the panel inside the calling agent's pane and follow that shell if pane roles change:
+
+```bash
+agtermctl session hud "gathering options…" --spinner --position bottom-right \
+  --pane "$AGTERM_PANE" --pane-id "$AGTERM_PANE_ID" --target "$AGTERM_SESSION_ID"
+```
+
+The stable pane ID wins when it resolves. `--pane` is the fallback for older or unknown IDs. The selected
+pane supplies the size, 80% cap, anchor, and 10% edge margin. A hidden pane keeps its HUD and shows it again
+when restored; closing the pane closes its HUD.
+
 `session hud update` repaints in place, no re-spawn and no blink, and it replaces the whole spec: `--detail`,
-the spinner and `--text-color` are dropped unless repeated. `--spinner-style bar|braille|circle|blocks|dot` picks the look and
+the spinner, `--text-color`, `--pane`, and `--pane-id` are dropped unless repeated. `--spinner-style bar|braille|circle|blocks|dot` picks the look and
 turns the spinner on by itself (`dot` blinks instead of animating, for a panel up for minutes), and an
 update may switch style mid-flight; `--spinner-style none` stops it, which is also what a read-back's
 `none` echoes back to. `--position` anchors the panel to any of the nine

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -781,7 +781,8 @@ error keeps those names for compatibility.
   `invalid text color: <value> (#rrggbb)`,
   `invalid position: <value> (top-left|top-center|top-right|center-left|center|center-right|bottom-left|bottom-center|bottom-right|top|bottom)`,
   `invalid spinner: <value> (bar|braille|circle|blocks|dot|none)`,
-  `--pane must be left or right`, `pane not visible`, `unknown pane id: <token>`,
+  `--pane must be left or right`, `hud pane must be left or right` when a pane ID resolves to scratch,
+  `pane not visible`, `unknown pane id: <token>`,
   and `session.hud.open: --size-percent must be 1...100`.
   A second `hud` replaces the first; a `session overlay open` replaces a HUD, while a HUD over a RUNNING
   program is refused with `overlay already open` — a message is replaceable, a program is not.
@@ -790,9 +791,11 @@ error keeps those names for compatibility.
   whole spec rather than patching it, so `--detail`, the spinner, `--position`, `--text-color`, and pane selectors must be
   repeated to survive and an omitted one drops. `--spinner-style` may name a DIFFERENT style than the panel
   opened with, and `--text-color` a different color; both ride the message file, so the look changes on the
-  next tick with no re-spawn. Same required message and same rejections as `open`. There is no
-  `--background-color`: the surface reads that once at creation, so only a fresh `session hud` can change
-  it, and `tree` keeps reporting the creation color across updates. Errors `no hud` when none is up.
+  next tick with no re-spawn. It shares `open`'s message, text, color, position, spinner, and pane-spelling
+  validation. Pane lifecycle differs: update accepts a hidden target, while a missing split errors
+  `session has no split` instead of `pane not visible`. There is no `--background-color`: the surface reads
+  that once at creation, so only a fresh `session hud` can change it, and `tree` keeps reporting the creation
+  color across updates. Errors `no hud` when none is up.
 - `session hud close [--target] [--window W]` — take the panel down and delete its message file. Errors
   `no hud` when none is up, so it is not idempotent. A program overlay in the same slot is left alone;
   `session overlay close`, ⌘W, and closing the session or its window also tear a HUD down and delete that
@@ -1455,10 +1458,12 @@ a terminal surface's.
 ## Errors you may see
 
 `notFound` / `ambiguous` (target resolution), `no such session`, `invalid split mode` /
-`invalid scratch mode`, `session has no split` (focus), `no selection` (copy), `overlay already open` /
+`invalid scratch mode`, `session has no split` (focus, restore, or HUD update), `no selection` (copy),
+`overlay already open` /
 `no overlay` / `overlay still running` / `no overlay result` / `pane overlay already open` /
 `pane not visible` (pane overlay or HUD open),
 `no hud` (session hud update/close with none up) /
+`hud pane must be left or right` (a HUD pane ID resolved to scratch) /
 `no overlay result: the slot holds a hud` (session overlay result over a HUD) /
 `a hud is always floating: pass --size-percent, not --full` (session overlay resize over a HUD) /
 `session.hud.open requires a message` (also for a blank one) / `session.hud.update requires a message` /
@@ -1487,7 +1492,8 @@ locally with `mode must be on, off, or toggle`),
 `failed to read surface buffer` (quick text / session text),
 `text must not contain a NUL byte` (session type / quick type),
 `invalid restore mode` / `session.restore set requires a command` / `command must not contain control characters` /
-`command too long (max 1024 bytes)` / `the scratch terminal is never restored` / `unknown pane id` (restore or HUD) /
+`command too long (max 1024 bytes)` / `the scratch terminal is never restored` /
+`unknown pane id: <token>` (restore or HUD) /
 `failed to save the restore override, the previous value is still in effect` (session
 restore; a `session restore --pane right` on a session with no split also returns `session has no split`),
 `window not open`

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -146,7 +146,7 @@ to restore the exact size),
 independently of the session-wide `overlay` flag, which a pane overlay never sets),
 `hud` (the message panel occupying the session-wide overlay slot — the read side of `session hud`; omitted
 when none is up. A
-`{message, detail?, spinner, backgroundColor?, textColor?, sizePercent?, heightPercent?, position}`
+`{message, detail?, spinner, backgroundColor?, textColor?, sizePercent?, heightPercent?, position, pane?}`
 object: `detail`, `backgroundColor` and `textColor` are omitted when the caller set none, `sizePercent` is the EFFECTIVE
 10–80 share of the pane's WIDTH the panel takes (the app's measurement of the message, or the caller's
 `--size-percent` override, either way bounded so a message never covers the session; always present for a
@@ -157,7 +157,8 @@ them never has to know the defaults. `position` always names one of the nine CAN
 who sent the `top`/`bottom` alias reads `top-center`/`bottom-center` back. The two colors differ in
 lifetime: `backgroundColor` is what the panel was CREATED with and survives every update, while `textColor`
 tracks the latest update. `spinner` names the STYLE, a string, so a static panel reads back as
-`"none"` rather than `false`. `hud` and `overlay` are mutually exclusive — one slot — and a HUD reports `overlay`
+`"none"` rather than `false`. A pane-scoped HUD also reports its target identity's current role as `pane`;
+session-wide placement omits it. `hud` and `overlay` are mutually exclusive because they share one slot, and a HUD reports `overlay`
 FALSE with `overlaySizePercent` omitted, so a poll for "is a program covering this session" cannot mistake
 a message for one. No event announces a HUD; poll `tree` for it),
 `scratch` (scratch shown), `flagged` (in the
@@ -723,8 +724,8 @@ error keeps those names for compatibility.
   the overlay has closed. Errors `overlay still running` while up, `no overlay result` if none ran.
   `--pane` reads that pane's overlay; omit it for the session-wide one. A HUD runs the app's own painter,
   not a caller's program, so there is no status to report and the session-wide arm errors
-  `no overlay result: the slot holds a hud`; the `--pane` arm is unaffected, since a HUD only ever takes
-  the session-wide slot.
+  `no overlay result: the slot holds a hud`; the `--pane` arm still reads the separate pane-overlay slot,
+  since HUD pane scope changes placement without changing slot ownership.
 - `session overlay copy [--pane left|right] [--target] [--window W]` — returns `result.text` with the
   selection made INSIDE the overlay. `session copy` cannot reach it: that one addresses the pane the overlay
   covers, so a selection the user made in the overlay reads as `no selection` there. Does NOT touch the
@@ -740,7 +741,7 @@ error keeps those names for compatibility.
   file. Errors `no overlay`, `overlay not realized` and `no overlay to read: the slot holds a hud` as
   `session overlay copy` does, plus `failed to read surface buffer` on a real read failure. It has no
   `no selection`: a blank realized screen is `ok` with an empty string.
-- `session hud [open] <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N] [--target] [--window W]`
+- `session hud [open] <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N] [--pane P] [--pane-id ID] [--target] [--window W]`
   — post a PASSIVE message panel over the session and return its id. It occupies the same session-wide slot
   as `session overlay open`, but carries a message rather than a program: it takes no input, the session
   keeps first responder and stays typable, and the terminal behind it is neither dimmed nor click-blocked.
@@ -756,6 +757,11 @@ error keeps those names for compatibility.
   the nine `top-left|top-center|top-right|center-left|center|center-right|bottom-left|bottom-center|bottom-right`
   (default `center`), the same anchors `session background` takes; every anchor off center holds a fixed
   margin off that pane edge on each axis it names, so a panel at the largest allowed size never overhangs.
+  `--pane primary|left|top|split|right|bottom` makes the selected pane the bounds for measurement, explicit
+  size, anchor, and margin. `--pane-id` takes the shell's stable `$AGTERM_PANE_ID`; a live token overrides
+  `--pane`, while an unknown token uses that role as fallback or errors without one. The stored identity follows
+  pane swap and promotion. Open refuses a pane that is not rendered. Hiding the target suppresses the panel
+  without stopping its helper, and showing it restores the panel. Destroying the target closes the HUD.
   A corner is what keeps a long-lived panel out of the text the user is reading. The bare `top`/`bottom`
   this argument shipped with are still accepted for `top-center`/`bottom-center`, and `hud.position` reports
   the canonical anchor whichever spelling was sent. The panel is measured from the message against the session's terminal font on BOTH
@@ -775,12 +781,13 @@ error keeps those names for compatibility.
   `invalid text color: <value> (#rrggbb)`,
   `invalid position: <value> (top-left|top-center|top-right|center-left|center|center-right|bottom-left|bottom-center|bottom-right|top|bottom)`,
   `invalid spinner: <value> (bar|braille|circle|blocks|dot|none)`,
+  `--pane must be left or right`, `pane not visible`, `unknown pane id: <token>`,
   and `session.hud.open: --size-percent must be 1...100`.
   A second `hud` replaces the first; a `session overlay open` replaces a HUD, while a HUD over a RUNNING
   program is refused with `overlay already open` — a message is replaceable, a program is not.
-- `session hud update <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--text-color #rrggbb] [--size-percent N] [--target] [--window W]`
+- `session hud update <message> [--detail T] [--spinner] [--spinner-style S] [--position P] [--text-color #rrggbb] [--size-percent N] [--pane P] [--pane-id ID] [--target] [--window W]`
   — repaint the live panel in place: no re-spawn, no blink, the panel does not flicker. It REPLACES the
-  whole spec rather than patching it, so `--detail`, the spinner, `--position` and `--text-color` must be
+  whole spec rather than patching it, so `--detail`, the spinner, `--position`, `--text-color`, and pane selectors must be
   repeated to survive and an omitted one drops. `--spinner-style` may name a DIFFERENT style than the panel
   opened with, and `--text-color` a different color; both ride the message file, so the look changes on the
   next tick with no re-spawn. Same required message and same rejections as `open`. There is no
@@ -1450,7 +1457,7 @@ a terminal surface's.
 `notFound` / `ambiguous` (target resolution), `no such session`, `invalid split mode` /
 `invalid scratch mode`, `session has no split` (focus), `no selection` (copy), `overlay already open` /
 `no overlay` / `overlay still running` / `no overlay result` / `pane overlay already open` /
-`pane not visible` (overlay),
+`pane not visible` (pane overlay or HUD open),
 `no hud` (session hud update/close with none up) /
 `no overlay result: the slot holds a hud` (session overlay result over a HUD) /
 `a hud is always floating: pass --size-percent, not --full` (session overlay resize over a HUD) /
@@ -1480,7 +1487,7 @@ locally with `mode must be on, off, or toggle`),
 `failed to read surface buffer` (quick text / session text),
 `text must not contain a NUL byte` (session type / quick type),
 `invalid restore mode` / `session.restore set requires a command` / `command must not contain control characters` /
-`command too long (max 1024 bytes)` / `the scratch terminal is never restored` / `unknown pane id` /
+`command too long (max 1024 bytes)` / `the scratch terminal is never restored` / `unknown pane id` (restore or HUD) /
 `failed to save the restore override, the previous value is still in effect` (session
 restore; a `session restore --pane right` on a session with no split also returns `session has no split`),
 `window not open`

--- a/site/commands.html
+++ b/site/commands.html
@@ -467,7 +467,7 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">["right"]</span> or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">["left","right"]</span>, omitted when neither is),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">hud</span> (the message panel holding the session-wide
-                slot — <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{message, detail?, spinner, backgroundColor?, textColor?, sizePercent?, heightPercent?, position}</span>, where
+                slot — <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{message, detail?, spinner, backgroundColor?, textColor?, sizePercent?, heightPercent?, position, pane?}</span>, where
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">spinner</span> names the effective style or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">none</span> —
                 omitted when none is up; mutually exclusive with
@@ -1774,7 +1774,8 @@
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
                 agtermctl session hud [open] &lt;message&gt; [--detail T] [--spinner] [--spinner-style S] [--position P]
-                [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N] [--target T] [--window W]
+                [--background-color #rrggbb] [--text-color #rrggbb] [--size-percent N] [--pane P] [--pane-id ID]
+                [--target T] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.hud.open</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
@@ -1806,6 +1807,13 @@
                 accepted for the middle column, and the read-back reports the canonical anchor. The panel is measured from the message
                 against the session's terminal font on BOTH axes separately — width from the longest wrapped line, height from
                 the number of them — so a title and a subtitle give a wide, short panel rather than a square one.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane primary|left|top|split|right|bottom</span>
+                uses that pane as the bounds for measurement, explicit size, anchors, and margins.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane-id</span> takes the shell's stable
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">$AGTERM_PANE_ID</span>. A live ID overrides
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span>; an unknown ID needs that role as a fallback.
+                Open rejects a pane that is not rendered. Hiding the target keeps the HUD alive and restores it with the pane;
+                closing the target closes the HUD.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--size-percent N</span> (1–100)
                 overrides the WIDTH only; the height always follows the message, since a caller-set height could only strand it
                 in an empty box. The effective width is bounded to 10–80% of the pane, so a message never covers the session
@@ -1836,7 +1844,7 @@
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
                 agtermctl session hud update &lt;message&gt; [--detail T] [--spinner] [--spinner-style S] [--position P]
-                [--text-color #rrggbb] [--size-percent N] [--target T] [--window W]
+                [--text-color #rrggbb] [--size-percent N] [--pane P] [--pane-id ID] [--target T] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.hud.update</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
@@ -1844,7 +1852,9 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--detail</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--spinner</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--position</span>, and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--text-color</span> must be repeated to survive;
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--text-color</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span>, and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane-id</span> must be repeated to survive;
                 an omitted one drops. Same required message and same rejections as
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">open</span>. Errors
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no hud</span> when none is up.
@@ -1876,7 +1886,8 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">hud</span> object, whose
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">position</span> and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">spinner</span> always report the effective value,
-                defaults included. Beside it the node's
+                defaults included. A pane-scoped HUD also reports the target identity's current role as
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pane</span>. Beside it the node's
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">overlay</span> reads false with
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">overlaySizePercent</span> omitted, so a poll for "is a
                 program covering this session" cannot mistake a message for one, and
@@ -3208,7 +3219,7 @@
                     padding: 4px 9px;
                     white-space: nowrap;
                   "
-                  >pane not visible<span style="color: #6b727a; font-family: &quot;IBM Plex Sans&quot;, sans-serif"> (overlay)</span></span
+                  >pane not visible<span style="color: #6b727a; font-family: &quot;IBM Plex Sans&quot;, sans-serif"> (overlay or HUD open)</span></span
                 >
                 <span
                   style="

--- a/site/commands.html
+++ b/site/commands.html
@@ -1855,8 +1855,10 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--text-color</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span>, and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane-id</span> must be repeated to survive;
-                an omitted one drops. Same required message and same rejections as
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">open</span>. Errors
+                an omitted one drops. It shares <span style="font-family: &quot;JetBrains Mono&quot;, monospace">open</span>'s
+                message and value validation. Pane lifecycle differs: update accepts a hidden target and reports
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session has no split</span> for a missing split,
+                where open reports <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pane not visible</span>. Errors
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no hud</span> when none is up.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">

--- a/site/docs.html
+++ b/site/docs.html
@@ -2269,7 +2269,11 @@
               <span style="color: #f2b45c">"$AGTERM_SESSION_ID"</span><br /><br /><span style="color: #6b727a"
                 ># anchor it and set its width by hand instead of measuring the message</span
               ><br />agtermctl session hud <span style="color: #f2b45c">"deploying"</span> --position top-right --size-percent
-              30<br /><br /><span style="color: #6b727a"># color both halves of the panel</span
+              30<br /><br /><span style="color: #6b727a"># keep the HUD inside the calling pane, even after its role changes</span
+              ><br />agtermctl session hud <span style="color: #f2b45c">"working"</span> --pane
+              <span style="color: #f2b45c">"$AGTERM_PANE"</span> --pane-id
+              <span style="color: #f2b45c">"$AGTERM_PANE_ID"</span> --target
+              <span style="color: #f2b45c">"$AGTERM_SESSION_ID"</span><br /><br /><span style="color: #6b727a"># color both halves of the panel</span
               ><br />agtermctl session hud <span style="color: #f2b45c">"deploying"</span> --text-color
               <span style="color: #f2b45c">"#7ec07e"</span> --background-color
               <span style="color: #f2b45c">"#202020"</span><br /><br />agtermctl session hud close --target <span style="color: #f2b45c">"$AGTERM_SESSION_ID"</span>
@@ -2301,6 +2305,13 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">bottom</span> this took before are
               still accepted for the middle column. The panel comes from the message on both axes — width from the longest line, height
               from the number of them, so a title and a subtitle give a wide, short panel rather than a square one.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--pane</span> uses one pane as the
+              bounds for sizing, anchors, and margins.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--pane-id "$AGTERM_PANE_ID"</span>
+              follows the same shell through pane swaps and promotion, with
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--pane "$AGTERM_PANE"</span> as
+              the fallback. Open refuses a pane that is not rendered. Hiding that pane hides the panel without stopping it;
+              showing the pane restores it, and closing the pane closes its HUD.
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--size-percent</span> overrides the
               width only, bounded to at most 80% of the pane, so a message never covers the session it is about.
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--text-color</span> sets the text's
@@ -2310,7 +2321,9 @@
               An update replaces the whole message, so
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--detail</span>,
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--spinner</span> and
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--text-color</span> have to be repeated
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--text-color</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--pane</span>, and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--pane-id</span> have to be repeated
               to survive it. The spinner takes a style —
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--spinner-style bar|braille|circle|blocks|dot|none</span>,
               which turns it on by itself, with
@@ -2336,6 +2349,8 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl tree --json</span> reports
               the panel as the session node's
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">hud</span> object, with
+              a pane-scoped HUD's current role in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">hud.pane</span> and
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">overlay</span> reading false beside it;
               there is no event, so a script that needs the state polls the tree.
             </p>


### PR DESCRIPTION
`session hud` anchors resolved against the whole session rect, so in a split an agent asking for
`bottom-right` got the panel over the other pane, and `--size-percent` measured the same way could
push a long message across the divider. Reported as a follow-up on discussion 384.

`hud open` and `hud update` now take `--pane` and `--pane-id`, resolved the way `session restore`
resolves them: a live stable token wins over the role, an unknown token with no role fallback errors.
The resolved pane identity is stored, so pane swap and split-survivor promotion carry the panel with
its shell.

Frame, anchor, `--size-percent`, the 80% cap and the edge margin all come from the deck pane host's
live bounds, published as a preference in the session detail coordinate space. Never `splitRatio`,
which is observation-ignored and would not re-lay-out on a divider drag, and never the terminal
surface frame, which terminal zoom reparents.

**Lifecycle**

- open refuses a pane the deck does not render
- hiding the target keeps the HUD alive but unmounted; showing the pane restores it
- destroying the pane closes the HUD, as `closeSplit` already does for a pane overlay
- `tree` reports the target's current role as `hud.pane`

**Not in scope.** This stays one last-writer-wins HUD per session, so two agents in a split still
share one panel and the later writer owns its message, appearance and location. A resident panel per
agent is a different request: it needs a per-pane slot with its own state and read-back, and it would
cost the pane overlay slot.

`ControlActions` keeps the original session-wide `openHud`/`updateHud` as requirements and defaults
the placement-carrying overloads to them, following the `sidebarWidth` precedent, so a conformer
outside this repo owes no source change.

Related to https://github.com/umputun/agterm/discussions/384
