### PR TITLE
Drop a terminal title equal to the pane's own cwd

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -525,15 +525,17 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         // already on the main actor; `oscTitle`/`splitTitle` are observed, so the sidebar row and window
         // title refresh live. like applyPwd this does NOT save() — OSC set-title re-fires on every prompt
         // redraw — and sanitizes: the title flows unquoted into a /bin/sh -c line via {AGT_SESSION_NAME}.
-        logger.debug("terminal title pane=\(self.paneToken, privacy: .public) split=\(self.isSplitPane) cwd=\(self.workingDirectory, privacy: .public) title=\(rawTitle, privacy: .public)")
         let title = TerminalText.sanitized(rawTitle)
+        // one value for the log and the drop below, so a trace can never name a cwd the check did not use.
+        let paneCwd = session.map { isSplitPane ? $0.cwd(for: .right) : $0.effectiveCwd }
+        logger.debug("terminal title pane=\(self.paneToken, privacy: .public) split=\(self.isSplitPane) cwd=\(paneCwd ?? "<none>", privacy: .public) title=\(rawTitle, privacy: .public)")
 
         // libghostty answers OSC 7 with a synthetic title equal to the pwd, and its PWD action does not
         // reliably reach `applyPwd` before that title, so no arming handshake catches it. A shell titles
         // with a basename or an abbreviated path, never the bare absolute cwd. Compares the SANITIZED
         // title, since `applyPwd` stores a sanitized cwd. Residual: between a cd and its OSC 7 the cwd
         // here is still the old one, so a synthetic title for the NEW directory is accepted.
-        if let session, title == (isSplitPane ? session.cwd(for: .right) : session.effectiveCwd) { return }
+        if title == paneCwd { return }
 
         if isSplitPane {
             if session?.splitTitle != title { session?.splitTitle = title }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -185,8 +185,6 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     var rendererVisible = true
     /// Sweeps the hidden layer's retained frame on a slow cadence; exits itself on reveal or teardown.
     var hiddenJanitorTask: Task<Void, Never>?
-    /// Sanitized OSC 7 value expected back as libghostty's synthetic title while this pane has no real title.
-    private var pendingPwdFallbackTitle: String?
     /// After `destroySurface()` the view is retired: never recreate a surface (a stray viewDidMoveToWindow).
     private var isDestroyed = false
 
@@ -516,13 +514,6 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         // no save(): OSC 7 fires on every cd/prompt redraw and would thrash the disk. live cwd is persisted on
         // quit and on structural mutations, so a crash loses only cwd changes since the last save. the
         // equality guard matters likewise: an equal write still notifies observers and churns the reconcile.
-        if let session {
-            let modelTitle = isSplitPane ? session.splitTitle : session.oscTitle
-            let titleIsBlank = modelTitle?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
-            pendingPwdFallbackTitle = titleIsBlank ? pwd : nil
-        } else {
-            pendingPwdFallbackTitle = nil
-        }
         if isSplitPane {
             if session?.splitCwd != pwd { session?.splitCwd = pwd }
         } else {
@@ -536,11 +527,13 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         // redraw — and sanitizes: the title flows unquoted into a /bin/sh -c line via {AGT_SESSION_NAME}.
         logger.debug("terminal title pane=\(self.paneToken, privacy: .public) split=\(self.isSplitPane) cwd=\(self.workingDirectory, privacy: .public) title=\(rawTitle, privacy: .public)")
         let title = TerminalText.sanitized(rawTitle)
-        if pendingPwdFallbackTitle == title {
-            pendingPwdFallbackTitle = nil
-            return
-        }
-        pendingPwdFallbackTitle = nil
+
+        // libghostty answers OSC 7 with a synthetic title equal to the pwd, and its PWD action does not
+        // reliably reach `applyPwd` before that title, so no arming handshake catches it. A shell titles
+        // with a basename or an abbreviated path, never the bare absolute cwd. Compares the SANITIZED
+        // title, since `applyPwd` stores a sanitized cwd. Residual: between a cd and its OSC 7 the cwd
+        // here is still the old one, so a synthetic title for the NEW directory is accepted.
+        if let session, title == (isSplitPane ? session.cwd(for: .right) : session.effectiveCwd) { return }
 
         if isSplitPane {
             if session?.splitTitle != title { session?.splitTitle = title }

--- a/agtermTests/GhosttySurfaceViewTitleTests.swift
+++ b/agtermTests/GhosttySurfaceViewTitleTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class GhosttySurfaceViewTitleTests: XCTestCase {
-    func testPwdFallbackDoesNotBecomePrimaryTitle() {
+    func testCwdEqualTitleIsDroppedAfterPwdReport() {
         let (session, view) = makeView()
 
         view.applyPwd("/tmp/\u{7}repo")
@@ -14,37 +14,102 @@ final class GhosttySurfaceViewTitleTests: XCTestCase {
         XCTAssertNil(session.oscTitle)
     }
 
-    func testRealTitleEqualToCwdWinsAfterPwdFallback() {
+    func testCwdEqualTitleIsDroppedWithoutAnyPwdReport() {
+        // a live-restored pane can get the synthetic title before the PWD action, leaving a guard armed
+        // by applyPwd unfired and the absolute path in the sidebar.
+        let (session, view) = makeView()
+
+        view.applyTitle("/tmp/start")
+
+        XCTAssertNil(session.currentCwd)
+        XCTAssertNil(session.oscTitle)
+    }
+
+    func testRepeatedCwdEqualTitleStaysDropped() {
         let (session, view) = makeView()
 
         view.applyPwd("/tmp/repo")
         view.applyTitle("/tmp/repo")
         view.applyTitle("/tmp/repo")
 
-        XCTAssertEqual(session.oscTitle, "/tmp/repo")
+        XCTAssertNil(session.oscTitle)
     }
 
-    func testExistingTitleDoesNotArmPwdFallback() {
+    func testCwdEqualTitleLeavesAnExistingTitleAlone() {
         let (session, view) = makeView()
         session.oscTitle = "existing"
 
         view.applyPwd("/tmp/repo")
         view.applyTitle("/tmp/repo")
 
-        XCTAssertEqual(session.oscTitle, "/tmp/repo")
+        XCTAssertEqual(session.oscTitle, "existing")
     }
 
-    func testDifferentTitleClearsPwdFallbackCandidate() {
+    func testRealTitleIsKeptAndDoesNotUnlockTheCwdTitle() {
         let (session, view) = makeView()
 
         view.applyPwd("/tmp/repo")
         view.applyTitle("chosen")
         view.applyTitle("/tmp/repo")
 
-        XCTAssertEqual(session.oscTitle, "/tmp/repo")
+        XCTAssertEqual(session.oscTitle, "chosen")
     }
 
-    func testPwdFallbackCandidateSurvivesSplitPromotion() {
+    func testTitleUnderTheCwdIsKept() {
+        let (session, view) = makeView()
+
+        view.applyPwd("/tmp/repo")
+        view.applyTitle("repo")
+
+        XCTAssertEqual(session.oscTitle, "repo")
+    }
+
+    func testSplitPaneDropsATitleEqualToItsOwnCwd() {
+        let (session, view) = makeView(split: true)
+        session.initialSplitCwd = "/tmp/right"
+
+        view.applyTitle("/tmp/right")
+
+        XCTAssertNil(session.splitTitle)
+    }
+
+    func testTitleIsSanitizedBeforeTheCwdComparison() {
+        let (session, view) = makeView()
+
+        view.applyPwd("/tmp/repo")
+        view.applyTitle("/tmp/\u{7}repo")
+
+        XCTAssertNil(session.oscTitle)
+    }
+
+    func testSplitPaneComparesTheLiveSplitCwdOverTheRestoredOne() {
+        let (session, view) = makeView(split: true)
+        session.initialSplitCwd = "/tmp/restored"
+
+        view.applyPwd("/tmp/live")
+        view.applyTitle("/tmp/live")
+
+        XCTAssertNil(session.splitTitle)
+    }
+
+    func testSplitPaneWithNoSplitCwdFallsBackToThePrimaryCwd() {
+        let (session, view) = makeView(split: true)
+
+        view.applyTitle("/tmp/start")
+
+        XCTAssertNil(session.splitTitle)
+    }
+
+    func testSplitPaneKeepsATitleEqualToThePrimaryCwd() {
+        let (session, view) = makeView(split: true)
+        session.initialSplitCwd = "/tmp/right"
+
+        view.applyTitle("/tmp/start")
+
+        XCTAssertEqual(session.splitTitle, "/tmp/start")
+    }
+
+    func testPromotedSplitDropsTheTitleEqualToTheMigratedCwd() {
         let (session, view) = makeView(split: true)
 
         view.applyPwd("/tmp/right")

--- a/docs/backlog/control-tree-exposes-no-split-pane-cwd.md
+++ b/docs/backlog/control-tree-exposes-no-split-pane-cwd.md
@@ -23,4 +23,4 @@ hits the same wall.
 Adding it is a `splitCwd` field on `ControlSessionNode`, populated from `session.splitCwd ??
 session.initialSplitCwd` next to the existing split fields, plus the read-back test the control-api
 rule requires. The `title`/`splitTitle` pair has the same asymmetry and is worth deciding at the same
-time. Surfaced by Fable while reviewing the synthetic-title fix.
+time. Surfaced while verifying the synthetic-title fix.

--- a/docs/backlog/control-tree-exposes-no-split-pane-cwd.md
+++ b/docs/backlog/control-tree-exposes-no-split-pane-cwd.md
@@ -1,0 +1,26 @@
+---
+worth: later
+where: agtermCore/Sources/agtermCore/ControlProjection.swift:87
+added: 2026-09-03
+---
+# The control tree exposes no split-pane cwd
+
+`ControlSessionNode` carries one `cwd`, the primary pane's. It already exposes the split's other
+per-pane state — `splitFocused`, `splitRatio`, `splitAxis`, `splitFontSize`, `splitForegroundShell` —
+so the directory is the one split field a caller cannot read. `Session.splitCwd` (and its restored
+`initialSplitCwd` fallback) is what `cwd(for: .right)` resolves, and nothing projects it.
+
+A caller cannot tell where a split pane actually is. That matters for any script that reasons about a
+session's panes separately: spawning something in the split's directory, or checking a pane's location
+before acting on it, both need a `tree` read the API cannot answer.
+
+It also blocks verification. The synthetic-title harness asserts each session's sidebar name against
+the basename of its cwd, and for the one session whose split lives in a different directory
+(`reproxy`, split in `fya`) it has no expectation to build, so that session's split pane is excluded
+from the check rather than verified. Any future harness comparing a pane against its own directory
+hits the same wall.
+
+Adding it is a `splitCwd` field on `ControlSessionNode`, populated from `session.splitCwd ??
+session.initialSplitCwd` next to the existing split fields, plus the read-back test the control-api
+rule requires. The `title`/`splitTitle` pair has the same asymmetry and is worth deciding at the same
+time. Surfaced by Fable while reviewing the synthetic-title fix.


### PR DESCRIPTION
a restored session sometimes shows its full path in the sidebar instead of its name. Started with live restore (#515), and hits a different session on each restart.

**what breaks**

libghostty answers an OSC 7 with a synthetic title equal to the pwd, emitted right after its PWD action. The guard in 6d34e63c armed a one-shot slot in `applyPwd` and dropped the next title matching it, which assumes the PWD action always arrives first. It does not: measured across a 60-session live restore, roughly a third of panes get the title with the slot still empty, and the absolute path is accepted as the session's title.

That much predates zmx. Live restore is what makes it visible: a reattached shell draws no new prompt, so no real OSC 2 ever writes over the wrong title, and the path stays in the sidebar until the user presses Enter in that pane.

**the fix**

Compare the sanitized title against the pane's own cwd, which needs no ordering at all: `effectiveCwd` for the primary pane, `cwd(for: .right)` for the split. `currentCwd` alone is wrong here, a restored session leaves it nil until the first `applyPwd`. A shell titles with a basename or an abbreviated path, never the bare absolute cwd, so nothing real is dropped. `pendingPwdFallbackTitle` goes away.

Three existing tests asserted that a title equal to the cwd wins, which was the defect written down as expected behavior. They flip. Twelve tests now cover the pane roles, the fallback order and that sanitization runs before the comparison.

**evidence**

An isolated instance seeded with a copy of a real 60-session tree, shell-only panes, restarted repeatedly. The check is positive rather than negative: every session's sidebar name must equal its snapshot `customName` where it has one, else the basename of its cwd.

| arm | rounds | session-observations | wrong |
| --- | --- | --- | --- |
| unfixed | 6 | 360 | 7, in 5 rounds |
| fixed | 12 | 720 | 0 |
| fixed, split focused | 8 | 480 | 0 |
| fixed, instrumentation stripped | 5 | 300 | 0 |

The first two arms are the headline: round-level Fisher, 5 of 6 against 0 of 12, p = 7e-4. Rounds are the unit because session-observations cluster within a round. The third arm exists because the sidebar reads `splitTitle` only while the split has focus, and a restored tree focuses the primary everywhere, so a right-pane leak is invisible without flipping focus. The fourth reruns the whole thing on the build with the probes removed, since those probes sat inside the two functions whose ordering is the defect.

**known residual**

Between a `cd` and its OSC 7 the compared cwd is still the old one, so a synthetic title naming the new directory is accepted. Narrow, and it needs libghostty's `seen_title` to be false. The stricter alternative, dropping any title beginning with `/`, removes it but also discards a title a program set deliberately. Recorded in the code comment.

The harness cannot check one session's split pane: its split lives in a different directory and the control tree exposes no split cwd to build an expectation from. Backlogged in `docs/backlog/control-tree-exposes-no-split-pane-cwd.md`.
