### PR TITLE
docs: explain the repeating App Data permission prompt

### DIFF
--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -34,6 +34,8 @@
 	<string>public.app-category.developer-tools</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Umputun</string>
+	<key>NSAppDataUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, docker talking to Docker Desktop) request access to other applications' data through agterm.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, an osascript one-liner or a build script) request permission to control other apps through agterm.</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,7 +247,7 @@ without complaint.
 Those three folders, along with removable and network volumes, are protected by macOS directly. It is a
 different mechanism from the section above: agterm is not sandboxed, and unlike the services listed there no
 missing entitlement can suppress this family's prompt. macOS defines an optional usage-description string per
-folder and agterm ships none, so the prompt carries macOS's own wording rather than agterm's. What matters is
+folder and agterm ships one for each, so the prompt carries agterm's wording. What matters is
 that the answer is recorded against the application macOS holds responsible. Approving kitty or
 Terminal says nothing about agterm, so a Mac where every other terminal reads the folder can still refuse
 this one, and as with the services above a dismissed prompt is not re-offered and the command just keeps
@@ -262,6 +262,30 @@ To tell a privacy denial from ordinary permission bits, run `/bin/ls -la ~/Downl
 against the folder itself, rather than a replacement such as `eza`. A privacy denial usually reads as
 `Operation not permitted` and ordinary permission bits as `Permission denied`, and some replacements print
 the same wording for both.
+
+## "agterm would like to access data from other apps" keeps coming back
+
+A command that reaches into another application's data raises a macOS dialog reading "Agterm.app would like
+to access data from other apps" — docker is the usual one. Allow works, and then the same dialog returns,
+sometimes on the very next command.
+
+This is a third mechanism, separate from both sections above. macOS calls it App Data, and the consent it
+records is held by a running process rather than stored as a setting: it lasts while that process lives and
+is gone once it exits. It is also the one family with no entry of its own in System Settings, so there is
+nothing to switch on ahead of time and nothing to revise afterwards.
+
+Which process holds the consent decides how often the dialog appears. macOS charges the request to the
+responsible app, normally agterm, so a session the running agterm started is charged to agterm — one dialog
+per launch, then quiet. Live sessions mode is different, because it carries panes across a restart on their
+own daemons: a pane carried over that way was started by an agterm that has since exited, and from then on
+every process in it answers as its own responsible process, including each command it runs. The consent
+belongs to the command, which is a new process every time, so the dialog returns on the next one.
+
+Full Disk Access is the only permanent answer. Add agterm under System Settings ▸ Privacy & Security ▸ Full
+Disk Access, which covers App Data as well as the folders above, at the cost that section describes; with it
+on, the App Data request is never made. In Live sessions mode, quitting and relaunching does not help on
+its own, since the same daemons are handed back. A launch in Fresh shells or Re-run commands mode does,
+because every session then starts under the running app.
 
 ## Reporting a problem
 

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -210,7 +210,7 @@ matching service, e.g. Automation ▸ agterm. This is macOS policy, not an agter
 
 macOS protects those folders, plus removable and network volumes, on its own: a separate mechanism from the
 services above, gated by no entitlement, and agterm is not sandboxed. The per-folder usage-description
-strings are optional and agterm ships none, so the prompt carries macOS's own wording. The answer is
+strings are optional and agterm ships one for each, so the prompt carries agterm's wording. The answer is
 recorded against the app macOS holds responsible, so another terminal listing the folder proves nothing
 about agterm. The user grants it in System Settings ▸ Privacy & Security ▸ Files & Folders ▸ agterm, or
 gives agterm Full Disk Access, which covers all of them at once. A dismissed prompt is never re-offered.
@@ -218,6 +218,18 @@ gives agterm Full Disk Access, which covers all of them at once. A dismissed pro
 not permitted` for the privacy denial, `Permission denied` for ordinary permission bits, and some `ls`
 replacements print the same wording for both. Needing the grant is macOS policy, not an agterm bug: do not
 file it.
+
+### "agterm would like to access data from other apps, over and over"
+
+macOS App Data, a third mechanism after the two above. The consent is held by a running process rather than
+stored as a setting, and App Data has no entry of its own in System Settings. macOS charges the request to
+the responsible app, so a session the running agterm started costs one prompt per agterm launch. A pane
+carried across a restart by Live sessions mode was started by an agterm that has since exited, and every
+process in it then answers as its own responsible process, so the consent belongs to each command and the
+prompt returns on the next one. Full Disk Access is the only permanent answer and stops the request being
+made at all; in Live sessions mode relaunching does not help on its own, since the same daemons are handed
+back, while a Fresh shells or Re-run commands launch starts every session under the running app. Needing the
+grant is macOS policy: do not file the prompt itself as an agterm bug.
 
 ### "The agent-status glyph does not update"
 


### PR DESCRIPTION
a command that reaches into another app's data raises the macOS dialog "Agterm.app would like to access data from other apps", and clicking Allow does not stop it coming back.

macOS calls this App Data. The consent is held by a running process instead of being stored as a setting, and it is charged to the process macOS holds responsible. A pane carried across a restart by Live sessions mode was started by an agterm that has since exited, so from then on every process in that pane answers as its own responsible process. The consent belongs to each command, which is a new process every time, so the dialog returns on the next one.

`responsibility_get_pid_responsible_for_pid` shows a pane the running app started resolving to that app's pid, and a pane carried over resolving to itself at every generation. App Data has no entry of its own in System Settings, so Full Disk Access is the only permanent answer, and with it on `tccd` allows the access on the Full Disk Access check and never reaches App Data.

**changes**

- `docs/troubleshooting.md`, new subsection on the prompt, why it repeats, and the fix
- `plugins/agterm/skills/agterm/troubleshooting.md`, the same in the skill's compact form
- both copies also drop a wrong claim: agterm was said to ship no per-folder usage-description strings, but `Info.plist` ships Desktop, Documents and Downloads, so that prompt carries agterm's wording
- `agterm/Info.plist`, adds `NSAppDataUsageDescription` in the existing wording family
