### PR TITLE
fix(hud): resolve pane-scoped placement against the pane, not the window

### DIFF
--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -13,15 +13,41 @@ enum PaneHostIdentity {
     }
 }
 
-private struct PaneHostCoordinateSpace: Hashable {
-    let sessionID: UUID
+/// The deck panes' bounds, carried as SwiftUI anchors rather than as resolved rects. `HSplitView` hosts its
+/// arranged subviews across an AppKit bridge that a named coordinate space does not cross: `frame(in:)`
+/// inside a split silently returns WINDOW coordinates, which the overlay layer then applies a second time
+/// through `.position`. An anchor has no space of its own — the reader resolves it in the reader's — so both
+/// the split and the lone-pane shape land in the session detail space `HudPaneFrame` documents.
+struct HudPaneAnchors {
+    var left: Anchor<CGRect>?
+    var right: Anchor<CGRect>?
+
+    mutating func merge(_ other: HudPaneAnchors) {
+        if let left = other.left { self.left = left }
+        if let right = other.right { self.right = right }
+    }
+
+    /// The panes' bounds in `proxy`'s own space.
+    func frames(in proxy: GeometryProxy) -> HudPaneFrames {
+        HudPaneFrames(left: left.map { HudPaneFrame(proxy[$0]) },
+                      right: right.map { HudPaneFrame(proxy[$0]) })
+    }
 }
 
-private struct HudPaneFramesPreferenceKey: PreferenceKey {
-    static let defaultValue = HudPaneFrames()
+struct HudPaneAnchorsPreferenceKey: PreferenceKey {
+    static let defaultValue = HudPaneAnchors()
 
-    static func reduce(value: inout HudPaneFrames, nextValue: () -> HudPaneFrames) {
+    static func reduce(value: inout HudPaneAnchors, nextValue: () -> HudPaneAnchors) {
         value.merge(nextValue())
+    }
+}
+
+extension View {
+    /// Publishes this pane host's bounds for the session's overlay layer to resolve.
+    func hudPaneAnchor(_ pane: OverlayPane) -> some View {
+        anchorPreference(key: HudPaneAnchorsPreferenceKey.self, value: .bounds) { anchor in
+            pane == .left ? HudPaneAnchors(left: anchor) : HudPaneAnchors(right: anchor)
+        }
     }
 }
 
@@ -119,12 +145,9 @@ extension WindowContentView {
                     .zIndex(1)
             }
         }
-        .coordinateSpace(.named(PaneHostCoordinateSpace(sessionID: session.id)))
-        .overlayPreferenceValue(HudPaneFramesPreferenceKey.self) { frames in
+        .overlayPreferenceValue(HudPaneAnchorsPreferenceKey.self) { anchors in
             overlayPanel(session: session, isActive: focusable,
-                         onScreen: deckInteractive && isActive, paneFrames: frames)
-                .onAppear { cachePaneFrames(frames, for: session) }
-                .onChange(of: frames) { _, value in cachePaneFrames(value, for: session) }
+                         onScreen: deckInteractive && isActive, paneAnchors: anchors)
         }
         // on PROGRAM overlay close refocus the topmost remaining surface via `topmostSurface` — never a pane
         // hidden under the scratch. One makeFirstResponder loses the race with the overlay's teardown/re-host,
@@ -228,17 +251,7 @@ extension WindowContentView {
             }
             paneOverlayPanel(session: session, pane: pane, focused: focused, gates: gates)
         }
-        .background {
-            GeometryReader { geo in
-                let rect = geo.frame(in: .named(PaneHostCoordinateSpace(sessionID: session.id)))
-                let frame = HudPaneFrame(x: Double(rect.minX), y: Double(rect.minY),
-                                         width: Double(rect.width), height: Double(rect.height))
-                Color.clear.preference(
-                    key: HudPaneFramesPreferenceKey.self,
-                    value: pane == .left ? HudPaneFrames(left: frame) : HudPaneFrames(right: frame)
-                )
-            }
-        }
+        .hudPaneAnchor(pane)
     }
 
     /// FULL, FLOATING, and HUD overlays render in `sessionDetail`'s always-present preference layer. Content
@@ -248,13 +261,14 @@ extension WindowContentView {
     /// Metal drawable). `OverlayPanelStyle` supplies every per-occupant parameter, so the chain below is the
     /// same chain whichever one is up.
     @ViewBuilder private func overlayPanel(session: Session, isActive: Bool, onScreen: Bool,
-                                           paneFrames: HudPaneFrames) -> some View {
+                                           paneAnchors: HudPaneAnchors) -> some View {
         let style = OverlayPanelStyle.resolve(session)
         // a HUD is passive: it neither takes first responder nor absorbs the clicks around it, so the panel
         // stays inert as a whole and the session underneath keeps both.
         let live = isActive && style.interactive
         GeometryReader { geo in
             let detailFrame = CGRect(origin: .zero, size: geo.size)
+            let paneFrames = paneAnchors.frames(in: geo)
             let paneFrame = session.hudTargetPane.flatMap { paneFrames[$0] }.map { CGRect($0) }
             let scopedHudVisible = OverlayPanelStyle.hudCanMount(
                 paneIdentity: session.hudPaneIdentity, paneFrameAvailable: paneFrame != nil
@@ -302,6 +316,8 @@ extension WindowContentView {
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
+            .onAppear { cachePaneFrames(paneFrames, for: session) }
+            .onChange(of: paneFrames) { _, value in cachePaneFrames(value, for: session) }
         }
         // with no overlay up this is an empty full-frame GeometryReader; keep it inert so it never
         // intercepts clicks meant for the pane(s).
@@ -502,6 +518,13 @@ private extension CGRect {
     init(_ frame: HudPaneFrame) {
         self.init(x: CGFloat(frame.x), y: CGFloat(frame.y),
                   width: CGFloat(frame.width), height: CGFloat(frame.height))
+    }
+}
+
+private extension HudPaneFrame {
+    init(_ rect: CGRect) {
+        self.init(x: Double(rect.minX), y: Double(rect.minY),
+                  width: Double(rect.width), height: Double(rect.height))
     }
 }
 

--- a/agtermTests/HudDeckGatesTests.swift
+++ b/agtermTests/HudDeckGatesTests.swift
@@ -341,17 +341,20 @@ final class HudDeckGatesTests: XCTestCase {
         // than for the first one to arrive — a fixed settle would only move the threshold.
         let deadline = Date().addingTimeInterval(2)
         var settled: HudPaneFrames?
+        var previous: HudPaneFrames?
         var repeats = 0
-        while Date() < deadline {
+        while Date() < deadline, settled == nil {
             // forcing a pass every turn is what makes a repeat mean "layout settled" rather than
             // "no pass has run yet", which a pre-layout rect would satisfy just as well.
             window.layoutIfNeeded()
             RunLoop.main.run(until: Date().addingTimeInterval(0.01))
             guard let current = resolved, current.left != nil, !split || current.right != nil else { continue }
-            repeats = current == settled ? repeats + 1 : 0
-            settled = current
-            if repeats >= 2 { break }
+            repeats = current == previous ? repeats + 1 : 0
+            previous = current
+            if repeats >= 2 { settled = current }
         }
+        // only a value that repeated is returned: handing back the last mid-flight sample would fail the
+        // assertions as a coordinate leak when the fixture simply never settled.
         return try XCTUnwrap(settled, "the deck never reported settled pane frames")
     }
 }

--- a/agtermTests/HudDeckGatesTests.swift
+++ b/agtermTests/HudDeckGatesTests.swift
@@ -1,4 +1,6 @@
 import agtermCore
+import AppKit
+import SwiftUI
 import XCTest
 @testable import agterm
 
@@ -258,5 +260,89 @@ final class HudDeckGatesTests: XCTestCase {
         XCTAssertTrue(OverlayPanelStyle.hudCanMount(paneIdentity: nil, paneFrameAvailable: false))
         XCTAssertFalse(OverlayPanelStyle.hudCanMount(paneIdentity: UUID(), paneFrameAvailable: false))
         XCTAssertTrue(OverlayPanelStyle.hudCanMount(paneIdentity: UUID(), paneFrameAvailable: true))
+    }
+
+    // MARK: - pane frame resolution
+
+    /// Discussion #384: a pane-scoped panel landed one detail-column origin off inside a split. `HSplitView`
+    /// hosts its arranged subviews across an AppKit bridge, so a pane measuring itself there reports window
+    /// coordinates; only the resolver's own space is the one the panel is positioned in. The fixture puts the
+    /// deck behind a sidebar and a titlebar so a leaked window origin has somewhere to show up.
+    func testSplitPaneFramesResolveAgainstTheDeckAndNotTheWindow() throws {
+        let frames = try resolvePaneFrames(split: true)
+
+        let left = try XCTUnwrap(frames.left)
+        let right = try XCTUnwrap(frames.right)
+        XCTAssertEqual(left.x, 0, accuracy: 0.5, "the left pane starts at the deck's own origin")
+        XCTAssertEqual(left.y, 0, accuracy: 0.5)
+        XCTAssertEqual(right.y, 0, accuracy: 0.5)
+        XCTAssertEqual(left.height, Self.deckSize.height, accuracy: 0.5)
+        XCTAssertEqual(right.x, left.width + Self.dividerAllowance, accuracy: Self.dividerAllowance)
+        XCTAssertEqual(right.x + right.width, Self.deckSize.width, accuracy: 0.5,
+                       "the panes must span the deck exactly, leaving no room for a window offset")
+    }
+
+    func testLonePaneFrameSpansTheWholeDeck() throws {
+        let frames = try resolvePaneFrames(split: false)
+
+        let left = try XCTUnwrap(frames.left)
+        XCTAssertNil(frames.right)
+        XCTAssertEqual(left.x, 0, accuracy: 0.5)
+        XCTAssertEqual(left.y, 0, accuracy: 0.5)
+        XCTAssertEqual(left.width, Self.deckSize.width, accuracy: 0.5)
+        XCTAssertEqual(left.height, Self.deckSize.height, accuracy: 0.5)
+    }
+
+    // MARK: - pane frame fixture
+
+    private static let sidebarWidth: CGFloat = 200
+    private static let titlebarHeight: CGFloat = 50
+    private static let deckSize = CGSize(width: 600, height: 550)
+    /// `HSplitView` spends a point on the divider, so the right pane starts just past the left one's width.
+    private static let dividerAllowance: CGFloat = 1
+
+    /// Mounts the production emitter and resolver in the shape that broke: a deck offset from the window by
+    /// a sidebar and a titlebar, with the panes inside `HSplitView`.
+    private func resolvePaneFrames(split: Bool) throws -> HudPaneFrames {
+        var resolved: HudPaneFrames?
+        let probe = HStack(spacing: 0) {
+            Color.clear.frame(width: Self.sidebarWidth)
+            VStack(spacing: 0) {
+                Color.clear.frame(height: Self.titlebarHeight)
+                ZStack {
+                    if split {
+                        HSplitView {
+                            Color.clear.frame(maxWidth: .infinity, maxHeight: .infinity).hudPaneAnchor(.left)
+                            Color.clear.frame(maxWidth: .infinity, maxHeight: .infinity).hudPaneAnchor(.right)
+                        }
+                    } else {
+                        Color.clear.hudPaneAnchor(.left)
+                    }
+                }
+                .overlayPreferenceValue(HudPaneAnchorsPreferenceKey.self) { anchors in
+                    GeometryReader { geo in
+                        let frames = anchors.frames(in: geo)
+                        Color.clear
+                            .onAppear { resolved = frames }
+                            .onChange(of: frames) { _, value in resolved = value }
+                    }
+                }
+            }
+        }
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0,
+                                                  width: Self.sidebarWidth + Self.deckSize.width,
+                                                  height: Self.titlebarHeight + Self.deckSize.height),
+                              styleMask: .borderless, backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        window.contentView = NSHostingView(rootView: probe)
+        window.layoutIfNeeded()
+        let deadline = Date().addingTimeInterval(2)
+        while resolved?.left == nil || (split && resolved?.right == nil), Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        // the first layout pass reports a pre-layout rect, so settle before reading.
+        for _ in 0..<5 { RunLoop.main.run(until: Date().addingTimeInterval(0.01)) }
+        return try XCTUnwrap(resolved)
     }
 }

--- a/agtermTests/HudDeckGatesTests.swift
+++ b/agtermTests/HudDeckGatesTests.swift
@@ -337,12 +337,21 @@ final class HudDeckGatesTests: XCTestCase {
         defer { window.close() }
         window.contentView = NSHostingView(rootView: probe)
         window.layoutIfNeeded()
+        // the first layout pass reports a pre-layout rect, so wait for the frames to stop moving rather
+        // than for the first one to arrive — a fixed settle would only move the threshold.
         let deadline = Date().addingTimeInterval(2)
-        while resolved?.left == nil || (split && resolved?.right == nil), Date() < deadline {
+        var settled: HudPaneFrames?
+        var repeats = 0
+        while Date() < deadline {
+            // forcing a pass every turn is what makes a repeat mean "layout settled" rather than
+            // "no pass has run yet", which a pre-layout rect would satisfy just as well.
+            window.layoutIfNeeded()
             RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+            guard let current = resolved, current.left != nil, !split || current.right != nil else { continue }
+            repeats = current == settled ? repeats + 1 : 0
+            settled = current
+            if repeats >= 2 { break }
         }
-        // the first layout pass reports a pre-layout rect, so settle before reading.
-        for _ in 0..<5 { RunLoop.main.run(until: Date().addingTimeInterval(0.01)) }
-        return try XCTUnwrap(resolved)
+        return try XCTUnwrap(settled, "the deck never reported settled pane frames")
     }
 }


### PR DESCRIPTION
a pane-scoped HUD drew one detail-column origin off whenever the session was split: shifted right by the sidebar plus divider, and up by the titlebar plus its hairline. Reported by @iatsiuk in https://github.com/umputun/agterm/discussions/384 with the exact numbers, on 0.26.3.

`HSplitView` hosts its arranged subviews across an AppKit bridge that a SwiftUI named coordinate space does not cross. `deckPane` measured itself with `frame(in: .named(PaneHostCoordinateSpace))`, which inside a split silently returns WINDOW coordinates instead, and `overlayPanel` then applied that origin a second time through `.position`. A lone pane sits outside the split, so only split sessions were wrong.

a standalone SwiftUI probe with the same shape confirms it. Inside `HSplitView` the left pane reports `.named` as `(200, 82, 399.5, 650)`, byte-identical to its `.global`, while the overlay's own `.global` is `(200, 82, 800, 650)`. Outside `HSplitView` the same pane reports `(0, 0)`.

the fix carries pane bounds as `Anchor<CGRect>` instead. An anchor has no space of its own, so the overlay layer resolves it with its own `GeometryProxy` and both shapes come out in the session detail space. `PaneHostCoordinateSpace` and its `.coordinateSpace` modifier are gone, and `deckPane`'s background `GeometryReader` collapses to one `.hudPaneAnchor(pane)`.

`agtermCore` is untouched on purpose. `HudPaneFrame` is public, documented as session-detail coordinates, and the `agterm-linux` fork consumes that module, so an earlier version of this that emitted global frames and normalized only at the layout site was dropped: it would have moved a published contract with nothing to tell the fork.

two hosted tests mount the emitter and the resolver behind a 200pt sidebar and a 50pt titlebar, where a leaked window origin has somewhere to show up. Reintroducing the leak fails seven assertions with exactly the shifts from the report.

checked by hand in a Debug instance: nine anchors, both panes, panel stays inside the pane it names.

one thing this does not cover. There is still no test of where the panel actually renders, which is why this got through in the first place. The HUD is a Metal surface with no addressable XCUIElement and it is click-transparent, so a screenshot comparison is the only XCUITest route, and that is its own piece of work.

Related to https://github.com/umputun/agterm/discussions/384
