### PR TITLE
fix(titlebar): read the window title in child views, not WindowContentView.body

### DIFF
--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -57,8 +57,9 @@ session drag are out of scope.
   `hasReopened`.
 - Do not use `.restorationBehavior`; it requires macOS 15, the floor is 14, and `SceneBuilder` rejects
   availability conditionals without an `AnyScene` eraser. Deduplicate by ID on both systems.
-- `TitleProbeView` sets `frameAutosaveName("agterm-window-<id>")`, reports key/main changes, and on close
-  tears down surfaces before `closeWindow`.
+- `TitleProbeView` persists the frame under the window UUID in `UserDefaults` on close and restores it
+  once on attach (SwiftUI's index-based autosave overrides `frameAutosaveName`), reports key/main
+  changes, and on close tears down surfaces before `closeWindow`.
   An app-exit close captures foreground commands first, while those surfaces are still alive; see
   [[settings]] for that contract.
 - `AppActions`, commands, palette construction, `ControlServer`, `SettingsModel`, and `SessionSwitcher`

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -2,14 +2,13 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Blends the window title bar with the terminal (the title text comes from SwiftUI's
-/// `.navigationTitle`/`.navigationSubtitle`): the probe's `window` is nil at make time, so the blend is
-/// applied from `viewDidMoveToWindow` and re-applied on every `titleToken` change (session switch) and the
-/// key/fullscreen transitions where AppKit rebuilds the titlebar subviews. It also carries the per-window
-/// plumbing: persisting/restoring the frame, reporting frontmost (key/main) and close (`willClose`) to the
-/// `WindowLibrary`, and registering the `NSWindow` in `WindowRegistry`.
+/// Blends the window title bar with the terminal: the probe's `window` is nil at make time, so the blend is
+/// applied from `viewDidMoveToWindow` and re-applied on the key/fullscreen transitions where AppKit rebuilds
+/// the titlebar subviews and on appearance changes. A `titleToken` change writes the OS title alone. It also
+/// carries the per-window plumbing: persisting/restoring the frame, reporting frontmost (key/main) and close
+/// (`willClose`) to the `WindowLibrary`, and registering the `NSWindow` in `WindowRegistry`.
 struct WindowAccessor: NSViewRepresentable {
-    /// Changes when the active session changes, so `updateNSView` re-runs the blend.
+    /// The OS window title, written on every change.
     let titleToken: String
     let windowID: WindowInfo.ID
     let library: WindowLibrary
@@ -21,7 +20,7 @@ struct WindowAccessor: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: TitleProbeView, context _: Context) {
-        nsView.reapplyBlend(title: titleToken)
+        nsView.setTitle(titleToken)
     }
 
     final class TitleProbeView: NSView {
@@ -55,9 +54,12 @@ struct WindowAccessor: NSViewRepresentable {
         /// XCUITest title-matching, but hidden via titleVisibility — the custom header draws the visible one.
         private var latestTitle = ""
 
-        func reapplyBlend(title: String) {
+        /// Writes the title and nothing else: an animated OSC title ticks this many times a second, and the
+        /// blend's other inputs reach `applyTitlebarBlend` through attach and the notifications below (#516).
+        func setTitle(_ title: String) {
             latestTitle = title
-            if let window { applyTitlebarBlend(window) }
+            guard let window, window.title != title else { return }
+            window.title = title
         }
 
         override func viewDidMoveToWindow() {

--- a/agterm/Views/WindowAppearance.swift
+++ b/agterm/Views/WindowAppearance.swift
@@ -16,9 +16,9 @@ enum WindowAppearance {
     }
 
     /// Apply the blend to `window` using `background` (the terminal background color) and the `chrome`
-    /// inputs. Idempotent, and re-applying on attach and on every window/title/appearance update is
-    /// REQUIRED: AppKit rebuilds the titlebar subviews and re-asserts a default toolbar style on
-    /// key/main/fullscreen transitions, bringing the seam back and unsticking the chosen toolbar style.
+    /// inputs. Idempotent, and re-applying on attach and on every key/main/fullscreen and appearance update
+    /// is REQUIRED: AppKit rebuilds the titlebar subviews and re-asserts a default toolbar style on those
+    /// transitions, bringing the seam back and unsticking the chosen toolbar style.
     ///
     /// At full opacity the window is opaque with a solid background; below it the window goes non-opaque
     /// and its background carries the alpha — the renderer is pinned transparent

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -44,10 +44,8 @@ extension WindowContentView {
     /// "Dashboard", plus "— <window name>" for a custom window name (auto "window N" omitted, like the
     /// `WindowTitleSync`). No cwd subtitle — the grid has no single active session to source one from.
     private var dashboardWindowTitle: String {
-        guard let info = library.windows.first(where: { $0.id == windowID }), info.hasCustomName else {
-            return "Dashboard"
-        }
-        return "Dashboard — \(info.name)"
+        guard let name = library.customWindowName(for: windowID) else { return "Dashboard" }
+        return "Dashboard — \(name)"
     }
 
     /// The stripped chrome above the OPEN grid, the counterpart of `zoomTitlebar`: in hidden-toolbar mode

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -42,7 +42,7 @@ extension WindowContentView {
     }
 
     /// "Dashboard", plus "— <window name>" for a custom window name (auto "window N" omitted, like the
-    /// normal `windowTitle`). No cwd subtitle — the grid has no single active session to source one from.
+    /// `WindowTitleSync`). No cwd subtitle — the grid has no single active session to source one from.
     private var dashboardWindowTitle: String {
         guard let info = library.windows.first(where: { $0.id == windowID }), info.hasCustomName else {
             return "Dashboard"

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -259,11 +259,3 @@ struct TitlebarLabel: View {
         )
     }
 }
-
-extension WindowLibrary {
-    /// The window's user-set name, nil for an auto "window N" name.
-    func customWindowName(for id: WindowInfo.ID) -> String? {
-        guard let info = windows.first(where: { $0.id == id }), info.hasCustomName else { return nil }
-        return info.name
-    }
-}

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -6,63 +6,17 @@ import SwiftUI
 /// Owns the title text (session / window name, gated by the Interface toggles), the row layout, and the
 /// per-session chrome buttons; recent-sessions / attention / dashboard buttons live in their own extensions.
 extension WindowContentView {
-    /// The titlebar title (first line): the active session's display name, suffixed as "session — window" for
-    /// a custom (user-set) window name; auto "window N" names are omitted, and "Agterm" when nothing is
-    /// selected. Non-private: the body's `WindowAccessor` uses it as the OS window title, always the real
-    /// name, regardless of the Interface toggles that gate only the on-screen `titleText`.
-    var windowTitle: String {
-        let session = store.activeSession?.displayName ?? "Agterm"
-        guard let name = customWindowName else { return session }
-        return "\(session) — \(name)"
+    /// The window title at the terminal's leading edge, shared with the zoom titlebar. A child view, so its
+    /// session-name reads register on its own body and an OSC title tick never invalidates this one (#516).
+    var titleLabel: TitlebarLabel {
+        TitlebarLabel(store: store, library: library, windowID: windowID, toolbarMode: toolbarMode,
+                      chromeText: chromeText, showsSessionName: shows(.sessionName),
+                      showsWindowName: shows(.windowName), showsContext: shows(.sessionContext))
     }
 
-    /// The titlebar subtitle (second line): the session's `context` when one is set and shown, else the
-    /// focused pane's `subtitleDetail` — the terminal title for a remote (SSH) session whose local cwd is
-    /// stale, else its cwd. Normal mode only; compact/hidden drop it.
-    private var windowSubtitle: String { composition.subtitle }
-
-    /// Both title-bar lines, laid out host-free. The toggles are resolved into `Parts` here, so
-    /// `TitlebarComposition` never sees the settings.
-    private var composition: TitlebarComposition {
-        TitlebarComposition.compose(
-            TitlebarComposition.Parts(
-                sessionName: shows(.sessionName) ? (store.activeSession?.displayName ?? "Agterm") : nil,
-                windowName: shows(.windowName) ? customWindowName : nil,
-                context: shows(.sessionContext) ? store.activeSession?.context : nil,
-                detail: store.activeSession?.subtitleDetail ?? ""
-            ),
-            mode: toolbarMode
-        )
-    }
-
-    /// The window's user-set name, or nil when it has none (an auto "window N" name). Feeds the optional
-    /// window-name part of `titleText`.
-    private var customWindowName: String? {
-        guard let info = library.windows.first(where: { $0.id == windowID }), info.hasCustomName else { return nil }
-        return info.name
-    }
-
-    /// The VISIBLE title-bar label. `windowTitle` above still feeds the OS title, so Mission Control and the
-    /// Window menu stay labelled whatever the Interface toggles hide here.
-    private var titleText: String { composition.title }
-
-    /// The window title at the terminal's leading edge, laid out by `composition` above. Non-private so the
-    /// zoom titlebar reuses it — a zoomed terminal shows the same title as the normal window.
-    var titleLabel: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            if !titleText.isEmpty {
-                Text(titleText).fontWeight(.semibold)
-            }
-            if !windowSubtitle.isEmpty {
-                Text(windowSubtitle)
-                    .font(.caption)
-                    .foregroundStyle(chromeText.opacity(0.6))
-            }
-        }
-        // a caller-set context can run to 256 bytes, far past the row; tail truncation drops its end rather
-        // than letting the label push the trailing button cluster off the bar.
-        .lineLimit(1)
-        .truncationMode(.tail)
+    /// Feeds the OS window title to `WindowAccessor` from its own body, for the same reason as `titleLabel`.
+    var windowTitleSync: WindowTitleSync {
+        WindowTitleSync(store: store, library: library, windowID: windowID, captureOnExit: captureOnExit)
     }
 
     /// The window chrome above the terminal: the full custom titlebar row, or in hidden mode an invisible ~3px
@@ -237,5 +191,79 @@ extension WindowContentView {
         .help(helpHint("Quick Terminal", .quickTerminal))
         .disabled(pick.pending != nil)
         .accessibilityIdentifier("quick-terminal-toggle")
+    }
+}
+
+/// The OS window title: the active session's display name, suffixed as "session — window" for a custom
+/// (user-set) window name; auto "window N" names are omitted, and "Agterm" when nothing is selected. Always
+/// the real name, regardless of the Interface toggles that gate only the on-screen `TitlebarLabel`, so
+/// Mission Control and the Window menu stay labelled.
+struct WindowTitleSync: View {
+    let store: AppStore
+    let library: WindowLibrary
+    let windowID: WindowInfo.ID
+    let captureOnExit: AppDelegate.ExitCapture?
+
+    var body: some View {
+        WindowAccessor(titleToken: title, windowID: windowID, library: library, store: store,
+                       captureOnExit: captureOnExit)
+    }
+
+    private var title: String {
+        let session = store.activeSession?.displayName ?? "Agterm"
+        guard let name = library.customWindowName(for: windowID) else { return session }
+        return "\(session) — \(name)"
+    }
+}
+
+/// Both title-bar lines: the session / window name, and in normal mode the session's `context` when one is
+/// set and shown, else the focused pane's `subtitleDetail`. The Interface toggles are resolved into `Parts`
+/// here, so `TitlebarComposition` never sees the settings.
+struct TitlebarLabel: View {
+    let store: AppStore
+    let library: WindowLibrary
+    let windowID: WindowInfo.ID
+    let toolbarMode: ToolbarMode
+    let chromeText: Color
+    let showsSessionName: Bool
+    let showsWindowName: Bool
+    let showsContext: Bool
+
+    var body: some View {
+        let composition = composition
+        VStack(alignment: .leading, spacing: 1) {
+            if !composition.title.isEmpty {
+                Text(composition.title).fontWeight(.semibold)
+            }
+            if !composition.subtitle.isEmpty {
+                Text(composition.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(chromeText.opacity(0.6))
+            }
+        }
+        // a caller-set context can run to 256 bytes, far past the row; tail truncation drops its end rather
+        // than letting the label push the trailing button cluster off the bar.
+        .lineLimit(1)
+        .truncationMode(.tail)
+    }
+
+    private var composition: TitlebarComposition {
+        TitlebarComposition.compose(
+            TitlebarComposition.Parts(
+                sessionName: showsSessionName ? (store.activeSession?.displayName ?? "Agterm") : nil,
+                windowName: showsWindowName ? library.customWindowName(for: windowID) : nil,
+                context: showsContext ? store.activeSession?.context : nil,
+                detail: store.activeSession?.subtitleDetail ?? ""
+            ),
+            mode: toolbarMode
+        )
+    }
+}
+
+extension WindowLibrary {
+    /// The window's user-set name, nil for an auto "window N" name.
+    func customWindowName(for id: WindowInfo.ID) -> String? {
+        guard let info = windows.first(where: { $0.id == id }), info.hasCustomName else { return nil }
+        return info.name
     }
 }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -220,9 +220,8 @@ struct WindowContentView: View {
             if let state = fullscreenState(from: note) { windowFullscreen = state }
         })
         // blend the title bar with the terminal; report frontmost/close to the library; surface the window
-        // un-minimized on launch. the title token re-runs the blend in updateNSView on a session switch.
-        .background(WindowAccessor(titleToken: windowTitle, windowID: windowID, library: library, store: store,
-                                   captureOnExit: captureOnExit))
+        // un-minimized on launch. a child view, so the OS title it feeds is read off this body.
+        .background(windowTitleSync)
         .onAppear {
             terminalZoom.targetResolver = { [store] in
                 TerminalZoomController.resolveTarget(store: store)

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -220,7 +220,7 @@ struct WindowContentView: View {
             if let state = fullscreenState(from: note) { windowFullscreen = state }
         })
         // blend the title bar with the terminal; report frontmost/close to the library; surface the window
-        // un-minimized on launch. a child view, so the OS title it feeds is read off this body.
+        // un-minimized on launch. a child view: it reads the OS title in its own body, never in this one.
         .background(windowTitleSync)
         .onAppear {
             terminalZoom.targetResolver = { [store] in

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -328,6 +328,12 @@ public final class WindowLibrary {
         return windows.first { $0.id == id }?.name ?? ""
     }
 
+    /// The window's user-set name, nil for an auto "window N" name or an unknown id.
+    public func customWindowName(for id: UUID) -> String? {
+        guard let info = windows.first(where: { $0.id == id }), info.hasCustomName else { return nil }
+        return info.name
+    }
+
     public var defaultWindowName: String {
         "window \(windows.count + 1)"
     }

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -56,6 +56,14 @@ final class WindowLibraryTests {
         #expect(library.windowName(for: UUID()) == "")
     }
 
+    @Test func customWindowNameSkipsAutoNamesAndUnknownIDs() {
+        let library = WindowLibrary(directory: directory)
+        #expect(library.customWindowName(for: library.windows[0].id) == nil)
+        let work = library.newWindow(name: "work")
+        #expect(library.customWindowName(for: work.id) == "work")
+        #expect(library.customWindowName(for: UUID()) == nil)
+    }
+
     @Test func allOpenSessionsFlattensEverySessionAcrossWindows() {
         let library = WindowLibrary(directory: directory)
         #expect(library.allOpenSessions().count == 1)

--- a/agtermTests/WindowAccessorTests.swift
+++ b/agtermTests/WindowAccessorTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the title probe's two write paths: a title write touches the OS title alone, while
+/// attach and the appearance notification run the full titlebar blend.
+@MainActor
+final class WindowAccessorTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var window: NSWindow!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-window-accessor-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+            // over-releases a window the registry may still hold, crashing the host at autorelease-pool pop
+            window.isReleasedWhenClosed = false
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            window?.close()
+            window = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testSetTitleWritesTheTitleAndSkipsTheBlend() throws {
+        let probe = try attachedProbe()
+        drain()
+        window.titlebarSeparatorStyle = .line
+        drain()
+        XCTAssertEqual(window.titlebarSeparatorStyle, .line,
+                       "the attach blends must have drained here, or the assertions below measure them")
+
+        probe.setTitle("spin 1")
+        drain()
+
+        XCTAssertEqual(window.title, "spin 1")
+        XCTAssertEqual(window.titlebarSeparatorStyle, .line, "a title write must not run the full blend")
+
+        NotificationCenter.default.post(name: .agtermAppearanceChanged, object: nil)
+        drain()
+        XCTAssertEqual(window.titlebarSeparatorStyle, .none,
+                       "the appearance notification must still run the blend, or the sentinel proves nothing")
+    }
+
+    func testATitleSetBeforeAttachIsAppliedOnAttach() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let probe = WindowAccessor.TitleProbeView(windowID: try XCTUnwrap(library.activeWindowID),
+                                                  library: library, store: store)
+        probe.setTitle("early")
+
+        window.contentView = probe
+        drain()
+
+        XCTAssertEqual(window.title, "early")
+    }
+
+    private func attachedProbe() throws -> WindowAccessor.TitleProbeView {
+        let store = try XCTUnwrap(library.activeStore)
+        let probe = WindowAccessor.TitleProbeView(windowID: try XCTUnwrap(library.activeWindowID),
+                                                  library: library, store: store)
+        window.contentView = probe
+        return probe
+    }
+
+    private func drain() {
+        for _ in 0..<5 { RunLoop.main.run(until: Date().addingTimeInterval(0.01)) }
+    }
+}

--- a/agtermTests/WindowContentView+TitlebarTests.swift
+++ b/agtermTests/WindowContentView+TitlebarTests.swift
@@ -1,0 +1,65 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the OS-title child view: a session or window rename reaches `NSWindow.title` through
+/// its own body, with the root view left in place.
+@MainActor
+final class WindowContentViewTitlebarTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var window: NSWindow!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-titlebar-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+            // over-releases a window the registry may still hold, crashing the host at autorelease-pool pop
+            window.isReleasedWhenClosed = false
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            window?.close()
+            window = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testTheWindowTitleFollowsSessionAndWindowRenames() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        window.contentView = NSHostingView(rootView: WindowTitleSync(store: store, library: library,
+                                                                    windowID: windowID, captureOnExit: nil))
+        window.layoutIfNeeded()
+        try waitForTitle(session.displayName)
+
+        session.oscTitle = "spin 1"
+        try waitForTitle("spin 1")
+
+        store.renameSession(session.id, to: "api")
+        try waitForTitle("api")
+
+        library.renameWindow(windowID, to: "work")
+        try waitForTitle("api — work")
+    }
+
+    private func waitForTitle(_ expected: String) throws {
+        let deadline = Date().addingTimeInterval(2)
+        while window.title != expected, Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertEqual(window.title, expected)
+    }
+}


### PR DESCRIPTION
PR B for #516, after #547. `WindowContentView.body` read the active session's `displayName` twice, for the OS title token and for the visible title row, so every OSC title tick invalidated the whole body and re-ran SwiftUI's graph and layout for the window. `WindowAccessor.updateNSView` then ran the full `WindowAppearance.sync` when only `NSWindow.title` had changed.

two child views now own those reads. `WindowTitleSync` resolves the OS title in its own body and hosts `WindowAccessor`; `TitlebarLabel` resolves `TitlebarComposition` for the visible row, and the zoom titlebar reuses it. The parent passes the store and ids and no title. `WindowAccessor` writes `window.title` on a token change and keeps the blend on attach, key, main, fullscreen, appearance and accessibility changes, which already carry every other blend input. The custom window name lookup moved into `WindowLibrary` next to `windowName(for:)`, and the dashboard title uses it.

tests: hosted, a `TitleProbeView` title write leaves a separator sentinel the full blend would reset, a title set before attach survives attachment, and `WindowTitleSync` hosted in `NSHostingView` follows an OSC title, a session rename and a window rename to `NSWindow.title`. Host-free, the `customWindowName(for:)` cases.

profile, Time Profiler, Debug builds of a8bbaa5a and this branch, isolated state, sidebar hidden, one session printing numbered OSC 2 titles at about 10 Hz, two recordings of about 20 s each, main thread only. Values are inclusive main-thread sample weight in ms:

| symbol | a8bbaa5a | this branch |
| --- | --- | --- |
| `WindowContentView.body.getter` | 212 | 0 |
| `WindowTitleSync.body` / `TitlebarLabel.body` | absent | 6 / 28 |
| `WindowAppearance.sync` | 70 | 0 |
| `-[NSWindow _dosetTitle:andDefeatWrap:]` | 187 | 213 |
| `GraphHost.flushTransactions` | 1086 | 539 |
| main thread, all samples | 1774 | 978 |

these are sample weights over two separately timed recordings, not update counts and not a per-tick or total-CPU saving: the baseline tick count was not recorded, so the two workloads are not matched. The SwiftUI Instruments template hung on finalization here, so there is no SwiftUI-lane update count; the parent body had zero samples in the patched recording while the two child bodies and the title write were present. @dimonb, could you rerun your harness against this patch to measure the per-tick change?

Fix #516
