### PR TITLE
fix(sidebar): update session labels in place

### DIFF
--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -349,10 +349,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// A row's visible content: label (workspace name or session `displayName`), split-rectangle icon,
-        /// the gated unseen-badge count and the agent-status indicator. A delta reloads just that row. Uses
-        /// `hasSplit` (not `isSplit`) so the icon persists while a split is hidden.
+        /// the gated unseen-badge count and the agent-status indicator. A delta reloads just that row, except
+        /// a session's label alone, which its live cell takes in place. Uses `hasSplit` (not `isSplit`) so
+        /// the icon persists while a split is hidden.
         private struct RowContent: Equatable {
-            let label: String
+            var label: String
             let hasSplit: Bool
             let splitAxis: SplitAxis
             let unseen: Int
@@ -364,6 +365,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
             /// independent of `focusEnabled`, so marking re-renders just that row even while the filter is
             /// off (with it on the shape changes too and the rebuild branch takes over). False for sessions.
             let focusMember: Bool
+
+            func differsOnlyInLabel(from other: RowContent) -> Bool {
+                var relabeled = self
+                relabeled.label = other.label
+                return label != other.label && relabeled == other
+            }
         }
 
         /// The session's own agent-status indicator (`.idle` for an unknown id / workspace row). Shown
@@ -381,8 +388,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// Decides between a full rebuild (a SHAPE change: add/move/close/reorder) and a targeted per-row
-        /// reload (a content change: rename, cwd-driven name, split open/close, badge). A reload during an
-        /// in-progress rename is skipped so a tick can't drop the edit.
+        /// update (a content change: rename, cwd-driven name, split open/close, badge). A row update during
+        /// an in-progress rename is skipped so a tick can't drop the edit.
         func reconcile() {
             // a mode flip swaps the whole data source, so rebuild regardless of the shape diff.
             let shape = currentShape()
@@ -409,15 +416,19 @@ struct WorkspaceSidebar: NSViewRepresentable {
             }
         }
 
-        /// Reloads only the rows whose visible content changed — the session row and, for a badge roll-up,
-        /// its workspace row. A per-row `reloadItem` re-renders at the row's stable frame, so a name/cwd
+        /// Updates only the rows whose visible content changed — the session row and, for a badge roll-up,
+        /// its workspace row. A session row whose label alone changed is relabeled in place; every other
+        /// delta takes a per-row `reloadItem`, which re-renders at the row's stable frame, so a name/cwd
         /// update never re-lays-out the tree. Skipped mid-rename so it can't drop an in-progress edit.
         private func reloadChangedContentRows() {
             guard let outline = outlineView, !renameController.isCommitting, !renameController.isEditing else { return }
             func reloadIfChanged(_ id: UUID, _ content: RowContent) {
-                guard content != lastRowContent[id] else { return }
+                let previous = lastRowContent[id]
+                guard content != previous else { return }
                 lastRowContent[id] = content
-                if let node = nodeCache[id] { outline.reloadItem(node) }
+                guard let node = nodeCache[id] else { return }
+                if node.kind == .session, previous?.differsOnlyInLabel(from: content) == true, relabel(node, content.label) { return }
+                outline.reloadItem(node)
             }
             for workspace in store.workspaces {
                 reloadIfChanged(workspace.id, rowContent(forWorkspace: workspace))
@@ -425,6 +436,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
                     reloadIfChanged(session.id, rowContent(forSession: session, workspaceName: workspace.name))
                 }
             }
+        }
+
+        /// Puts a new label on a session row's live cell; false when the row has no cell (collapsed or
+        /// scrolled off). Schedules layout so the changed label refreshes its truncation tooltip.
+        private func relabel(_ node: SidebarNode, _ label: String) -> Bool {
+            guard let outline = outlineView else { return false }
+            let row = outline.row(forItem: node)
+            guard row >= 0, let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: false) as? SidebarCellView,
+                  let field = cell.textField else { return false }
+            field.stringValue = label
+            cell.needsLayout = true
+            return true
         }
 
         /// Records every row's current visible content, keyed by id, so the next reconcile can diff it.

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -341,7 +341,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         // MARK: - Model rebuild
 
         /// The tree SHAPE: a workspace's id and its ordered session ids. Equal shapes mean no
-        /// add/remove/move/reorder, so a content change takes a targeted per-row reload. Row TEXT is NOT
+        /// add/remove/move/reorder, so a content change takes a targeted per-row update. Row TEXT is NOT
         /// here: a cwd-driven `displayName` change must not `reloadData` + re-expand, which jitters labels.
         private struct TreeShape: Equatable {
             let workspaceID: UUID

--- a/agtermTests/SidebarRowViewsTests.swift
+++ b/agtermTests/SidebarRowViewsTests.swift
@@ -66,6 +66,23 @@ final class SidebarRowViewsTests: XCTestCase {
         XCTAssertNil(field.toolTip, "a fully visible name needs no tooltip; repeating it on hover is noise")
     }
 
+    func testATitleTickRefreshesTheTooltipOnTheLiveCell() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+        let cell = try renderedCell(forSession: session.id)
+        let long = "PROJ-123 enforce the storage quota on the plan endpoint before the billing cutover"
+
+        for (title, expected) in [("api", nil), (long, long), ("api", nil)] {
+            session.oscTitle = title
+            coordinator.reconcile()
+            cell.layoutSubtreeIfNeeded()
+            XCTAssertTrue(try renderedCell(forSession: session.id) === cell, "a title tick must keep the cell")
+            XCTAssertEqual(cell.textField?.stringValue, title)
+            XCTAssertEqual(cell.textField?.toolTip, expected, "the relabel must schedule the layout pass that owns the tooltip")
+        }
+    }
+
     func testWideningTheRowClearsAToolTipItNoLongerNeeds() throws {
         let store = try XCTUnwrap(library.activeStore)
         let session = try XCTUnwrap(store.activeSession)
@@ -163,14 +180,18 @@ final class SidebarRowViewsTests: XCTestCase {
     }
 
     private func renderedNameField(forSession id: UUID) throws -> NSTextField {
+        let cell = try renderedCell(forSession: id)
+        cell.layoutSubtreeIfNeeded()
+        return try XCTUnwrap(cell.textField)
+    }
+
+    private func renderedCell(forSession id: UUID) throws -> SidebarCellView {
         outline.layoutSubtreeIfNeeded()
         let row = try XCTUnwrap((0..<outline.numberOfRows).first { index in
             guard let node = outline.item(atRow: index) as? SidebarNode else { return false }
             return node.kind == .session && node.id == id
         }, "the session row should be visible in the outline")
-        let cell = try XCTUnwrap(outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? SidebarCellView)
-        cell.layoutSubtreeIfNeeded()
-        return try XCTUnwrap(cell.textField)
+        return try XCTUnwrap(outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? SidebarCellView)
     }
 
     private func renderedIcon(forSession id: UUID) throws -> NSImage? {

--- a/agtermTests/SidebarStatusBlinkTests.swift
+++ b/agtermTests/SidebarStatusBlinkTests.swift
@@ -4,7 +4,7 @@ import XCTest
 import agtermCore
 
 /// Hosted coverage for the sidebar status glyph's blink lifecycle: it starts and stops with the indicator,
-/// and survives a per-row reload, which a terminal title change triggers through `displayName`.
+/// and survives a terminal title change, which relabels the row's cell in place through `displayName`.
 @MainActor
 final class SidebarStatusBlinkTests: XCTestCase {
     private var stateDir: URL!
@@ -13,6 +13,7 @@ final class SidebarStatusBlinkTests: XCTestCase {
     private var window: NSWindow!
     private var outline: SidebarOutlineView!
     private var coordinator: WorkspaceSidebar.Coordinator!
+    private var builds: CellBuildCounter!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -30,6 +31,7 @@ final class SidebarStatusBlinkTests: XCTestCase {
             window = nil
             outline = nil
             coordinator = nil
+            builds = nil
             actions = nil
             library = nil
             try? FileManager.default.removeItem(at: stateDir)
@@ -48,15 +50,31 @@ final class SidebarStatusBlinkTests: XCTestCase {
         session.agentIndicator = AgentIndicator(status: .active, blink: true)
         coordinator.reconcile()
         let (firstCell, firstBlink) = try renderedStatus(forSession: session.id)
+        let built = builds.count
 
         session.oscTitle = "spin 1"
         coordinator.reconcile()
         let (secondCell, secondBlink) = try renderedStatus(forSession: session.id)
 
-        XCTAssertTrue(firstCell === secondCell,
-                      "a per-row reload must recycle the cell, or a surviving animation proves nothing")
+        XCTAssertEqual(builds.count, built, "a title tick must relabel the live cell, not rebuild it through reloadItem")
+        XCTAssertTrue(firstCell === secondCell, "the relabel must land on the cell already on screen")
+        XCTAssertEqual(secondCell.textField?.stringValue, "spin 1")
         XCTAssertTrue(firstBlink === secondBlink,
-                      "the blink must ride through the reload; a fresh animation restarts the fade at full opacity")
+                      "the blink must ride through the relabel; a fresh animation restarts the fade at full opacity")
+    }
+
+    func testAFlagChangeStillRebuildsTheCell() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+        _ = try renderedRow(forSession: session.id)
+        let built = builds.count
+
+        session.flagged = true
+        coordinator.reconcile()
+        _ = try renderedRow(forSession: session.id)
+
+        XCTAssertGreaterThan(builds.count, built, "the counter must see a reload, or the zero above proves nothing")
     }
 
     func testStatusChangeStillStartsTheBlink() throws {
@@ -123,8 +141,9 @@ final class SidebarStatusBlinkTests: XCTestCase {
     private func buildSidebar(for store: AppStore) {
         outline = SidebarOutlineView()
         coordinator = WorkspaceSidebar.Coordinator(store: store, actions: actions)
+        builds = CellBuildCounter(forwarding: coordinator)
         outline.dataSource = coordinator
-        outline.delegate = coordinator
+        outline.delegate = builds
         outline.headerView = nil
         outline.rowSizeStyle = .custom
         outline.rowHeight = AppSettings.sidebarRowHeight(fontSize: GhosttyApp.shared.sidebarFontSize)
@@ -162,5 +181,29 @@ final class SidebarStatusBlinkTests: XCTestCase {
         let blink = try XCTUnwrap(cell.statusIcon.layer?.animation(forKey: Self.blinkKey),
                                   "a blinking status should have installed the opacity animation")
         return (cell, blink)
+    }
+}
+
+/// Counts the outline's cell-builder calls and hands every other delegate message to the coordinator.
+@MainActor
+private final class CellBuildCounter: NSObject, NSOutlineViewDelegate {
+    private(set) var count = 0
+    private let coordinator: WorkspaceSidebar.Coordinator
+
+    init(forwarding coordinator: WorkspaceSidebar.Coordinator) {
+        self.coordinator = coordinator
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+        count += 1
+        return coordinator.outlineView(outlineView, viewFor: tableColumn, item: item)
+    }
+
+    override func responds(to aSelector: Selector!) -> Bool {
+        super.responds(to: aSelector) || coordinator.responds(to: aSelector)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        coordinator
     }
 }

--- a/docs/backlog/flagged-noop-rename-strips-workspace-tail.md
+++ b/docs/backlog/flagged-noop-rename-strips-workspace-tail.md
@@ -1,0 +1,24 @@
+---
+worth: yes
+where: agterm/Views/SidebarRenameController.swift:56
+added: 2026-09-04
+---
+# flagged-mode no-op rename strips the row's ": workspace" tail
+
+`beginEditing` seeds the field with the bare `displayName` so an edit cannot bake the ` : workspace`
+decoration into the custom name, and nothing puts the decoration back on its own: `restore(field:kind:)`
+resets editability, accessibility id and colors but not the text, and the decorated label is re-rendered
+only when a reconcile sees a `RowContent` delta.
+
+Repro: sidebar in flagged mode, a session already custom-named `api`, double-click its row, press Return
+without changing the name. `AppStore.renameSession` returns early on an unchanged `customName`, so no
+reconcile fires and the row reads `api` where its neighbours read `api : work`. A session with no custom
+name reaches the same state by another route: accepting its automatic name sets `customName`, the
+reconcile runs, but the `RowContent` label is unchanged so the row is not reloaded either. The row stays
+stripped until a badge or status delta or a tree rebuild touches it; a title tick cannot, because the
+custom name short-circuits the OSC title in `displayName`. Invisible in tree mode, where the label equals
+`displayName`.
+
+Surfaced by the revmux round on the #516 PR A branch, which relabels the row through the same decorated
+`content.label` and neither causes nor worsens it. Fix candidates: rewrite the field from the current
+`rowLabel` in `restore`, or have the rename-ended path reload the row regardless of the store outcome.


### PR DESCRIPTION
PR A for #516: an animated OSC title on an un-renamed session changes only the row label, and `reloadChangedContentRows` answered every content delta with `reloadItem`, which tears the cell down and rebuilds it through the delegate on each tick. The profile from @dimonb in #516 attributed 2.61 of the 2.80 ms per sidebar update to `reloadItem`.

a session row whose `RowContent` delta is the label alone now sets `stringValue` on its live cell and schedules layout, so the truncation tooltip re-evaluates. Workspace rows, every other delta, and a row with no live cell (collapsed or scrolled off) keep the `reloadItem` path. The rename guard is unchanged.

tests assert that title ticks skip the cell builder, preserve the blink animation, and refresh the truncation tooltip.

B, the window title as a dependency of `WindowContentView.body`, is a separate PR. A pre-existing flagged-mode rename defect found on the way is recorded in `docs/backlog/flagged-noop-rename-strips-workspace-tail.md`.

Related to #516
