### PR TITLE
fix(codex): stop reading a literal question mark as a question

### DIFF
--- a/agterm/Resources/agent-status/agterm-codex-status.sh
+++ b/agterm/Resources/agent-status/agterm-codex-status.sh
@@ -4,7 +4,7 @@
 # Codex fires PermissionRequest before Auto Review decides whether a person must approve. Treating
 # that raw event as blocked therefore false-flags automatically reviewed tools. This hook keeps the
 # agent-specific workaround inside the installed hook package: one watcher per agterm pane reads the
-# live visible footer for dialogs, while Stop checks the final assistant message for a question mark.
+# live visible footer for dialogs, while Stop checks the final assistant message for a question.
 set -u
 
 [ -n "${AGTERM_SESSION_ID:-}" ] || exit 0
@@ -27,9 +27,15 @@ report_status() {
 }
 
 assistant_message_contains_question() {
-  local message
+  local message prose question
   message=$(/usr/bin/plutil -extract last_assistant_message raw -o - - 2>/dev/null) || return 1
-  [[ "$message" == *"?"* ]]
+  # a span becomes a word rather than nothing so "run `make test`?" keeps its ? attached
+  prose=$(printf '%s\n' "$message" \
+    | /usr/bin/awk '/^[[:space:]]*```/ { fenced = !fenced; next } !fenced' \
+    | /usr/bin/sed 's/`[^`]*`/code/g')
+  # bash 3.2 cannot parse this bracket set inline in [[ ]]
+  question=$'[^[:space:]]\\?[]"\')*_!’”]*([[:space:]]|$)'
+  [[ "$prose" =~ $question ]]
 }
 
 read_visible_screen() {

--- a/agtermCore/Tests/agtermCoreTests/CodexStatusHookTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CodexStatusHookTests.swift
@@ -116,6 +116,49 @@ struct CodexStatusHookTests {
         #expect(try run("stop", input: input).statusCalls == ["blocked"])
     }
 
+    @Test func stopReportsBlockedWhenQuestionFollowsCodeSpan() throws {
+        let input = #"{"hook_event_name":"Stop","last_assistant_message":"Run `make test`?"}"#
+        #expect(try run("stop", input: input).statusCalls == ["blocked"])
+    }
+
+    @Test func stopReportsBlockedWhenQuestionFollowsFencedBlock() throws {
+        let input = """
+        {"hook_event_name":"Stop","last_assistant_message":"Patch:\\n```diff\\n-a\\n+b\\n```\\nApply it?"}
+        """
+        #expect(try run("stop", input: input).statusCalls == ["blocked"])
+    }
+
+    @Test(arguments: [
+        #"Confirm “deploy now?”"#, #"Confirm ‘deploy now?’"#, #"Confirm \"deploy now?\""#,
+        "Confirm 'deploy now?'", "Confirm (deploy now?)", "Confirm [deploy now?]", "Confirm *deploy now?*",
+        "Confirm _deploy now?_", "Deploy now?!",
+    ])
+    func stopReportsBlockedWhenQuestionEndsInClosingPunctuation(message: String) throws {
+        let input = #"{"hook_event_name":"Stop","last_assistant_message":""# + message + #""}"#
+        #expect(try run("stop", input: input).statusCalls == ["blocked"])
+    }
+
+    @Test func stopReportsCompletedWhenQuestionMarkIsLiteralCharacter() throws {
+        let input = """
+        {"hook_event_name":"Stop","last_assistant_message":"Sent Claude one remaining blocker: \
+        Mongo\\u2019s credential parsing differs from `url.Parse`, allowing numeric-prefix passwords \
+        containing `/` or `?` to leak. Two real-provider probes reproduce it.\\n\\nAll 14 previous probes pass."}
+        """
+        #expect(try run("stop", input: input).statusCalls == ["completed --auto-reset"])
+    }
+
+    @Test func stopReportsCompletedWhenQuestionMarkIsDetachedOrInsideURL() throws {
+        let input = #"{"hook_event_name":"Stop","last_assistant_message":"Passwords with / or ? leak; see https://example.com/a?b=1 for details."}"#
+        #expect(try run("stop", input: input).statusCalls == ["completed --auto-reset"])
+    }
+
+    @Test func stopReportsCompletedWhenQuestionMarkEndsFencedCodeLine() throws {
+        let input = """
+        {"hook_event_name":"Stop","last_assistant_message":"The prompt is\\n```text\\nProceed?\\n```\\nand it renders."}
+        """
+        #expect(try run("stop", input: input).statusCalls == ["completed --auto-reset"])
+    }
+
     @Test func stopReportsCompletedWhenAssistantMessageHasNoQuestionMark() throws {
         let input = #"{"hook_event_name":"Stop","last_assistant_message":"Review completed."}"#
         #expect(try run("stop", input: input).statusCalls == ["completed --auto-reset"])

--- a/site/docs.html
+++ b/site/docs.html
@@ -3003,9 +3003,11 @@
               Six Codex lifecycle events run a dedicated adapter.
               A permission request is only a candidate because it fires before Auto Review; the adapter keeps automatic decisions
               active and changes the row to blocked only after a real approval or structured question appears in that pane.
-              On Stop, a final assistant message containing
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">?</span> reports blocked;
-              every other final message reports completed and auto-resets.
+              On Stop, a final assistant message that ends a sentence with
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">?</span> reports blocked.
+              The check is a heuristic: it ignores single-backtick spans and triple-backtick blocks, and a mark
+              that stands alone or sits inside a word, as in a URL query string, does not count.
+              Every other final message reports completed and auto-resets.
             </p>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               <strong style="color: #e6e1d7"


### PR DESCRIPTION
the Codex status adapter reported blocked on Stop whenever the final message contained a `?` anywhere, so a literal one in prose ("passwords containing `/` or `?` leak") turned a finished turn into a blocked row.

the check now drops triple-backtick blocks, replaces single-backtick spans with a placeholder word (so "run `make test`?" still counts as a question), and then treats a `?` as punctuation only when it is preceded by a non-space character and followed by optional closing punctuation, then whitespace or the end of the message. A detached mark, or a mark followed immediately by a letter or digit, does not count.

fixtures cover the original payload and preserve questions after code spans, fences, and each closing character. The docs sentence on the Stop rule now describes the heuristic and the two Markdown shapes it handles. Known miss: a French-style question with a space before the mark reads as completed.
