### PR TITLE
docs(cookbook): state how peer-chat.py resolves

### DIFF
--- a/cookbook/two-agent-chat/README.md
+++ b/cookbook/two-agent-chat/README.md
@@ -22,7 +22,7 @@ agterm 0.24.0 or later, which added `surface cursor`. The recipe refuses to type
 
 1. Copy `peer-chat.py` somewhere on your `PATH`, keeping the executable bit.
 2. Copy `SKILL-claude.md` to `~/.claude/skills/peer-chat/SKILL.md` and `SKILL-codex.md` to `~/.codex/skills/peer-chat/SKILL.md`. Both loaders require the installed file to be named exactly `SKILL.md`, so the suffix here only says which agent the file is for. Each one tells its own agent how to send, how to recognise an incoming message, and what it may not do to the other pane.
-3. Edit both copies so the path they name for `peer-chat.py` matches where you put it.
+3. Keep `peer-chat.py` on your `PATH`: both skills invoke it as a bare command and name no path. If you install it somewhere off `PATH` instead, prefix the command lines in both copies with its full path.
 4. If you start either agent through a wrapper script instead of as `claude` or `codex`, put that wrapper's name in the same file, as the `--target-command` value the agent should pass when sending to it. Without this the first send refuses, saying the target pane is not running the expected command.
 5. To let Codex reserve and send file-backed messages without separate approvals, add these two entries to `~/.codex/rules/default.rules`, creating the file if needed and using the command name or path from step 1:
 

--- a/cookbook/two-agent-chat/SKILL-claude.md
+++ b/cookbook/two-agent-chat/SKILL-claude.md
@@ -14,6 +14,9 @@ the script checks the target agent, window, composer and cursor, sends the body 
 observed pieces through `session type --stdin`, then sends the submit key after the final piece
 settles. A raw command bypasses those checks.
 
+Invoke `peer-chat.py` as a bare command resolved through `PATH`; it is not a file inside this
+skill directory.
+
 ## Preconditions
 
 The session needs a split with Codex already running in it, started by the user. This skill never

--- a/cookbook/two-agent-chat/SKILL-codex.md
+++ b/cookbook/two-agent-chat/SKILL-codex.md
@@ -13,6 +13,9 @@ the script checks the target agent, window, composer and cursor, sends the body 
 observed pieces through `session type --stdin`, then sends the submit key after the final piece
 settles. A raw command bypasses those checks.
 
+Invoke `peer-chat.py` as a bare command resolved through `PATH`; it is not a file inside this
+skill directory.
+
 ## Preconditions
 
 The session needs both panes running, with Claude Code on the left, started by the user. This skill


### PR DESCRIPTION
Previously, neither peer chat skill said where `peer-chat.py` lives, and Setup step 3 asked the reader to edit a path that neither skill file contains. An agent that reads a bare command inside a skill directory infers a bundled `scripts/` subdirectory, which is the layout most skills use, and invokes a path that does not exist.

This is not hypothetical. In a real session Codex read the installed `SKILL.md`, ran `~/.codex/skills/peer-chat/scripts/peer-chat.py`, got `[Errno 2] No such file or directory`, searched the filesystem, and recovered on the bare command. It then repeated the same wrong path immediately after a context compaction, because the correction lived only in the conversation while the skill text stayed silent. Asked about it afterwards, it said it had no evidence for a bundled `scripts/` directory and had applied a common skill-layout heuristic to an unconstrained bare command.

After this change both skills state that `peer-chat.py` is a bare command resolved through `PATH` and is not a file inside the skill directory. Setup step 3 now states the `PATH` requirement the recipe actually has, and keeps an instruction for the case where the script is installed elsewhere.

Documentation only. `peer-chat.py` and its tests are unchanged.
