### PR TITLE
feat: ask dialog, a control-driven modal question with terminal and gui styles

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -591,7 +591,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   The active button uses solid foreground fill with background-colored text. Colors come from the theme.
 - GUI style uses the picker's material, corner radius, and appearance handling, with system fonts,
   a headline title, secondary message, and native push buttons in a row. The active button is
-  prominent in the accent color; destructive is tinted red and becomes prominent red when active. No hard-coded colors.
+  prominent in the accent color; destructive is tinted red and becomes prominent red when active. System colors only, so light and dark follow the picker.
 - The dialog is window-modal and shares `PickController.modalPending` with pick. A second open of
   either family is refused. Focus, auto-follow, menu, quick-terminal, search, zoom, and dashboard gates
   consult the shared predicate.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -575,21 +575,23 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   nonempty labels. Title, message, and labels reject control characters. Optional button `hotkey` is
   one ASCII letter, unique case-insensitively and stored lowercase.
 - `defaultButton` and `destructiveButton` name supplied ids and cannot name the same button.
-  Default seeds the highlight; without it Return is inert until navigation. Tab/Right/Down enter at
-  the first button, Shift-Tab/Left/Up at the last, then wrap.
+  Default seeds the highlight; otherwise the first non-destructive button is selected, or the first
+  button if it is the only choice. Tab/Right/Down move forward, Shift-Tab/Left/Up move back, and wrap.
   Return chooses the highlight; a letter hotkey chooses directly. Outside clicks leave the dialog open.
 - Optional `style` is `terminal` (default) or `gui`; invalid values return `unknown style`.
   Style affects decoration only and has no read-back. Both styles share keyboard behavior, results,
   anchoring, modality, and the modal slot.
+- Optional `align` is `left`, `center`, or `right` (default). It aligns the whole button block, including
+  the vertical fallback, in both styles. Invalid values return `unknown align`; it has no read-back.
 - Terminal buttons use padded, bracketed labels and a dim fill from the theme foreground at low opacity.
   The active button uses solid foreground fill with background-colored text. Colors come from the theme.
 - GUI style uses the picker's material, corner radius, and appearance handling, with system fonts,
-  a headline title, secondary message, and native push buttons in a trailing row. The default is
-  prominent in the accent color; destructive is tinted red. No hard-coded colors.
+  a headline title, secondary message, and native push buttons in a row. The active button is
+  prominent in the accent color; destructive is tinted red and becomes prominent red when active. No hard-coded colors.
 - The dialog is window-modal and shares `PickController.modalPending` with pick. A second open of
   either family is refused. Focus, auto-follow, menu, quick-terminal, search, zoom, and dashboard gates
   consult the shared predicate.
-- No `target` centers the dialog in the window. A session target anchors to its whole area;
+- No `target` centers the dialog over the terminal area, excluding the sidebar. A session target anchors to its whole area;
   `pane` or `paneID` narrows it and requires a target. The session must be selected in its owning
   window and the pane rendered; zoom/dashboard reject anchored opens. `follow` raises the window.
   A live pane token overrides the role; an unknown token uses the supplied role or errors without one.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -151,7 +151,8 @@ renumbering. Do not reintroduce a count anywhere.
   `.scratch`, `.focus`, `.resize`, `.go`, `.copy`, `.paste`, `.selectall`, `.text`, `.search`, `.status`,
   `.flag`, `.seen`, `.restore`, `.background`, `.overlay.open`, `.overlay.close`, `.overlay.resize`,
   `.overlay.result`, `.overlay.copy`, `.overlay.text`, `.hud.open`, `.hud.update`, `.hud.close`
-- `surface.zoom`, `surface.cursor`, `dashboard`, `pick.open`, `pick.result`, `pick.cancel`
+- `surface.zoom`, `surface.cursor`, `dashboard`, `pick.open`, `pick.result`, `pick.cancel`,
+  `ask.open`, `ask.result`, `ask.cancel`
 - `quick`, `quick.type`, `quick.text`
 - `sidebar`, `sidebar.mode`, `sidebar.expand`, `sidebar.collapse`, `sidebar.width`, `notify`
 - `font.inc`, `font.dec`, `font.reset`
@@ -337,7 +338,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   read failure, and no open window. Hidden previously shown quick remains addressable (#170).
   Text is type's read-back.
 
-## Overlay, zoom, dashboard, and picker
+## Overlay, zoom, dashboard, pick, and ask
 
 - Overlay open runs one shell-wrapped program in a nonpersisted per-session surface. Size nil is full;
   1...100 is floating; values outside that range are refused. Optional color uses shared validated
@@ -553,7 +554,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   without `allowCustom` returns `pick.open requires at least one item`.
   Optional subtitle/prompt/query/custom/follow; `query` prefills the field so the picker opens filtered.
   Reject duplicate IDs and control characters host-free; `prompt` and `query` stay unvalidated free text.
-  One picker may be pending per window. Background remains background unless follow raises and publishes
+  One pick or ask may be pending per window. Background remains background unless follow raises and publishes
   frontmost.
 - Caller-supplied rows match on their label only. Subtitles are displayed but never searched, so
   consequence text cannot filter a safe row out and leave a destructive one preselected. An empty query
@@ -569,6 +570,44 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - CLI reads JSON array when stdin begins `[`, otherwise nonblank lines become ID=label. Blocking poll is
   100ms for one second, then 500ms; print bare result JSON; exit 0 picked/custom, 2 cancelled, 1 failure.
   `--no-block` prints picker ID JSON; result/cancel are one-shot commands.
+
+- `ask.open` accepts a nonblank `title`, optional `message`, and 1...6 `buttons` with unique ids and
+  nonempty labels. Title, message, and labels reject control characters. Optional button `hotkey` is
+  one ASCII letter, unique case-insensitively and stored lowercase.
+- `defaultButton` and `destructiveButton` name supplied ids and cannot name the same button.
+  Default seeds the highlight; without it Return is inert until navigation. Tab/Right/Down enter at
+  the first button, Shift-Tab/Left/Up at the last, then wrap.
+  Return chooses the highlight; a letter hotkey chooses directly. Outside clicks leave the dialog open.
+- Optional `style` is `terminal` (default) or `gui`; invalid values return `unknown style`.
+  Style affects decoration only and has no read-back. Both styles share keyboard behavior, results,
+  anchoring, modality, and the modal slot.
+- Terminal buttons use padded, bracketed labels and a dim fill from the theme foreground at low opacity.
+  The active button uses solid foreground fill with background-colored text. Colors come from the theme.
+- GUI style uses the picker's material, corner radius, and appearance handling, with system fonts,
+  a headline title, secondary message, and native push buttons in a trailing row. The default is
+  prominent in the accent color; destructive is tinted red. No hard-coded colors.
+- The dialog is window-modal and shares `PickController.modalPending` with pick. A second open of
+  either family is refused. Focus, auto-follow, menu, quick-terminal, search, zoom, and dashboard gates
+  consult the shared predicate.
+- No `target` centers the dialog in the window. A session target anchors to its whole area;
+  `pane` or `paneID` narrows it and requires a target. The session must be selected in its owning
+  window and the pane rendered; zoom/dashboard reject anchored opens. `follow` raises the window.
+  A live pane token overrides the role; an unknown token uses the supplied role or errors without one.
+  `ask.open` echoes the resolved role in `result.pane` for pane placement.
+- Anchor geometry follows resize and the captured pane identity through role changes. Closing or
+  deselecting the session, or losing the pane's identity or rendered role, cancels. Session-wide
+  anchors and a still-rendered pane survive split collapse.
+- Esc and Command-W return `escaped`. `ask.cancel`, window teardown, app termination, and anchor loss
+  return `cancelled`. Result/cancel use the exact global ask id; an explicit window must match its owner.
+  Cancelling a retained terminal result is a successful no-op.
+- Blocking CLI output is `{"result":"answered","id":"yes","label":"Yes","index":0}`,
+  `{"result":"escaped"}`, or `{"result":"cancelled"}`; index follows caller order.
+  Exit 0 means answered, including a No button; exit 3 means escaped, exit 2 means cancelled,
+  and exit 1 means failure. `--no-block` prints `{"id":"…"}`.
+  One-shot `ask result` also prints `pending` and exits 1 for it.
+- Tree exposes top-level `askPending` while waiting. Ask results retain eight answers per open window
+  and 32 across closed windows, separately from pick. App shutdown can interrupt polling.
+  Ask emits no events; result and tree polling are its explicit event exemption.
 
 ## Status, notifications, and flags
 
@@ -725,7 +764,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   qualifies. The capture (`.command`) stays leader-only, because a non-nil capture sets `hadForeground`,
   which preempts `initialCommand` in `restorePlan` and would drop the exec path.
 - Top-level tree includes idle/auto-follow, live sidebar visibility/mode/width, workspace filter, quick
-  visibility, zoom, dashboard, and picker state. Prefer live tree sidebar state over cached window list.
+  visibility, zoom, dashboard, pick, and ask state. Prefer live tree sidebar state over cached window list.
   `sidebarWidth` is tree-only: nothing needs width discovery across windows, which is all the cached
   `window.list` copy would add.
   `quickVisible` and a `quick` `zoomedSurface` are APP-level, so every projected window reports the same

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -583,7 +583,11 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   anchoring, modality, and the modal slot.
 - Optional `align` is `left`, `center`, or `right` (default). It aligns the whole button block, including
   the vertical fallback, in both styles. Invalid values return `unknown align`; it has no read-back.
-- Terminal buttons use padded, bracketed labels and a dim fill from the theme foreground at low opacity.
+- Both styles fit their content, capped at 90 percent of the anchor width and 72 cells.
+  Narrow layouts wrap labels and use the vertical button fallback.
+- Optional `width` fixes the panel width to an integer percentage of the anchor, 10...100, in either
+  style. It replaces automatic sizing and has no read-back. Invalid values return `width must be 10 to 100`.
+- Terminal buttons use padded labels and a dim fill from the theme foreground at low opacity.
   The active button uses solid foreground fill with background-colored text. Colors come from the theme.
 - GUI style uses the picker's material, corner radius, and appearance handling, with system fonts,
   a headline title, secondary message, and native push buttons in a row. The active button is

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -123,8 +123,8 @@ paths:
   that way. One that changes WHERE a mutation lands is not: give it a read-back so a caller can see what the
   server did, rather than leaving the two outcomes indistinguishable. A read-back is any observable read, not
   necessarily a response field: `session.paste --pane` is covered by `session.text --pane`, its documented
-  read-back command, as `session.type` and `font.*` are, and only `session.restore` carries `result.pane`,
-  for the token reason below. Since `agtermctl` ships inside the
+  read-back command, as `session.type` and `font.*` are, and `result.pane` is carried by `session.restore`,
+  for the token reason below, and by `ask.open` for its resolved pane anchor. Since `agtermctl` ships inside the
   bundle, the CLI that sends a field and the app that reads it are the same build, so the exposure is a
   stale RUNNING process across an upgrade, not a mismatched install. Only an app predating `result.pane`
   omits it from a successful `session.restore`; treat absence as UNKNOWN, never as the default pane.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -28,8 +28,9 @@ paths:
   (no active session, no current workspace). Add a term to `PaletteContext` and the predicate; never to one
   item's `.disabled(…)`. An action's own `AppActions` method keeps its guard as well — belt and braces, not
   the contract.
-- The modal cover — terminal zoom, the open dashboard grid, a pending native picker — reads off the same
-  predicate. Close Session, both reloads, the three font sizes and Toggle Terminal Zoom carry no modal term
+- Modal covers include terminal zoom, the dashboard, and a pending pick or ask. They share the same
+  predicate. Ask's terminal and GUI styles have the same modal gates.
+  Close Session, both reloads, the three font sizes and Toggle Terminal Zoom carry no modal term
   (⌘W is how a cover is dismissed); Dashboard carries every cover but its own grid, its item being that
   grid's escape hatch. Items with no palette row (window management, the three palette launchers) keep the
   bare `context.modalActive`.
@@ -150,12 +151,11 @@ paths:
 
 ## Close and reselection
 
-- Command-W first dismisses the frontmost cover: the quick-terminal panel (un-zoom, then hide), then
-  overlay, then scratch, then the
-  FOCUSED pane's own overlay (`focusedOverlayPane`; one on the sibling pane is not in front of the user and
-  does not intercept). Only then close the active session. If no cover or session exists, the menu performs
-  window close. Keep the cover check inside `closeActiveSession`, since a sessionless window can still show
-  quick terminal.
+- Command-W first dismisses a pending pick or ask. An ask returns `escaped`, as with Esc.
+  Then come the quick terminal (un-zoom, then hide), terminal zoom,
+  dashboard, session overlay, scratch, and the focused pane's overlay (`focusedOverlayPane`; a sibling's
+  overlay does not intercept). Only then close the active session, or the window when no session remains.
+  Keep cover checks before the active-session lookup; a sessionless window can still show a modal.
 - The panel's two rungs read `holdsKey`, not `isVisible`. A PINNED panel (a control `quick show`) stays on
   screen without owning the keyboard, and Command-W in a terminal window must then close that session
   rather than reach past it to the panel.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ agtermctl session type $'pwd\n' --target "$sid"           # drive a session you 
 agtermctl session text --target "$sid" --lines 10         # read its terminal back
 agtermctl session status blocked --target "$sid"          # set the sidebar status glyph
 printf '%s\n' staging production | agtermctl pick --prompt "Deploy where?"   # open the native picker
+agtermctl ask "Deploy now?" --button yes=Deploy --button no=Not\ yet --default no  # ask a question, get the button
 agtermctl tree --json                                     # dump the whole model as JSON
 ```
 
-`session type` returns once the keystrokes are queued, so a following `session text` races the shell, and `pick` blocks until someone chooses.
+`session type` returns once the keystrokes are queued, so a following `session text` races the shell, and `pick` and `ask` block until someone answers.
 
 The same interface covers windows, splits, overlays, dashboards, HUDs, notifications, events, themes, and restoration. Every command is at [agterm.com/commands](https://agterm.com/commands).
 

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -39,18 +39,11 @@ extension AppActions {
         PickRegistry.shared.controller(for: windowID)?.modalPending == true
     }
 
-    /// dismissPendingAsk reserves named answers for user dismissal; administrative cancellation never picks a button.
     @discardableResult
-    func dismissPendingAsk(for windowID: WindowInfo.ID?, userInitiated: Bool) -> Bool {
+    func escapePendingAsk(for windowID: WindowInfo.ID?) -> Bool {
         guard let controller = PickRegistry.shared.controller(for: windowID),
-              let ask = controller.pendingAsk else { return false }
-        if userInitiated, let cancelID = ask.cancelID,
-           let index = ask.buttons.firstIndex(where: { $0.id == cancelID }) {
-            let button = ask.buttons[index]
-            controller.resolveAsk(ControlAskResult(result: .answered, id: button.id, label: button.label, index: index))
-        } else {
-            controller.cancelAsk()
-        }
+              controller.pendingAsk != nil else { return false }
+        controller.escapeAsk()
         return true
     }
 

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -33,10 +33,25 @@ extension AppActions {
         DashboardControllerRegistry.shared.controller(for: library.activeWindowID)?.isOpen == true
     }
 
-    /// Whether the specified window has a native control picker pending. Kept as one window-scoped
+    /// Whether the specified window has a control picker or ask pending. Kept as one window-scoped
     /// predicate so both frontmost and session-addressed focus paths use the same modal invariant.
     func pickActive(for windowID: WindowInfo.ID?) -> Bool {
-        PickRegistry.shared.controller(for: windowID)?.pending != nil
+        PickRegistry.shared.controller(for: windowID)?.modalPending == true
+    }
+
+    /// dismissPendingAsk reserves named answers for user dismissal; administrative cancellation never picks a button.
+    @discardableResult
+    func dismissPendingAsk(for windowID: WindowInfo.ID?, userInitiated: Bool) -> Bool {
+        guard let controller = PickRegistry.shared.controller(for: windowID),
+              let ask = controller.pendingAsk else { return false }
+        if userInitiated, let cancelID = ask.cancelID,
+           let index = ask.buttons.firstIndex(where: { $0.id == cancelID }) {
+            let button = ask.buttons[index]
+            controller.resolveAsk(ControlAskResult(result: .answered, id: button.id, label: button.label, index: index))
+        } else {
+            controller.cancelAsk()
+        }
+        return true
     }
 
     /// Whether terminal zoom is active in the window OWNING this session — the right gate for the

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -259,7 +259,7 @@ final class AppActions {
         guard let controller = PickRegistry.shared.controller(for: windowID),
               controller.modalPending
         else { return false }
-        if dismissPendingAsk(for: windowID, userInitiated: true) { return true }
+        if escapePendingAsk(for: windowID) { return true }
         controller.cancel()
         return true
     }

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -45,7 +45,7 @@ final class AppActions {
         guard let windowID else { return false }
         return TerminalZoomRegistry.shared.controller(for: windowID)?.target == nil
             && DashboardControllerRegistry.shared.controller(for: windowID)?.isOpen != true
-            && PickRegistry.shared.controller(for: windowID)?.pending == nil
+            && PickRegistry.shared.controller(for: windowID)?.modalPending != true
     }
 
     /// Set while a rename starts, so the palette / quick-terminal close focus-restore skips the rename field.
@@ -95,7 +95,7 @@ final class AppActions {
         terminationObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification, object: nil, queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.cancelAllPendingPicks() }
+            MainActor.assumeIsolated { self?.cancelAllPendingModals() }
         }
     }
 
@@ -216,9 +216,9 @@ final class AppActions {
     // keep-alive, and a floating overlay holds first responder too, so ANY overlay is dismissed, not only full.
     @discardableResult
     func closeActiveSession() -> Bool {
-        // a pick is an external caller waiting on an answer: the first ⌘W layer even behind a zoomed terminal,
+        // a control dialog has an external caller waiting: the first ⌘W layer even behind a zoomed terminal,
         // and resolved rather than hidden so the caller can finish.
-        if cancelPendingPick(for: library.activeWindowID) { return true }
+        if dismissPendingModal(for: library.activeWindowID) { return true }
         // the quick-terminal panel floats above every window, so it outranks anything inside one — the window
         // rungs below read state the panel is covering, and clearing a zoom the user cannot see is a silent
         // mutation of state they never touched. Stepwise like zoom: a zoomed panel un-zooms first, the next
@@ -252,22 +252,25 @@ final class AppActions {
         if !closeActiveSession() { window?.performClose(nil) }
     }
 
-    /// Resolve the pending picker owned by `windowID` as cancelled. Used by ⌘W and app termination;
+    /// dismissPendingModal resolves the window's control dialog on user dismissal;
     /// window teardown cancels through `PickRegistry.unregister` so it can retain the terminal result.
     @discardableResult
-    func cancelPendingPick(for windowID: WindowInfo.ID?) -> Bool {
+    func dismissPendingModal(for windowID: WindowInfo.ID?) -> Bool {
         guard let controller = PickRegistry.shared.controller(for: windowID),
-              controller.pending != nil
+              controller.modalPending
         else { return false }
+        if dismissPendingAsk(for: windowID, userInitiated: true) { return true }
         controller.cancel()
         return true
     }
 
-    /// Resolve every open window's pending picker during the synchronous app-termination notification. The
+    /// cancelAllPendingModals resolves each window's pending dialog during synchronous app termination. The
     /// library retains its open ids through quit teardown, so every mounted controller is still addressable.
-    func cancelAllPendingPicks() {
+    func cancelAllPendingModals() {
         for windowID in library.openIDs() {
-            cancelPendingPick(for: windowID)
+            guard let controller = PickRegistry.shared.controller(for: windowID) else { continue }
+            controller.cancel()
+            controller.cancelAsk()
         }
     }
 

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -317,7 +317,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_: Notification) {
         // resolve in-memory picker state before closing the socket: a client already polling may observe
         // cancellation, but a later poll can still race socket teardown at process exit.
-        actions?.cancelAllPendingPicks()
+        actions?.cancelAllPendingModals()
         controlServer?.stop()
         customCommandRunner?.stop()
         // clear the OS-level Dock badge — it outlives the process while unseenCount is ephemeral, so a quit

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -237,8 +237,8 @@ extension ControlServer {
         let want = parsedMode.desiredValue(current: controller.isVisible)
         // NOT gated on the panel being hidden: `show` also carries the pin, and `canShow` refuses under a
         // pending pick, so an already-visible panel would answer ok with the pin silently not applied.
-        if want, PickRegistry.shared.controller(for: library.activeWindowID)?.pending != nil {
-            return ControlResponse(ok: false, error: "pick pending")
+        if want, let error = PickRegistry.shared.controller(for: library.activeWindowID)?.pendingModalError {
+            return ControlResponse(ok: false, error: error)
         }
         // `show` runs even when the panel is ALREADY visible, which `hide` has no equivalent of: it is what
         // pins a panel the user summoned by hotkey. Skipping it there would answer ok and leave the caller's

--- a/agterm/Control/ControlServer+Ask.swift
+++ b/agterm/Control/ControlServer+Ask.swift
@@ -42,7 +42,7 @@ extension ControlServer {
         }
         let pending = PendingAsk(id: ask.id, title: ask.title, message: ask.message, buttons: ask.buttons,
                                  defaultID: ask.defaultID, destructiveID: ask.destructiveID, style: ask.style, align: ask.align,
-                                 anchor: anchor)
+                                 width: ask.width, anchor: anchor)
         guard controller.openAsk(pending) else {
             return ControlResponse(ok: false, error: controller.pendingAsk != nil ? "ask already pending" : "pick already pending")
         }

--- a/agterm/Control/ControlServer+Ask.swift
+++ b/agterm/Control/ControlServer+Ask.swift
@@ -44,7 +44,7 @@ extension ControlServer {
                                  defaultID: ask.defaultID, cancelID: ask.cancelID, destructiveID: ask.destructiveID,
                                  anchor: anchor)
         guard controller.openAsk(pending) else {
-            return ControlResponse(ok: false, error: controller.pending != nil ? "pick already pending" : "ask already pending")
+            return ControlResponse(ok: false, error: controller.pendingAsk != nil ? "ask already pending" : "pick already pending")
         }
         if follow {
             WindowRegistry.shared.raise(windowID)

--- a/agterm/Control/ControlServer+Ask.swift
+++ b/agterm/Control/ControlServer+Ask.swift
@@ -41,7 +41,7 @@ extension ControlServer {
             }
         }
         let pending = PendingAsk(id: ask.id, title: ask.title, message: ask.message, buttons: ask.buttons,
-                                 defaultID: ask.defaultID, cancelID: ask.cancelID, destructiveID: ask.destructiveID,
+                                 defaultID: ask.defaultID, destructiveID: ask.destructiveID, style: ask.style, align: ask.align,
                                  anchor: anchor)
         guard controller.openAsk(pending) else {
             return ControlResponse(ok: false, error: controller.pendingAsk != nil ? "ask already pending" : "pick already pending")

--- a/agterm/Control/ControlServer+Ask.swift
+++ b/agterm/Control/ControlServer+Ask.swift
@@ -1,0 +1,124 @@
+import Foundation
+import agtermCore
+
+extension ControlServer {
+    func openAsk(_ ask: PendingAsk, target: String?, window: String?,
+                 placement: ControlAskPlacement, follow: Bool) -> ControlResponse {
+        if let target {
+            return resolver.resolveSession(target, window: window) { store, id in
+                presentAsk(ask, in: store, sessionID: id, placement: placement, follow: follow)
+            }
+        }
+        return resolver.resolveOpenPlacementStore(window) { store in
+            presentAsk(ask, in: store, sessionID: nil, placement: placement, follow: follow)
+        }
+    }
+
+    private func presentAsk(_ ask: PendingAsk, in store: AppStore, sessionID: UUID?,
+                            placement: ControlAskPlacement, follow: Bool) -> ControlResponse {
+        guard let windowID = library.windowID(for: store) else {
+            return ControlResponse(ok: false, error: "no open window")
+        }
+        guard let controller = PickRegistry.shared.controller(for: windowID) else {
+            return ControlResponse(ok: false, error: "no ask surface")
+        }
+        var anchor: AskAnchor?
+        if let sessionID {
+            guard let session = store.session(withID: sessionID) else {
+                return ControlResponse(ok: false, error: "no such session")
+            }
+            guard store.selectedSessionID == sessionID,
+                  TerminalZoomRegistry.shared.controller(for: windowID)?.target == nil,
+                  DashboardControllerRegistry.shared.controller(for: windowID)?.isOpen != true else {
+                return ControlResponse(ok: false, error: "session not visible")
+            }
+            switch resolvePanePlacement(placement.pane, paneID: placement.paneID, in: session,
+                                        requireVisible: true, invalidPaneError: "ask pane must be left or right") {
+            case let .resolved(identity, pane):
+                anchor = AskAnchor(sessionID: sessionID, pane: pane, paneIdentity: identity)
+            case .rejected(let response):
+                return response
+            }
+        }
+        let pending = PendingAsk(id: ask.id, title: ask.title, message: ask.message, buttons: ask.buttons,
+                                 defaultID: ask.defaultID, cancelID: ask.cancelID, destructiveID: ask.destructiveID,
+                                 anchor: anchor)
+        guard controller.openAsk(pending) else {
+            return ControlResponse(ok: false, error: controller.pending != nil ? "pick already pending" : "ask already pending")
+        }
+        if follow {
+            WindowRegistry.shared.raise(windowID)
+            takeFrontmost(windowID)
+        }
+        if library.activeWindowID == windowID {
+            actions.palette?.close()
+        }
+        return ControlResponse(ok: true, result: ControlResult(id: ask.id, pane: anchor?.pane?.rawValue))
+    }
+
+    func askResult(_ target: String, window: String?) -> ControlResponse {
+        if window == nil {
+            if let live = PickRegistry.shared.liveAsk(for: target),
+               let result = live.controller.askResult(for: target) {
+                return ControlResponse(ok: true, result: ControlResult(ask: result))
+            }
+            if let retained = PickRegistry.shared.retainedAskResult(for: target) {
+                return ControlResponse(ok: true, result: ControlResult(ask: retained.result))
+            }
+            return ControlResponse(ok: false, error: "unknown ask: \(target)")
+        }
+        if let retained = PickRegistry.shared.retainedAskResult(for: target) {
+            return resolver.resolveWindowID(window) { windowID in
+                guard windowID == retained.windowID else {
+                    return ControlResponse(ok: false, error: "unknown ask: \(target)")
+                }
+                return ControlResponse(ok: true, result: ControlResult(ask: retained.result))
+            }
+        }
+        return withAskController(window: window) { controller in
+            guard let result = controller.askResult(for: target) else {
+                return ControlResponse(ok: false, error: "unknown ask: \(target)")
+            }
+            return ControlResponse(ok: true, result: ControlResult(ask: result))
+        }
+    }
+
+    func cancelAsk(_ target: String, window: String?) -> ControlResponse {
+        if window == nil {
+            if let live = PickRegistry.shared.liveAsk(for: target) {
+                if live.controller.pendingAsk?.id == target { live.controller.cancelAsk() }
+                return ControlResponse(ok: true)
+            }
+            if PickRegistry.shared.retainedAskResult(for: target) != nil {
+                return ControlResponse(ok: true)
+            }
+            return ControlResponse(ok: false, error: "unknown ask: \(target)")
+        }
+        if let retained = PickRegistry.shared.retainedAskResult(for: target) {
+            return resolver.resolveWindowID(window) { windowID in
+                windowID == retained.windowID
+                    ? ControlResponse(ok: true)
+                    : ControlResponse(ok: false, error: "unknown ask: \(target)")
+            }
+        }
+        return withAskController(window: window) { controller in
+            guard controller.askResult(for: target) != nil else {
+                return ControlResponse(ok: false, error: "unknown ask: \(target)")
+            }
+            if controller.pendingAsk?.id == target { controller.cancelAsk() }
+            return ControlResponse(ok: true)
+        }
+    }
+
+    private func withAskController(window: String?, _ body: (PickController) -> ControlResponse) -> ControlResponse {
+        resolver.resolveOpenPlacementStore(window) { store in
+            guard let windowID = library.windowID(for: store) else {
+                return ControlResponse(ok: false, error: "no open window")
+            }
+            guard let controller = PickRegistry.shared.controller(for: windowID) else {
+                return ControlResponse(ok: false, error: "no ask surface")
+            }
+            return body(controller)
+        }
+    }
+}

--- a/agterm/Control/ControlServer+Hud.swift
+++ b/agterm/Control/ControlServer+Hud.swift
@@ -22,7 +22,8 @@ extension ControlServer {
             }
             let paneIdentity: UUID?
             let pane: OverlayPane?
-            switch self.resolveHudPlacement(placement, in: session, requireVisible: true) {
+            switch self.resolvePanePlacement(placement.pane, paneID: placement.paneID, in: session,
+                                            requireVisible: true, invalidPaneError: "hud pane must be left or right") {
             case .resolved(let identity, let targetPane):
                 paneIdentity = identity
                 pane = targetPane
@@ -69,7 +70,8 @@ extension ControlServer {
             }
             let paneIdentity: UUID?
             let pane: OverlayPane?
-            switch self.resolveHudPlacement(placement, in: session, requireVisible: false) {
+            switch self.resolvePanePlacement(placement.pane, paneID: placement.paneID, in: session,
+                                            requireVisible: false, invalidPaneError: "hud pane must be left or right") {
             case .resolved(let identity, let targetPane):
                 paneIdentity = identity
                 pane = targetPane
@@ -138,40 +140,6 @@ extension ControlServer {
                            paneWidth: size.width, paneHeight: size.height,
                            paddingWidth: Self.windowPadding.horizontal,
                            paddingHeight: Self.windowPadding.vertical)
-    }
-
-    private enum HudPlacementResolution {
-        case resolved(identity: UUID?, pane: OverlayPane?)
-        case rejected(ControlResponse)
-    }
-
-    private func resolveHudPlacement(_ placement: ControlHudPlacement, in session: Session,
-                                     requireVisible: Bool) -> HudPlacementResolution {
-        var pane = placement.pane
-        if let token = placement.paneID, !token.isEmpty {
-            if let resolved = session.paneRole(forToken: token) {
-                guard resolved != .scratch else {
-                    return .rejected(ControlResponse(ok: false, error: "hud pane must be left or right"))
-                }
-                pane = resolved == .left ? .left : .right
-            } else if pane == nil {
-                return .rejected(ControlResponse(ok: false, error: "unknown pane id: \(token)"))
-            }
-        }
-        guard let pane else { return .resolved(identity: nil, pane: nil) }
-        if requireVisible, !session.rendersPane(pane) {
-            return .rejected(ControlResponse(ok: false, error: PaneOverlayError.paneNotVisible))
-        }
-        switch pane {
-        case .left:
-            return .resolved(identity: session.paneIdentity, pane: .left)
-        case .right:
-            guard let identity = session.splitPaneIdentity else {
-                let error = requireVisible ? PaneOverlayError.paneNotVisible : "session has no split"
-                return .rejected(ControlResponse(ok: false, error: error))
-            }
-            return .resolved(identity: identity, pane: .right)
-        }
     }
 
     /// One cell of `family` at `size`: the horizontal advance of a digit (every glyph advances the same in

--- a/agterm/Control/ControlServer+PanePlacement.swift
+++ b/agterm/Control/ControlServer+PanePlacement.swift
@@ -1,0 +1,38 @@
+import Foundation
+import agtermCore
+
+extension ControlServer {
+    enum PanePlacementResolution {
+        case resolved(identity: UUID?, pane: OverlayPane?)
+        case rejected(ControlResponse)
+    }
+
+    func resolvePanePlacement(_ fallback: OverlayPane?, paneID: String?, in session: Session,
+                              requireVisible: Bool, invalidPaneError: String) -> PanePlacementResolution {
+        var pane = fallback
+        if let token = paneID, !token.isEmpty {
+            if let resolved = session.paneRole(forToken: token) {
+                guard resolved != .scratch else {
+                    return .rejected(ControlResponse(ok: false, error: invalidPaneError))
+                }
+                pane = resolved == .left ? .left : .right
+            } else if pane == nil {
+                return .rejected(ControlResponse(ok: false, error: "unknown pane id: \(token)"))
+            }
+        }
+        guard let pane else { return .resolved(identity: nil, pane: nil) }
+        if requireVisible, !session.rendersPane(pane) {
+            return .rejected(ControlResponse(ok: false, error: PaneOverlayError.paneNotVisible))
+        }
+        switch pane {
+        case .left:
+            return .resolved(identity: session.paneIdentity, pane: .left)
+        case .right:
+            guard let identity = session.splitPaneIdentity else {
+                let error = requireVisible ? PaneOverlayError.paneNotVisible : "session has no split"
+                return .rejected(ControlResponse(ok: false, error: error))
+            }
+            return .resolved(identity: identity, pane: .right)
+        }
+    }
+}

--- a/agterm/Control/ControlServer+Pick.swift
+++ b/agterm/Control/ControlServer+Pick.swift
@@ -6,7 +6,7 @@ extension ControlServer {
     func openPick(_ pick: PendingPick, window: String?, follow: Bool) -> ControlResponse {
         withPickController(window: window) { controller, windowID in
             guard controller.open(pick) else {
-                return ControlResponse(ok: false, error: "pick already pending")
+                return ControlResponse(ok: false, error: controller.pendingAsk != nil ? "ask already pending" : "pick already pending")
             }
 
             if follow {

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -696,8 +696,8 @@ extension ControlServer: ControlActions {
             }
             let want = mode.desiredValue(current: controller.target == resolved.target)
             if want, controller.target != resolved.target,
-               PickRegistry.shared.controller(for: resolved.windowID)?.pending != nil {
-                return ControlResponse(ok: false, error: "pick pending")
+               let error = PickRegistry.shared.controller(for: resolved.windowID)?.pendingModalError {
+                return ControlResponse(ok: false, error: error)
             }
             // `hide` is idempotent: skip the availability check for `.off`, since the surface may have
             // vanished (an exited overlay auto-clears the zoom) while the end state holds; `set(.off, …)`
@@ -721,8 +721,8 @@ extension ControlServer: ControlActions {
                 return ControlResponse(ok: false, error: "window not open — window.select it first")
             }
             if controller.target == nil, mode != .off,
-               PickRegistry.shared.controller(for: windowID)?.pending != nil {
-                return ControlResponse(ok: false, error: "pick pending")
+               let error = PickRegistry.shared.controller(for: windowID)?.pendingModalError {
+                return ControlResponse(ok: false, error: error)
             }
             // this arm only picks the effective target (the current zoom when one is up, so on/off/toggle
             // act on it, else the resolved active surface) and shapes the response; mode-vs-state semantics

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -401,8 +401,8 @@ extension ControlServer {
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
         if let windowID = library.windowID(forSession: id) {
-            if PickRegistry.shared.controller(for: windowID)?.pending != nil {
-                return ControlResponse(ok: false, error: "pick pending")
+            if let error = PickRegistry.shared.controller(for: windowID)?.pendingModalError {
+                return ControlResponse(ok: false, error: error)
             }
             if TerminalZoomRegistry.shared.controller(for: windowID)?.target != nil {
                 return ControlResponse(ok: false, error: "terminal zoom active")

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -645,8 +645,8 @@ final class ControlServer {
                 controller.close()
                 return ControlResponse(ok: true)
             }
-            if PickRegistry.shared.controller(for: windowID)?.pending != nil {
-                return ControlResponse(ok: false, error: "pick pending")
+            if let error = PickRegistry.shared.controller(for: windowID)?.pendingModalError {
+                return ControlResponse(ok: false, error: error)
             }
             var resolvedTargets: [ResolvedDashboardTarget] = []
             var unresolved: [String] = []

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -503,12 +503,14 @@ final class ControlServer {
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
                 .windowFullscreen, .windowMinimize,
                 .restoreClear, .restoreCapture, .restoreMode, .zmxList, .zmxPrune, .zmxKill, .zmxTree,
-                .zmxAttach, .dashboard, .version, .askOpen, .askResult, .askCancel:
+                .zmxAttach, .dashboard, .version:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)
         case .pickOpen, .pickResult, .pickCancel:
             preconditionFailure("pick command returned nil from ControlDispatcher")
+        case .askOpen, .askResult, .askCancel:
+            preconditionFailure("ask command returned nil from ControlDispatcher")
         case .sessionHudOpen, .sessionHudUpdate, .sessionHudClose:
             preconditionFailure("hud command returned nil from ControlDispatcher")
         }
@@ -745,6 +747,7 @@ final class ControlServer {
             // resolved through the projected window's registry entry on every tree build, and tree-only:
             // window.list is cache-backed, so mirroring a GUI-resolved pick there would go stale.
             pickPending: { windowID.flatMap { PickRegistry.shared.controller(for: $0)?.pending?.id } },
+            askPending: { windowID.flatMap { PickRegistry.shared.controller(for: $0)?.pendingAsk?.id } },
             dashboardMembers: {
                 guard let dashboard, dashboard.isOpen else { return nil }
                 return dashboard.members.map(\.controlRef)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -503,7 +503,7 @@ final class ControlServer {
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
                 .windowFullscreen, .windowMinimize,
                 .restoreClear, .restoreCapture, .restoreMode, .zmxList, .zmxPrune, .zmxKill, .zmxTree,
-                .zmxAttach, .dashboard, .version:
+                .zmxAttach, .dashboard, .version, .askOpen, .askResult, .askCancel:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -827,12 +827,12 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
         }
     }
 
-    /// A picker is modal to terminal keyboard focus in its own window. The check lives inside both retry loops,
-    /// not just their callers: a picker can open after a retry starts, and the next tick must stop before it
-    /// steals first responder from the picker field.
+    /// A control dialog owns keyboard focus in its window. The check lives inside both retry loops,
+    /// not just their callers: a dialog can open after a retry starts, and the next tick must stop before it
+    /// steals first responder from the dialog.
     static func pickOwnsFocus(in window: NSWindow?) -> Bool {
         guard let window, let windowID = WindowRegistry.shared.windowID(for: window) else { return false }
-        return PickRegistry.shared.controller(for: windowID)?.pending != nil
+        return PickRegistry.shared.controller(for: windowID)?.modalPending == true
     }
 
     func destroySurface() {

--- a/agterm/Views/AskDialogView.swift
+++ b/agterm/Views/AskDialogView.swift
@@ -1,0 +1,221 @@
+import AppKit
+import SwiftUI
+import agtermCore
+
+struct AskAnchorPreferences {
+    var sessionID: UUID?
+    var container: Anchor<CGRect>?
+    var panes: [OverlayPane: Anchor<CGRect>] = [:]
+
+    mutating func merge(_ other: AskAnchorPreferences) {
+        guard let id = other.sessionID else { return }
+        guard sessionID == id else { self = other; return }
+        if let container = other.container { self.container = container }
+        panes.merge(other.panes) { _, newest in newest }
+    }
+}
+
+struct AskAnchorPreferenceKey: PreferenceKey {
+    static let defaultValue = AskAnchorPreferences()
+
+    static func reduce(value: inout AskAnchorPreferences, nextValue: () -> AskAnchorPreferences) {
+        value.merge(nextValue())
+    }
+}
+
+struct AskDialogView: View {
+    let ask: PendingAsk
+    let anchorFrame: CGRect
+    let font: NSFont
+    let foreground: Color
+    let background: Color
+    let focusAllowed: Bool
+    let onAnswer: (Int) -> Void
+    let onDismiss: () -> Void
+    @State private var navigation: AskNavigation
+    @State private var focusRevision = 0
+
+    init(ask: PendingAsk, anchorFrame: CGRect, font: NSFont, foreground: Color, background: Color,
+         focusAllowed: Bool, onAnswer: @escaping (Int) -> Void, onDismiss: @escaping () -> Void) {
+        self.ask = ask
+        self.anchorFrame = anchorFrame
+        self.font = font
+        self.foreground = foreground
+        self.background = background
+        self.focusAllowed = focusAllowed
+        self.onAnswer = onAnswer
+        self.onDismiss = onDismiss
+        _navigation = State(initialValue: AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID))
+    }
+
+    private var cell: CGFloat { max(8, font.pointSize * 0.6) }
+    private var panelWidth: CGFloat { min(max(0, anchorFrame.width - 2 * cell), 72 * cell) }
+    private var panelHeight: CGFloat { max(0, anchorFrame.height - 2 * cell) }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.2)
+                .contentShape(Rectangle())
+                .onTapGesture { focusRevision += 1 }
+            ScrollViewReader { reader in
+                ViewThatFits(in: .vertical) {
+                    content.fixedSize(horizontal: false, vertical: true)
+                        .background(background)
+                        .overlay { Rectangle().stroke(foreground.opacity(0.6), lineWidth: 1) }
+                        .accessibilityElement(children: .contain)
+                        .accessibilityIdentifier("ask-dialog")
+                    ScrollView { content }
+                        .background(background)
+                        .overlay { Rectangle().stroke(foreground.opacity(0.6), lineWidth: 1) }
+                        .accessibilityElement(children: .contain)
+                        .accessibilityIdentifier("ask-dialog")
+                }
+                .frame(width: panelWidth)
+                .frame(maxHeight: panelHeight)
+                .position(x: anchorFrame.midX, y: anchorFrame.midY)
+                .onChange(of: navigation.highlighted, initial: true) { _, index in
+                    guard let index else { return }
+                    reader.scrollTo(ask.buttons[index].id)
+                }
+            }
+            AskKeyCatcher(focusAllowed: focusAllowed, focusRevision: focusRevision, onKey: handle)
+                .frame(width: 0, height: 0)
+                .allowsHitTesting(false)
+        }
+        .font(Font(font))
+        .foregroundStyle(foreground)
+        .simultaneousGesture(TapGesture().onEnded { focusRevision += 1 })
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: cell * 1.5) {
+            Text(verbatim: ask.title)
+                .fontWeight(.bold)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("ask-title")
+            if let message = ask.message, !message.isEmpty {
+                Text(verbatim: message)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("ask-message")
+            }
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: cell) {
+                    ForEach(Array(ask.buttons.enumerated()), id: \.element.id) { index, choice in
+                        button(choice, index: index).fixedSize()
+                    }
+                }
+                VStack(alignment: .leading, spacing: cell) {
+                    ForEach(Array(ask.buttons.enumerated()), id: \.element.id) { index, choice in
+                        button(choice, index: index)
+                    }
+                }
+            }
+        }
+        .padding(cell * 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func button(_ choice: ControlAskButton, index: Int) -> some View {
+        Button { onAnswer(index) } label: {
+            Text(Self.buttonLabel(choice, destructive: choice.id == ask.destructiveID))
+                .fontWeight(choice.id == ask.destructiveID ? .bold : .regular)
+                .padding(.horizontal, cell * 0.5)
+                .padding(.vertical, cell * 0.4)
+                .foregroundStyle(navigation.highlighted == index ? background : foreground)
+                .background(navigation.highlighted == index ? foreground : Color.clear)
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .id(choice.id)
+        .accessibilityLabel(Text(verbatim: choice.label))
+        .accessibilityValue(navigation.highlighted == index ? "selected" : "")
+        .accessibilityIdentifier("ask-button-\(choice.id)")
+    }
+
+    static func buttonLabel(_ choice: ControlAskButton, destructive: Bool) -> AttributedString {
+        var label = AttributedString(choice.label)
+        if let hotkey = choice.hotkey {
+            if let range = label.range(of: hotkey, options: .caseInsensitive) {
+                label[range].underlineStyle = .single
+            } else {
+                var hint = AttributedString(hotkey.uppercased())
+                hint.underlineStyle = .single
+                label += AttributedString(" (") + hint + AttributedString(")")
+            }
+        }
+        return AttributedString(destructive ? "[ ! " : "[ ") + label + AttributedString(" ]")
+    }
+
+    private func handle(_ key: AskKey) {
+        switch key {
+        case .forward: navigation.moveForward()
+        case .backward: navigation.moveBackward()
+        case .activate:
+            if let index = navigation.activate() { onAnswer(index) }
+        case .cancel: onDismiss()
+        case .hotkey(let letter):
+            if let index = navigation.hotkey(letter) { onAnswer(index) }
+        }
+    }
+}
+
+enum AskKey: Equatable {
+    case forward, backward, activate, cancel
+    case hotkey(String)
+}
+
+struct AskKeyCatcher: NSViewRepresentable {
+    let focusAllowed: Bool
+    let focusRevision: Int
+    let onKey: (AskKey) -> Void
+
+    func makeNSView(context _: Context) -> KeyCatcherView {
+        let view = KeyCatcherView()
+        view.focusAllowed = focusAllowed
+        view.onKey = onKey
+        return view
+    }
+
+    func updateNSView(_ nsView: KeyCatcherView, context _: Context) {
+        _ = focusRevision
+        nsView.focusAllowed = focusAllowed
+        nsView.onKey = onKey
+        nsView.grabFocus()
+    }
+
+    static func key(for event: NSEvent) -> AskKey? {
+        guard event.modifierFlags.isDisjoint(with: [.command, .control, .option]) else { return nil }
+        switch event.keyCode {
+        case 48: return event.modifierFlags.contains(.shift) ? .backward : .forward
+        case 124, 125: return .forward
+        case 123, 126: return .backward
+        case 36, 76: return .activate
+        case 53: return .cancel
+        default:
+            guard let text = event.charactersIgnoringModifiers, text.utf8.count == 1,
+                  let ascii = text.utf8.first, (65...90).contains(ascii) || (97...122).contains(ascii) else { return nil }
+            return .hotkey(text.lowercased())
+        }
+    }
+
+    final class KeyCatcherView: NSView {
+        var focusAllowed = false
+        var onKey: ((AskKey) -> Void)?
+
+        override var acceptsFirstResponder: Bool { true }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            grabFocus()
+        }
+
+        func grabFocus() {
+            guard focusAllowed, let window, window.firstResponder !== self else { return }
+            window.makeFirstResponder(self)
+        }
+
+        override func keyDown(with event: NSEvent) {
+            if let key = AskKeyCatcher.key(for: event) { onKey?(key) }
+        }
+    }
+}

--- a/agterm/Views/AskDialogView.swift
+++ b/agterm/Views/AskDialogView.swift
@@ -45,10 +45,24 @@ struct AskDialogView: View {
         self.focusAllowed = focusAllowed
         self.onAnswer = onAnswer
         self.onDismiss = onDismiss
-        _navigation = State(initialValue: AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID))
+        _navigation = State(initialValue: AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID, destructiveID: ask.destructiveID))
     }
 
-    private var cell: CGFloat { max(8, font.pointSize * 0.6) }
+    private var cell: CGFloat { ask.style == .gui ? 8 : max(8, font.pointSize * 0.6) }
+    private var buttonAlignment: Alignment {
+        switch ask.align {
+        case .left: .leading
+        case .center: .center
+        case .right: .trailing
+        }
+    }
+    private var columnAlignment: HorizontalAlignment {
+        switch ask.align {
+        case .left: .leading
+        case .center: .center
+        case .right: .trailing
+        }
+    }
     private var panelWidth: CGFloat { min(max(0, anchorFrame.width - 2 * cell), 72 * cell) }
     private var panelHeight: CGFloat { max(0, anchorFrame.height - 2 * cell) }
 
@@ -60,13 +74,11 @@ struct AskDialogView: View {
             ScrollViewReader { reader in
                 ViewThatFits(in: .vertical) {
                     content.fixedSize(horizontal: false, vertical: true)
-                        .background(background)
-                        .overlay { Rectangle().stroke(foreground.opacity(0.6), lineWidth: 1) }
+                        .modifier(AskPanelStyle(style: ask.style, foreground: foreground, background: background))
                         .accessibilityElement(children: .contain)
                         .accessibilityIdentifier("ask-dialog")
                     ScrollView { content }
-                        .background(background)
-                        .overlay { Rectangle().stroke(foreground.opacity(0.6), lineWidth: 1) }
+                        .modifier(AskPanelStyle(style: ask.style, foreground: foreground, background: background))
                         .accessibilityElement(children: .contain)
                         .accessibilityIdentifier("ask-dialog")
                 }
@@ -82,19 +94,21 @@ struct AskDialogView: View {
                 .frame(width: 0, height: 0)
                 .allowsHitTesting(false)
         }
-        .font(Font(font))
-        .foregroundStyle(foreground)
+        .font(ask.style == .gui ? .body : Font(font))
+        .foregroundStyle(ask.style == .gui ? .primary : foreground)
         .simultaneousGesture(TapGesture().onEnded { focusRevision += 1 })
     }
 
     private var content: some View {
         VStack(alignment: .leading, spacing: cell * 1.5) {
             Text(verbatim: ask.title)
+                .font(ask.style == .gui ? .headline : Font(font))
                 .fontWeight(.bold)
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityIdentifier("ask-title")
             if let message = ask.message, !message.isEmpty {
                 Text(verbatim: message)
+                    .foregroundStyle(ask.style == .gui ? .secondary : foreground)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("ask-message")
             }
@@ -104,11 +118,13 @@ struct AskDialogView: View {
                         button(choice, index: index).fixedSize()
                     }
                 }
-                VStack(alignment: .leading, spacing: cell) {
+                .frame(maxWidth: .infinity, alignment: buttonAlignment)
+                VStack(alignment: columnAlignment, spacing: cell) {
                     ForEach(Array(ask.buttons.enumerated()), id: \.element.id) { index, choice in
                         button(choice, index: index)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: buttonAlignment)
             }
         }
         .padding(cell * 2)
@@ -116,15 +132,13 @@ struct AskDialogView: View {
     }
 
     private func button(_ choice: ControlAskButton, index: Int) -> some View {
-        Button { onAnswer(index) } label: {
-            Text(Self.buttonLabel(choice, destructive: choice.id == ask.destructiveID))
-                .fontWeight(choice.id == ask.destructiveID ? .bold : .regular)
-                .padding(.horizontal, cell * 0.5)
-                .padding(.vertical, cell * 0.4)
-                .foregroundStyle(navigation.highlighted == index ? background : foreground)
-                .background(navigation.highlighted == index ? foreground : Color.clear)
+        Group {
+            if ask.style == .gui {
+                guiButton(choice, index: index)
+            } else {
+                terminalButton(choice, index: index)
+            }
         }
-        .buttonStyle(.plain)
         .focusable(false)
         .id(choice.id)
         .accessibilityLabel(Text(verbatim: choice.label))
@@ -132,7 +146,38 @@ struct AskDialogView: View {
         .accessibilityIdentifier("ask-button-\(choice.id)")
     }
 
-    static func buttonLabel(_ choice: ControlAskButton, destructive: Bool) -> AttributedString {
+    private func terminalButton(_ choice: ControlAskButton, index: Int) -> some View {
+        Button { onAnswer(index) } label: {
+            Text(Self.buttonLabel(choice, destructive: choice.id == ask.destructiveID))
+                .fontWeight(choice.id == ask.destructiveID ? .bold : .regular)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, cell * 0.5)
+                .padding(.vertical, cell * 0.4)
+                .foregroundStyle(navigation.highlighted == index ? background : foreground)
+                .background(navigation.highlighted == index ? foreground : foreground.opacity(0.12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func guiButton(_ choice: ControlAskButton, index: Int) -> some View {
+        let button = Button(role: choice.id == ask.destructiveID ? .destructive : nil) {
+            onAnswer(index)
+        } label: {
+            Text(Self.buttonLabel(choice, destructive: false, bracketed: false))
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .tint(choice.id == ask.destructiveID ? Color.red : Color.accentColor)
+        if navigation.highlighted == index {
+            button.buttonStyle(.borderedProminent)
+        } else {
+            button.buttonStyle(.bordered)
+        }
+    }
+
+    static func buttonLabel(_ choice: ControlAskButton, destructive: Bool, bracketed: Bool = true) -> AttributedString {
         var label = AttributedString(choice.label)
         if let hotkey = choice.hotkey {
             if let range = label.range(of: hotkey, options: .caseInsensitive) {
@@ -143,7 +188,7 @@ struct AskDialogView: View {
                 label += AttributedString(" (") + hint + AttributedString(")")
             }
         }
-        return AttributedString(destructive ? "[ ! " : "[ ") + label + AttributedString(" ]")
+        return bracketed ? AttributedString(destructive ? "[ ! " : "[ ") + label + AttributedString(" ]") : label
     }
 
     private func handle(_ key: AskKey) {
@@ -156,6 +201,25 @@ struct AskDialogView: View {
         case .hotkey(let letter):
             if let index = navigation.hotkey(letter) { onAnswer(index) }
         }
+    }
+}
+
+private struct AskPanelStyle: ViewModifier {
+    let style: ControlAskStyle
+    let foreground: Color
+    let background: Color
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                if style == .gui { PalettePanelBackground() } else { background }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: style == .gui ? 12 : 0))
+            .overlay {
+                RoundedRectangle(cornerRadius: style == .gui ? 12 : 0)
+                    .strokeBorder(style == .gui ? .white.opacity(0.1) : foreground.opacity(0.6))
+            }
+            .shadow(radius: style == .gui ? 24 : 0)
     }
 }
 

--- a/agterm/Views/AskDialogView.swift
+++ b/agterm/Views/AskDialogView.swift
@@ -48,7 +48,8 @@ struct AskDialogView: View {
         _navigation = State(initialValue: AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID, destructiveID: ask.destructiveID))
     }
 
-    private var cell: CGFloat { ask.style == .gui ? 8 : max(8, font.pointSize * 0.6) }
+    private var terminalCell: CGFloat { max(8, font.pointSize * 0.6) }
+    private var cell: CGFloat { ask.style == .gui ? 8 : terminalCell }
     private var buttonAlignment: Alignment {
         switch ask.align {
         case .left: .leading
@@ -56,14 +57,10 @@ struct AskDialogView: View {
         case .right: .trailing
         }
     }
-    private var columnAlignment: HorizontalAlignment {
-        switch ask.align {
-        case .left: .leading
-        case .center: .center
-        case .right: .trailing
-        }
+    private var panelWidth: CGFloat {
+        if let width = ask.width { return max(0, anchorFrame.width) * CGFloat(min(100, max(10, width))) / 100 }
+        return min(max(0, anchorFrame.width * 0.9), 72 * terminalCell)
     }
-    private var panelWidth: CGFloat { min(max(0, anchorFrame.width - 2 * cell), 72 * cell) }
     private var panelHeight: CGFloat { max(0, anchorFrame.height - 2 * cell) }
 
     var body: some View {
@@ -72,18 +69,13 @@ struct AskDialogView: View {
                 .contentShape(Rectangle())
                 .onTapGesture { focusRevision += 1 }
             ScrollViewReader { reader in
-                ViewThatFits(in: .vertical) {
-                    content.fixedSize(horizontal: false, vertical: true)
-                        .modifier(AskPanelStyle(style: ask.style, foreground: foreground, background: background))
-                        .accessibilityElement(children: .contain)
-                        .accessibilityIdentifier("ask-dialog")
-                    ScrollView { content }
-                        .modifier(AskPanelStyle(style: ask.style, foreground: foreground, background: background))
-                        .accessibilityElement(children: .contain)
-                        .accessibilityIdentifier("ask-dialog")
+                ViewThatFits(in: .horizontal) {
+                    if ask.width == nil {
+                        panel.fixedSize(horizontal: true, vertical: false)
+                    }
+                    panel.frame(width: panelWidth)
                 }
-                .frame(width: panelWidth)
-                .frame(maxHeight: panelHeight)
+                .frame(maxWidth: panelWidth, maxHeight: panelHeight)
                 .position(x: anchorFrame.midX, y: anchorFrame.midY)
                 .onChange(of: navigation.highlighted, initial: true) { _, index in
                     guard let index else { return }
@@ -99,6 +91,19 @@ struct AskDialogView: View {
         .simultaneousGesture(TapGesture().onEnded { focusRevision += 1 })
     }
 
+    private var panel: some View {
+        ViewThatFits(in: .vertical) {
+            content.fixedSize(horizontal: false, vertical: true)
+                .modifier(AskPanelStyle(style: ask.style, foreground: foreground, background: background))
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("ask-dialog")
+            ScrollView { content }
+                .modifier(AskPanelStyle(style: ask.style, foreground: foreground, background: background))
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("ask-dialog")
+        }
+    }
+
     private var content: some View {
         VStack(alignment: .leading, spacing: cell * 1.5) {
             Text(verbatim: ask.title)
@@ -108,18 +113,18 @@ struct AskDialogView: View {
                 .accessibilityIdentifier("ask-title")
             if let message = ask.message, !message.isEmpty {
                 Text(verbatim: message)
-                    .foregroundStyle(ask.style == .gui ? .secondary : foreground)
+                    .foregroundStyle(ask.style == .gui ? .secondary : foreground.opacity(0.7))
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("ask-message")
             }
             ViewThatFits(in: .horizontal) {
-                HStack(spacing: cell) {
+                AskButtonLayout(axis: .horizontal, spacing: cell) {
                     ForEach(Array(ask.buttons.enumerated()), id: \.element.id) { index, choice in
-                        button(choice, index: index).fixedSize()
+                        button(choice, index: index)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: buttonAlignment)
-                VStack(alignment: columnAlignment, spacing: cell) {
+                AskButtonLayout(axis: .vertical, spacing: cell) {
                     ForEach(Array(ask.buttons.enumerated()), id: \.element.id) { index, choice in
                         button(choice, index: index)
                     }
@@ -152,6 +157,7 @@ struct AskDialogView: View {
                 .fontWeight(choice.id == ask.destructiveID ? .bold : .regular)
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, cell * 0.5)
                 .padding(.vertical, cell * 0.4)
                 .foregroundStyle(navigation.highlighted == index ? background : foreground)
@@ -165,9 +171,10 @@ struct AskDialogView: View {
         let button = Button(role: choice.id == ask.destructiveID ? .destructive : nil) {
             onAnswer(index)
         } label: {
-            Text(Self.buttonLabel(choice, destructive: false, bracketed: false))
+            Text(Self.buttonLabel(choice, destructive: false))
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity)
         }
         .tint(choice.id == ask.destructiveID ? Color.red : Color.accentColor)
         if navigation.highlighted == index {
@@ -177,7 +184,7 @@ struct AskDialogView: View {
         }
     }
 
-    static func buttonLabel(_ choice: ControlAskButton, destructive: Bool, bracketed: Bool = true) -> AttributedString {
+    static func buttonLabel(_ choice: ControlAskButton, destructive: Bool) -> AttributedString {
         var label = AttributedString(choice.label)
         if let hotkey = choice.hotkey {
             if let range = label.range(of: hotkey, options: .caseInsensitive) {
@@ -188,7 +195,7 @@ struct AskDialogView: View {
                 label += AttributedString(" (") + hint + AttributedString(")")
             }
         }
-        return bracketed ? AttributedString(destructive ? "[ ! " : "[ ") + label + AttributedString(" ]") : label
+        return destructive ? AttributedString("! ") + label : label
     }
 
     private func handle(_ key: AskKey) {
@@ -200,6 +207,41 @@ struct AskDialogView: View {
         case .cancel: onDismiss()
         case .hotkey(let letter):
             if let index = navigation.hotkey(letter) { onAnswer(index) }
+        }
+    }
+}
+
+private struct AskButtonLayout: Layout {
+    let axis: Axis
+    let spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let sizes = sizes(proposal: proposal, subviews: subviews)
+        let gaps = spacing * CGFloat(max(0, sizes.count - 1))
+        if axis == .horizontal {
+            return CGSize(width: sizes.reduce(0) { $0 + $1.width } + gaps, height: sizes.map(\.height).max() ?? 0)
+        }
+        return CGSize(width: sizes.first?.width ?? 0, height: sizes.reduce(0) { $0 + $1.height } + gaps)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let sizes = sizes(proposal: ProposedViewSize(bounds.size), subviews: subviews)
+        var offset: CGFloat = 0
+        for (index, subview) in subviews.enumerated() {
+            let size = sizes[index]
+            let point = axis == .horizontal
+                ? CGPoint(x: bounds.minX + offset, y: bounds.midY - size.height / 2)
+                : CGPoint(x: bounds.minX, y: bounds.minY + offset)
+            subview.place(at: point, anchor: .topLeading, proposal: ProposedViewSize(size))
+            offset += (axis == .horizontal ? size.width : size.height) + spacing
+        }
+    }
+
+    private func sizes(proposal: ProposedViewSize, subviews: Subviews) -> [CGSize] {
+        let widest = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? 0
+        let width = axis == .vertical ? min(widest, proposal.width ?? widest) : widest
+        return subviews.map {
+            CGSize(width: width, height: $0.sizeThatFits(ProposedViewSize(width: width, height: nil)).height)
         }
     }
 }
@@ -217,7 +259,7 @@ private struct AskPanelStyle: ViewModifier {
             .clipShape(RoundedRectangle(cornerRadius: style == .gui ? 12 : 0))
             .overlay {
                 RoundedRectangle(cornerRadius: style == .gui ? 12 : 0)
-                    .strokeBorder(style == .gui ? .white.opacity(0.1) : foreground.opacity(0.6))
+                    .strokeBorder(style == .gui ? .white.opacity(0.1) : foreground.opacity(0.3))
             }
             .shadow(radius: style == .gui ? 24 : 0)
     }

--- a/agterm/Views/AskDialogView.swift
+++ b/agterm/Views/AskDialogView.swift
@@ -211,7 +211,7 @@ struct AskDialogView: View {
     }
 }
 
-private struct AskButtonLayout: Layout {
+struct AskButtonLayout: Layout {
     let axis: Axis
     let spacing: CGFloat
 
@@ -238,11 +238,18 @@ private struct AskButtonLayout: Layout {
     }
 
     private func sizes(proposal: ProposedViewSize, subviews: Subviews) -> [CGSize] {
-        let widest = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? 0
-        let width = axis == .vertical ? min(widest, proposal.width ?? widest) : widest
+        let width = Self.sharedWidth(natural: subviews.map { $0.sizeThatFits(.unspecified).width },
+                                     proposal: proposal.width, axis: axis)
         return subviews.map {
             CGSize(width: width, height: $0.sizeThatFits(ProposedViewSize(width: width, height: nil)).height)
         }
+    }
+
+    /// Every button takes the widest natural width; a column also caps it at the proposed width so a long
+    /// label wraps instead of widening the panel.
+    static func sharedWidth(natural: [CGFloat], proposal: CGFloat?, axis: Axis) -> CGFloat {
+        let widest = natural.max() ?? 0
+        return axis == .vertical ? min(widest, proposal ?? widest) : widest
     }
 }
 

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -340,7 +340,7 @@ struct CommandPalette: View {
 }
 
 /// A separate view type so a selection change in `CommandPalette` doesn't re-resolve the whole backdrop.
-private struct PalettePanelBackground: View {
+struct PalettePanelBackground: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     @ViewBuilder var body: some View {

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -107,7 +107,7 @@ extension WindowContentView {
                 captionBackground: terminalColor,
                 pillColor: dashboardPillColor,
                 pillTextColor: dashboardPillTextColor,
-                focusAllowed: pick.pending == nil,
+                focusAllowed: !pick.modalPending,
                 showsTopHairline: toolbarMode != .hidden,
                 onClick: { clickDashboardMember($0) },
                 onSelect: { selectDashboardMember($0) },

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -149,6 +149,14 @@ extension WindowContentView {
             overlayPanel(session: session, isActive: focusable,
                          onScreen: deckInteractive && isActive, paneAnchors: anchors)
         }
+        .transformAnchorPreference(key: AskAnchorPreferenceKey.self, value: .bounds) { value, anchor in
+            if isActive {
+                value.sessionID = session.id
+                value.container = anchor
+            } else {
+                value = AskAnchorPreferences()
+            }
+        }
         // on PROGRAM overlay close refocus the topmost remaining surface via `topmostSurface` — never a pane
         // hidden under the scratch. One makeFirstResponder loses the race with the overlay's teardown/re-host,
         // so drive the bounded retry the split-collapse survivor uses. Only the visible session reclaims focus:
@@ -224,6 +232,7 @@ extension WindowContentView {
     /// which therefore renders only on the unfocused pane of a shown split.
     @ViewBuilder private func deckPane(_ session: Session, pane: OverlayPane, focused: Bool,
                                        gates: DeckPaneGates) -> some View {
+        let publishesAskAnchor = store.selectedSessionID == session.id
         // a pane hidden under its OWN overlay is not on screen: it registers no drag types and sets no mouse
         // cursor (the `deckVisible` note in libghostty.md, issue #225 class), and never takes first responder.
         let covered = session.paneOverlay(pane) != nil
@@ -252,6 +261,11 @@ extension WindowContentView {
             paneOverlayPanel(session: session, pane: pane, focused: focused, gates: gates)
         }
         .hudPaneAnchor(pane)
+        .anchorPreference(key: AskAnchorPreferenceKey.self, value: .bounds) { anchor in
+            publishesAskAnchor
+                ? AskAnchorPreferences(sessionID: session.id, panes: [pane: anchor])
+                : AskAnchorPreferences()
+        }
     }
 
     /// FULL, FLOATING, and HUD overlays render in `sessionDetail`'s always-present preference layer. Content

--- a/agterm/Views/WindowContentView+RecentSessions.swift
+++ b/agterm/Views/WindowContentView+RecentSessions.swift
@@ -21,9 +21,9 @@ extension WindowContentView {
     /// (only the current session). Opening a popover is interactive-only, so it is control-API keep-in-sync
     /// exempt, like the bell opening the attention palette.
     var recentSessionsButton: some View {
-        let enabled = !recentSessions.isEmpty && pick.pending == nil
+        let enabled = !recentSessions.isEmpty && !pick.modalPending
         return Button {
-            guard pick.pending == nil else { return }
+            guard !pick.modalPending else { return }
             recentSessionsShown.toggle()
         } label: {
             Label("Recent sessions", systemImage: "clock.arrow.circlepath")
@@ -98,7 +98,7 @@ extension WindowContentView {
     /// Commit a popover row click: note activity (so auto-follow can't pull the selection back), select the
     /// session, focus it, and close the popover — the mouse twin of the Ctrl-Tab release commit.
     private func selectRecent(_ id: UUID) {
-        guard pick.pending == nil else { return }
+        guard !pick.modalPending else { return }
         store.noteUserActivity()
         store.selectSession(id)
         actions.focusActiveSession()
@@ -117,9 +117,9 @@ extension WindowContentView {
         let sessions = store.attentionSessions
         let blocked = sessions.contains { $0.agentIndicator.status == .blocked }
         let empty = sessions.isEmpty
-        let enabled = !empty && pick.pending == nil
+        let enabled = !empty && !pick.modalPending
         return Button {
-            guard pick.pending == nil else { return }
+            guard !pick.modalPending else { return }
             attentionPopoverShown.toggle()
         } label: {
             Label("Attention", systemImage: blocked ? "bell.fill" : "bell")
@@ -172,7 +172,7 @@ extension WindowContentView {
     /// Commit an attention popover row click: select the session and reveal its blocked pane (the pane that
     /// set the status), then close the popover — the mouse twin of the ⌃⇧I palette's select-and-reveal.
     private func selectAttention(_ id: UUID) {
-        guard pick.pending == nil else { return }
+        guard !pick.modalPending else { return }
         store.noteUserActivity()
         let indicator = store.selectSession(id)
         actions.revealActiveBlockedPane(captured: indicator)

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -189,7 +189,7 @@ extension WindowContentView {
             Label("Quick Terminal", systemImage: "terminal")
         }
         .help(helpHint("Quick Terminal", .quickTerminal))
-        .disabled(pick.pending != nil)
+        .disabled(pick.modalPending)
         .accessibilityIdentifier("quick-terminal-toggle")
     }
 }

--- a/agterm/Views/WindowContentView+Zoom.swift
+++ b/agterm/Views/WindowContentView+Zoom.swift
@@ -174,7 +174,7 @@ extension WindowContentView {
     /// machinery. The outer retry here only waits for a surface the zoom layer's `TerminalView` hasn't
     /// realized yet (e.g. zooming a never-shown scratch), and dies as soon as the zoom target changes.
     func focusZoomedSessionSurface(session: Session, surface: TerminalZoomSurface, attempt: Int = 0) {
-        guard pick.pending == nil else { return }
+        guard !pick.modalPending else { return }
         let expectedTarget = TerminalZoomTarget.session(session.id, surface)
         guard terminalZoom.target == expectedTarget else { return }
         if let view = surface.surface(in: session) as? GhosttySurfaceView {

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -131,6 +131,10 @@ struct WindowContentView: View {
                 .padding(.top, titlebarHeight)
                 .zIndex(20)
         }
+        .overlayPreferenceValue(AskAnchorPreferenceKey.self) { anchors in
+            askDialogOverlay(anchors).zIndex(20)
+                .allowsHitTesting(pick.pendingAsk != nil)
+        }
         // with the title bar hidden (.hiddenTitleBar), pull our header to the very top so the traffic
         // lights overlay it as one row; no system title bar is left to clip the content.
         .ignoresSafeArea(.container, edges: .top)
@@ -595,6 +599,65 @@ struct WindowContentView: View {
             )
             .id(pending.id)
         }
+    }
+
+    private func askDialogOverlay(_ anchors: AskAnchorPreferences) -> some View {
+        GeometryReader { proxy in
+            if let ask = pick.pendingAsk {
+                let valid = askAnchorIsValid(ask.anchor)
+                ZStack {
+                    Color.clear.contentShape(Rectangle()).onTapGesture {}
+                    if let frame = askAnchorFrame(ask.anchor, anchors: anchors, proxy: proxy), valid {
+                        AskDialogView(ask: ask, anchorFrame: frame, font: askFont,
+                                      foreground: chromeText, background: terminalColor, focusAllowed: isFrontmost,
+                                      onAnswer: { index in
+                                          guard pick.pendingAsk?.id == ask.id else { return }
+                                          let button = ask.buttons[index]
+                                          pick.resolveAsk(ControlAskResult(result: .answered, id: button.id,
+                                                                           label: button.label, index: index))
+                                      },
+                                      onDismiss: {
+                                          guard pick.pendingAsk?.id == ask.id else { return }
+                                          actions.dismissPendingAsk(for: windowID, userInitiated: true)
+                                      })
+                    }
+                }
+                .id(ask.id)
+                .onChange(of: valid, initial: true) { _, valid in
+                    if !valid, pick.pendingAsk?.id == ask.id { pick.cancelAsk() }
+                }
+            }
+        }
+    }
+
+    private var askFont: NSFont {
+        let size = actions.settingsModel?.settings.fontSize ?? GhosttyApp.shared.baseFontSize
+        if let family = actions.settingsModel?.settings.fontFamily, let font = NSFont(name: family, size: size) {
+            return font
+        }
+        return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    private func askAnchorIsValid(_ anchor: AskAnchor?) -> Bool {
+        guard let anchor else { return true }
+        guard store.selectedSessionID == anchor.sessionID,
+              let session = store.session(withID: anchor.sessionID) else { return false }
+        guard let identity = anchor.paneIdentity else { return anchor.pane == nil }
+        guard let pane = session.askTargetPane(for: identity) else { return false }
+        return session.rendersPane(pane)
+    }
+
+    private func askAnchorFrame(_ anchor: AskAnchor?, anchors: AskAnchorPreferences, proxy: GeometryProxy) -> CGRect? {
+        guard let anchor else {
+            return CGRect(x: 0, y: titlebarHeight, width: proxy.size.width, height: max(0, proxy.size.height - titlebarHeight))
+        }
+        guard anchors.sessionID == anchor.sessionID else { return nil }
+        if let identity = anchor.paneIdentity {
+            guard let session = store.session(withID: anchor.sessionID),
+                  let pane = session.askTargetPane(for: identity), let bounds = anchors.panes[pane] else { return nil }
+            return proxy[bounds]
+        }
+        return anchors.container.map { proxy[$0] }
     }
 
     /// The Ctrl-Tab session switcher overlay, mounted only while cycling in the frontmost window.

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -643,7 +643,7 @@ struct WindowContentView: View {
         guard store.selectedSessionID == anchor.sessionID,
               let session = store.session(withID: anchor.sessionID) else { return false }
         guard let identity = anchor.paneIdentity else { return anchor.pane == nil }
-        guard let pane = session.askTargetPane(for: identity) else { return false }
+        guard let pane = session.paneRole(forIdentity: identity) else { return false }
         return session.rendersPane(pane)
     }
 
@@ -655,7 +655,7 @@ struct WindowContentView: View {
         guard anchors.sessionID == anchor.sessionID else { return nil }
         if let identity = anchor.paneIdentity {
             guard let session = store.session(withID: anchor.sessionID),
-                  let pane = session.askTargetPane(for: identity), let bounds = anchors.panes[pane] else { return nil }
+                  let pane = session.paneRole(forIdentity: identity), let bounds = anchors.panes[pane] else { return nil }
             return proxy[bounds]
         }
         return anchors.container.map { proxy[$0] }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -185,8 +185,8 @@ struct WindowContentView: View {
         }
         // a native picker owns keyboard focus like a palette: pair auto-follow suppression per window, then
         // return first responder to this window's terminal after every resolution path.
-        .onChange(of: pick.pending?.id) { old, new in
-            if old == nil, new != nil, !pickSuppressesAutoFollow {
+        .onChange(of: pick.modalPending) { old, new in
+            if !old, new, !pickSuppressesAutoFollow {
                 // a socket-driven picker may arrive with either title-bar popover already open; dismiss
                 // both so no second interactive surface remains above the modal picker. The quick-terminal
                 // panel is now exactly that surface and the worst of them: it floats above every window and
@@ -197,7 +197,7 @@ struct WindowContentView: View {
                 attentionPopoverShown = false
                 store.suppressAutoFollow()
                 pickSuppressesAutoFollow = true
-            } else if old != nil, new == nil, pickSuppressesAutoFollow {
+            } else if old, !new, pickSuppressesAutoFollow {
                 store.resumeAutoFollow()
                 pickSuppressesAutoFollow = false
                 if pickFocusRestoration.pickerResolved(isFrontmost: isFrontmost) {
@@ -303,8 +303,8 @@ struct WindowContentView: View {
             .opacity(terminalZoom.target == nil ? 1 : 0)
             .allowsHitTesting(terminalZoom.target == nil)
             .onChange(of: isFrontmost) { _, frontmost in
-                if frontmost, pick.pending != nil { palette.close() }
-                if frontmost, pickFocusRestoration.windowBecameFrontmost(pickPending: pick.pending != nil) {
+                if frontmost, pick.modalPending { palette.close() }
+                if frontmost, pickFocusRestoration.windowBecameFrontmost(pickPending: pick.modalPending) {
                     restoreFocusAfterPick()
                 }
             }
@@ -560,7 +560,7 @@ struct WindowContentView: View {
     /// Mounted only while a palette is open in the frontmost window; its content (search field + result
     /// list) is rebuilt from `palette.mode`.
     @ViewBuilder private var commandPaletteOverlay: some View {
-        if isFrontmost, pick.pending == nil, palette.mode != nil {
+        if isFrontmost, !pick.modalPending, palette.mode != nil {
             CommandPalette(controller: palette, actions: actions, terminalAreaInset: terminalAreaInset)
         }
     }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -618,7 +618,7 @@ struct WindowContentView: View {
                                       },
                                       onDismiss: {
                                           guard pick.pendingAsk?.id == ask.id else { return }
-                                          actions.dismissPendingAsk(for: windowID, userInitiated: true)
+                                          actions.escapePendingAsk(for: windowID)
                                       })
                     }
                 }
@@ -649,7 +649,8 @@ struct WindowContentView: View {
 
     private func askAnchorFrame(_ anchor: AskAnchor?, anchors: AskAnchorPreferences, proxy: GeometryProxy) -> CGRect? {
         guard let anchor else {
-            return CGRect(x: 0, y: titlebarHeight, width: proxy.size.width, height: max(0, proxy.size.height - titlebarHeight))
+            return CGRect(x: terminalAreaInset, y: titlebarHeight, width: max(0, proxy.size.width - terminalAreaInset),
+                          height: max(0, proxy.size.height - titlebarHeight))
         }
         guard anchors.sessionID == anchor.sessionID else { return nil }
         if let identity = anchor.paneIdentity {

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -479,7 +479,7 @@ struct agtermApp: App {
             guard windowID.flatMap({ TerminalZoomRegistry.shared.controller(for: $0) })?.target == nil else { return }
             // a control picker is the topmost modal: `session.search --to close` stays valid cleanup while one
             // is pending, but its async END must not return focus behind it.
-            guard PickRegistry.shared.controller(for: windowID)?.pending == nil else { return }
+            guard PickRegistry.shared.controller(for: windowID)?.modalPending != true else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
         view.onSearchTotal = { total in store.session(withID: sessionID)?.searchTotal = total }
@@ -726,14 +726,14 @@ struct agtermApp: App {
         // selection behind the panel while the user types (mirrors the overlay/scratch).
         controller.onUserInput = { [weak library] in library?.activeStore?.noteUserActivity() }
         controller.focusAllowed = { [weak library] in
-            PickRegistry.shared.controller(for: library?.activeWindowID)?.pending == nil
+            PickRegistry.shared.controller(for: library?.activeWindowID)?.modalPending != true
         }
         // the global hotkey reaches the controller directly, with none of the `uiActionsEnabled` gating every
         // in-app path has, so the pick term belongs here. Only that term: refusing a system-wide summon
         // because some BACKGROUND window has a dashboard open would defeat the point of the chord.
         controller.canShow = { [weak library] in
             guard let library, !library.openIDs().isEmpty else { return false }
-            return PickRegistry.shared.controller(for: library.activeWindowID)?.pending == nil
+            return PickRegistry.shared.controller(for: library.activeWindowID)?.modalPending != true
         }
         controller.terminalColorProvider = { WindowContentView.resolvedTerminalColor() }
     }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -269,6 +269,7 @@ public final class AppStore {
                             quickVisible: () -> Bool? = { nil },
                             zoomedSurface: () -> String? = { nil },
                             pickPending: () -> String? = { nil },
+                            askPending: () -> String? = { nil },
                             dashboardMembers: () -> [String]? = { nil },
                             dashboardHighlighted: () -> String? = { nil },
                             dashboardFontSize: () -> Double? = { nil },
@@ -345,7 +346,7 @@ public final class AppStore {
                            dashboardHighlighted: dashboardHighlighted(),
                            dashboardFontSize: dashboardFontSize(),
                            dashboardFontMode: dashboardFontMode(),
-                           pickPending: pickPending(), app: app)
+                           pickPending: pickPending(), askPending: askPending(), app: app)
     }
 
     /// The tree's `paneOverlays`: the panes covered by their own overlay, omitted when neither is.

--- a/agtermCore/Sources/agtermCore/Ask.swift
+++ b/agtermCore/Sources/agtermCore/Ask.swift
@@ -32,6 +32,8 @@ public struct PendingAsk: Equatable, Sendable {
     public let style: ControlAskStyle
     /// align positions the button block in both row and column layouts.
     public let align: ControlAskAlignment
+    /// width is a fixed percentage of the anchor, absent for content sizing.
+    public let width: Int?
     /// destructiveID identifies the button styled as destructive.
     public let destructiveID: String?
     /// anchor is absent for a dialog centered over the window's terminal area.
@@ -39,7 +41,7 @@ public struct PendingAsk: Equatable, Sendable {
 
     public init(id: String, title: String, message: String? = nil, buttons: [ControlAskButton],
                 defaultID: String? = nil, destructiveID: String? = nil, style: ControlAskStyle = .terminal, align: ControlAskAlignment = .right,
-                anchor: AskAnchor? = nil) {
+                width: Int? = nil, anchor: AskAnchor? = nil) {
         self.id = id
         self.title = title
         self.message = message
@@ -47,6 +49,7 @@ public struct PendingAsk: Equatable, Sendable {
         self.defaultID = defaultID
         self.style = style
         self.align = align
+        self.width = width
         self.destructiveID = destructiveID
         self.anchor = anchor
     }

--- a/agtermCore/Sources/agtermCore/Ask.swift
+++ b/agtermCore/Sources/agtermCore/Ask.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// AskAnchor identifies the session or pane captured when a dialog opens.
+public struct AskAnchor: Equatable, Sendable {
+    /// sessionID identifies the session whose area anchors the dialog.
+    public let sessionID: UUID
+    /// pane is the role resolved at open, absent for a session-wide anchor.
+    public let pane: OverlayPane?
+    /// paneIdentity follows the pane through swaps and primary promotion.
+    public let paneIdentity: UUID?
+
+    public init(sessionID: UUID, pane: OverlayPane? = nil, paneIdentity: UUID? = nil) {
+        self.sessionID = sessionID
+        self.pane = pane
+        self.paneIdentity = paneIdentity
+    }
+}
+
+/// PendingAsk holds one dialog awaiting an answer in its owning window.
+public struct PendingAsk: Equatable, Sendable {
+    /// id is the globally unique dialog request id.
+    public let id: String
+    /// title is the dialog headline.
+    public let title: String
+    /// message is the optional body below the title.
+    public let message: String?
+    /// buttons preserves the caller's choice order.
+    public let buttons: [ControlAskButton]
+    /// defaultID identifies the initially highlighted button.
+    public let defaultID: String?
+    /// cancelID identifies the button returned on user dismissal.
+    public let cancelID: String?
+    /// destructiveID identifies the button styled as destructive.
+    public let destructiveID: String?
+    /// anchor is absent for a dialog centered in the window.
+    public let anchor: AskAnchor?
+
+    public init(id: String, title: String, message: String? = nil, buttons: [ControlAskButton],
+                defaultID: String? = nil, cancelID: String? = nil, destructiveID: String? = nil,
+                anchor: AskAnchor? = nil) {
+        self.id = id
+        self.title = title
+        self.message = message
+        self.buttons = buttons
+        self.defaultID = defaultID
+        self.cancelID = cancelID
+        self.destructiveID = destructiveID
+        self.anchor = anchor
+    }
+}
+
+/// AskNavigation tracks keyboard selection in caller button order.
+public struct AskNavigation: Sendable {
+    /// highlighted is absent until a default or navigation selects a button.
+    public private(set) var highlighted: Int?
+    private let buttons: [ControlAskButton]
+
+    public init(buttons: [ControlAskButton], defaultID: String? = nil) {
+        self.buttons = buttons
+        highlighted = defaultID.flatMap { id in buttons.firstIndex { $0.id == id } }
+    }
+
+    /// moveForward enters at the first button and wraps after the last.
+    public mutating func moveForward() {
+        guard !buttons.isEmpty else { return }
+        highlighted = highlighted.map { ($0 + 1) % buttons.count } ?? 0
+    }
+
+    /// moveBackward enters at the last button and wraps before the first.
+    public mutating func moveBackward() {
+        guard !buttons.isEmpty else { return }
+        highlighted = highlighted.map { ($0 + buttons.count - 1) % buttons.count } ?? (buttons.count - 1)
+    }
+
+    /// activate returns the highlighted button's index, or nil before selection.
+    public func activate() -> Int? {
+        highlighted
+    }
+
+    /// hotkey returns a matching button's index without requiring a highlight.
+    public func hotkey(_ letter: String) -> Int? {
+        let key = letter.lowercased()
+        return buttons.firstIndex { $0.hotkey?.lowercased() == key }
+    }
+}

--- a/agtermCore/Sources/agtermCore/Ask.swift
+++ b/agtermCore/Sources/agtermCore/Ask.swift
@@ -28,22 +28,25 @@ public struct PendingAsk: Equatable, Sendable {
     public let buttons: [ControlAskButton]
     /// defaultID identifies the initially highlighted button.
     public let defaultID: String?
-    /// cancelID identifies the button returned on user dismissal.
-    public let cancelID: String?
+    /// style selects the dialog rendering without changing its behavior.
+    public let style: ControlAskStyle
+    /// align positions the button block in both row and column layouts.
+    public let align: ControlAskAlignment
     /// destructiveID identifies the button styled as destructive.
     public let destructiveID: String?
-    /// anchor is absent for a dialog centered in the window.
+    /// anchor is absent for a dialog centered over the window's terminal area.
     public let anchor: AskAnchor?
 
     public init(id: String, title: String, message: String? = nil, buttons: [ControlAskButton],
-                defaultID: String? = nil, cancelID: String? = nil, destructiveID: String? = nil,
+                defaultID: String? = nil, destructiveID: String? = nil, style: ControlAskStyle = .terminal, align: ControlAskAlignment = .right,
                 anchor: AskAnchor? = nil) {
         self.id = id
         self.title = title
         self.message = message
         self.buttons = buttons
         self.defaultID = defaultID
-        self.cancelID = cancelID
+        self.style = style
+        self.align = align
         self.destructiveID = destructiveID
         self.anchor = anchor
     }
@@ -51,13 +54,15 @@ public struct PendingAsk: Equatable, Sendable {
 
 /// AskNavigation tracks keyboard selection in caller button order.
 public struct AskNavigation: Sendable {
-    /// highlighted is absent until a default or navigation selects a button.
+    /// highlighted is absent only when the button list is empty.
     public private(set) var highlighted: Int?
     private let buttons: [ControlAskButton]
 
-    public init(buttons: [ControlAskButton], defaultID: String? = nil) {
+    public init(buttons: [ControlAskButton], defaultID: String? = nil, destructiveID: String? = nil) {
         self.buttons = buttons
         highlighted = defaultID.flatMap { id in buttons.firstIndex { $0.id == id } }
+            ?? buttons.firstIndex { $0.id != destructiveID }
+            ?? buttons.indices.first
     }
 
     /// moveForward enters at the first button and wraps after the last.
@@ -72,7 +77,7 @@ public struct AskNavigation: Sendable {
         highlighted = highlighted.map { ($0 + buttons.count - 1) % buttons.count } ?? (buttons.count - 1)
     }
 
-    /// activate returns the highlighted button's index, or nil before selection.
+    /// activate returns the highlighted button's index, or nil for an empty list.
     public func activate() -> Int? {
         highlighted
     }

--- a/agtermCore/Sources/agtermCore/ControlActionsDefaults.swift
+++ b/agtermCore/Sources/agtermCore/ControlActionsDefaults.swift
@@ -3,6 +3,19 @@ import Foundation
 // Default `ControlActions` implementations, kept out of `ControlDispatcher.swift` so that file stays
 // inside the 1000-line limit.
 public extension ControlActions {
+    func openAsk(_: PendingAsk, target _: String?, window _: String?,
+                 placement _: ControlAskPlacement, follow _: Bool) -> ControlResponse {
+        ControlResponse(ok: false, error: ControlActionsUnsupported.message("ask.open"))
+    }
+
+    func askResult(_: String, window _: String?) -> ControlResponse {
+        ControlResponse(ok: false, error: ControlActionsUnsupported.message("ask.result"))
+    }
+
+    func cancelAsk(_: String, window _: String?) -> ControlResponse {
+        ControlResponse(ok: false, error: ControlActionsUnsupported.message("ask.cancel"))
+    }
+
     /// Defaults keep outside conformers building when the shared protocol grows. Mac-only commands refuse
     /// by name rather than answering an empty success; compatibility overloads delegate to the older form.
     func readRestoreMode() -> ControlResponse {

--- a/agtermCore/Sources/agtermCore/ControlAsk.swift
+++ b/agtermCore/Sources/agtermCore/ControlAsk.swift
@@ -1,0 +1,63 @@
+/// ControlAskButton is a caller-provided dialog button.
+public struct ControlAskButton: Codable, Sendable, Equatable {
+    /// maxButtons limits the number of buttons in one dialog.
+    public static let maxButtons = 6
+
+    /// id identifies the button in role assignments and answered results.
+    public let id: String
+    /// label is the button text shown in the dialog.
+    public let label: String
+    /// hotkey is the optional ASCII letter that activates the button.
+    public let hotkey: String?
+
+    public init(id: String, label: String, hotkey: String? = nil) {
+        self.id = id
+        self.label = label
+        self.hotkey = hotkey
+    }
+}
+
+/// ControlAskOutcome is the current or terminal state returned by ask.result.
+public enum ControlAskOutcome: String, Codable, Sendable, CaseIterable {
+    /// pending means the dialog is awaiting an answer.
+    case pending
+    /// answered means the dialog resolved to a caller-provided button.
+    case answered
+    /// cancelled means the dialog resolved without a button answer.
+    case cancelled
+}
+
+/// ControlAskResult is the nested wire payload returned by ask.result.
+public struct ControlAskResult: Codable, Sendable, Equatable {
+    /// result is the current or terminal dialog outcome.
+    public let result: ControlAskOutcome
+    /// id identifies the answered button, absent for pending or cancelled results.
+    public let id: String?
+    /// label is the answered button's text, absent without a button answer.
+    public let label: String?
+    /// index is the answered button's zero-based position in caller order.
+    public let index: Int?
+
+    public init(result: ControlAskOutcome, id: String? = nil, label: String? = nil, index: Int? = nil) {
+        self.result = result
+        self.id = id
+        self.label = label
+        self.index = index
+    }
+}
+
+/// ResolvedAsk pairs a retained outcome with the dialog that produced it.
+public struct ResolvedAsk: Codable, Sendable, Equatable {
+    /// id identifies the dialog request, not the answered button.
+    public let id: String
+    /// result is the retained terminal outcome.
+    public let result: ControlAskResult
+    /// sequence orders resolutions across windows for retention.
+    public let sequence: Int
+
+    public init(id: String, result: ControlAskResult, sequence: Int = 0) {
+        self.id = id
+        self.result = result
+        self.sequence = sequence
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlAsk.swift
+++ b/agtermCore/Sources/agtermCore/ControlAsk.swift
@@ -23,15 +23,35 @@ public enum ControlAskOutcome: String, Codable, Sendable, CaseIterable {
     case pending
     /// answered means the dialog resolved to a caller-provided button.
     case answered
-    /// cancelled means the dialog resolved without a button answer.
+    /// escaped means the user dismissed the dialog with Esc or Command-W.
+    case escaped
+    /// cancelled means the dialog was cancelled administratively.
     case cancelled
+}
+
+/// ControlAskStyle selects dialog decoration without changing behavior or placement.
+public enum ControlAskStyle: String, Codable, Sendable, CaseIterable {
+    /// terminal uses monospace text and terminal theme colors.
+    case terminal
+    /// gui uses the palette appearance and native buttons.
+    case gui
+}
+
+/// ControlAskAlignment positions the button block within its panel.
+public enum ControlAskAlignment: String, Codable, Sendable, CaseIterable {
+    /// left aligns the block to the leading edge.
+    case left
+    /// center centers the block horizontally.
+    case center
+    /// right aligns the block to the trailing edge.
+    case right
 }
 
 /// ControlAskResult is the nested wire payload returned by ask.result.
 public struct ControlAskResult: Codable, Sendable, Equatable {
     /// result is the current or terminal dialog outcome.
     public let result: ControlAskOutcome
-    /// id identifies the answered button, absent for pending or cancelled results.
+    /// id identifies the answered button, absent without a button answer.
     public let id: String?
     /// label is the answered button's text, absent without a button answer.
     public let label: String?

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// ControlAskPlacement carries pane selectors for the host to resolve against the target session.
+public struct ControlAskPlacement: Equatable, Sendable {
+    /// pane is the parsed role used when no live paneID resolves.
+    public let pane: OverlayPane?
+    /// paneID is the caller's stable pane token, resolved by the host.
+    public let paneID: String?
+
+    public init(pane: OverlayPane? = nil, paneID: String? = nil) {
+        self.pane = pane
+        self.paneID = paneID
+    }
+}
+
+extension ControlDispatcher {
+    /// dispatchAskCommand validates caller input before the host resolves placement or changes modal state.
+    func dispatchAskCommand(_ request: ControlRequest) -> ControlResponse {
+        switch request.cmd {
+        case .askOpen:
+            return dispatchAskOpen(request)
+        case .askResult:
+            guard let target = request.target else {
+                return ControlResponse(ok: false, error: "ask.result requires an ask id")
+            }
+            return actions.askResult(target, window: request.args?.window)
+        case .askCancel:
+            guard let target = request.target else {
+                return ControlResponse(ok: false, error: "ask.cancel requires an ask id")
+            }
+            return actions.cancelAsk(target, window: request.args?.window)
+        default:
+            preconditionFailure("dispatchAskCommand called for \(request.cmd.rawValue)")
+        }
+    }
+
+    private func dispatchAskOpen(_ request: ControlRequest) -> ControlResponse {
+        guard let args = request.args, let title = args.title,
+              !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return ControlResponse(ok: false, error: "ask.open requires a title")
+        }
+        guard let buttons = args.buttons else {
+            return ControlResponse(ok: false, error: "ask.open requires buttons")
+        }
+        guard !buttons.isEmpty else {
+            return ControlResponse(ok: false, error: "ask.open requires at least one button")
+        }
+        guard buttons.count <= ControlAskButton.maxButtons else {
+            return ControlResponse(ok: false, error: "too many buttons (max \(ControlAskButton.maxButtons))")
+        }
+        guard buttons.allSatisfy({ !$0.label.isEmpty }) else {
+            return ControlResponse(ok: false, error: "ask button label must not be empty")
+        }
+        var ids = Set<String>()
+        guard buttons.allSatisfy({ ids.insert($0.id).inserted }) else {
+            return ControlResponse(ok: false, error: "ask button ids must be unique")
+        }
+        guard !containsControlCharacters(title), !containsControlCharacters(args.message ?? ""),
+              buttons.allSatisfy({ !containsControlCharacters($0.label) }) else {
+            return ControlResponse(ok: false, error: "ask text must not contain control characters")
+        }
+        for (role, id) in [("default", args.defaultButton), ("cancel", args.cancelButton),
+                           ("destructive", args.destructiveButton)] {
+            if let id, !ids.contains(id) {
+                return ControlResponse(ok: false, error: "unknown \(role) button: \(id)")
+            }
+        }
+        if let destructive = args.destructiveButton {
+            if args.defaultButton == destructive {
+                return ControlResponse(ok: false, error: "default button must not be destructive")
+            }
+            if args.cancelButton == destructive {
+                return ControlResponse(ok: false, error: "cancel button must not be destructive")
+            }
+        }
+        var hotkeys = Set<String>()
+        for button in buttons {
+            guard let hotkey = button.hotkey else { continue }
+            guard hotkey.utf8.count == 1, let ascii = hotkey.utf8.first,
+                  (65...90).contains(ascii) || (97...122).contains(ascii) else {
+                return ControlResponse(ok: false, error: "ask button hotkey must be one ASCII letter")
+            }
+            guard hotkeys.insert(hotkey.lowercased()).inserted else {
+                return ControlResponse(ok: false, error: "ask button hotkeys must be unique")
+            }
+        }
+        if args.pane != nil || args.paneID != nil, request.target == nil {
+            return ControlResponse(ok: false, error: "--pane requires a session")
+        }
+        let pane: OverlayPane?
+        switch parsePane(args.pane, error: "--pane must be left or right",
+                         parse: { OverlayPane(controlName: $0) }) {
+        case .pane(let parsed): pane = parsed
+        case .rejected(let response): return response
+        }
+        let ask = PendingAsk(
+            id: UUID().uuidString, title: title, message: args.message,
+            buttons: buttons.map { ControlAskButton(id: $0.id, label: $0.label, hotkey: $0.hotkey?.lowercased()) },
+            defaultID: args.defaultButton, cancelID: args.cancelButton, destructiveID: args.destructiveButton
+        )
+        return actions.openAsk(ask, target: request.target, window: args.window,
+                               placement: ControlAskPlacement(pane: pane, paneID: args.paneID),
+                               follow: args.follow == true)
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift
@@ -59,7 +59,7 @@ extension ControlDispatcher {
               buttons.allSatisfy({ !containsControlCharacters($0.label) }) else {
             return ControlResponse(ok: false, error: "ask text must not contain control characters")
         }
-        for (role, id) in [("default", args.defaultButton), ("cancel", args.cancelButton),
+        for (role, id) in [("default", args.defaultButton),
                            ("destructive", args.destructiveButton)] {
             if let id, !ids.contains(id) {
                 return ControlResponse(ok: false, error: "unknown \(role) button: \(id)")
@@ -69,9 +69,12 @@ extension ControlDispatcher {
             if args.defaultButton == destructive {
                 return ControlResponse(ok: false, error: "default button must not be destructive")
             }
-            if args.cancelButton == destructive {
-                return ControlResponse(ok: false, error: "cancel button must not be destructive")
-            }
+        }
+        guard let style = ControlAskStyle(rawValue: args.style ?? "terminal") else {
+            return ControlResponse(ok: false, error: "unknown style")
+        }
+        guard let align = ControlAskAlignment(rawValue: args.align ?? "right") else {
+            return ControlResponse(ok: false, error: "unknown align")
         }
         var hotkeys = Set<String>()
         for button in buttons {
@@ -96,7 +99,7 @@ extension ControlDispatcher {
         let ask = PendingAsk(
             id: UUID().uuidString, title: title, message: args.message,
             buttons: buttons.map { ControlAskButton(id: $0.id, label: $0.label, hotkey: $0.hotkey?.lowercased()) },
-            defaultID: args.defaultButton, cancelID: args.cancelButton, destructiveID: args.destructiveButton
+            defaultID: args.defaultButton, destructiveID: args.destructiveButton, style: style, align: align
         )
         return actions.openAsk(ask, target: request.target, window: args.window,
                                placement: ControlAskPlacement(pane: pane, paneID: args.paneID),

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift
@@ -76,6 +76,9 @@ extension ControlDispatcher {
         guard let align = ControlAskAlignment(rawValue: args.align ?? "right") else {
             return ControlResponse(ok: false, error: "unknown align")
         }
+        if let width = args.width, !(10...100).contains(width) {
+            return ControlResponse(ok: false, error: "width must be 10 to 100")
+        }
         var hotkeys = Set<String>()
         for button in buttons {
             guard let hotkey = button.hotkey else { continue }
@@ -99,7 +102,7 @@ extension ControlDispatcher {
         let ask = PendingAsk(
             id: UUID().uuidString, title: title, message: args.message,
             buttons: buttons.map { ControlAskButton(id: $0.id, label: $0.label, hotkey: $0.hotkey?.lowercased()) },
-            defaultID: args.defaultButton, destructiveID: args.destructiveButton, style: style, align: align
+            defaultID: args.defaultButton, destructiveID: args.destructiveButton, style: style, align: align, width: args.width
         )
         return actions.openAsk(ask, target: request.target, window: args.window,
                                placement: ControlAskPlacement(pane: pane, paneID: args.paneID),

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -202,6 +202,8 @@ public struct ControlDispatcher {
             return nil
         case .pickOpen, .pickResult, .pickCancel:
             return dispatchPickCommand(request)
+        case .askOpen, .askResult, .askCancel:
+            return nil
         case .sessionHudOpen, .sessionHudUpdate, .sessionHudClose:
             return dispatchHudCommand(request)
         }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -130,6 +130,13 @@ public protocol ControlActions {
     func pickResult(_ target: String, window: String?) -> ControlResponse
     /// Cancel a native picker. The host owns window resolution, registry lookup, and dismissal.
     func cancelPick(_ target: String, window: String?) -> ControlResponse
+    /// openAsk lets the host resolve a validated dialog's window and session or pane anchor.
+    func openAsk(_ ask: PendingAsk, target: String?, window: String?,
+                 placement: ControlAskPlacement, follow: Bool) -> ControlResponse
+    /// askResult reads the current or retained outcome by globally unique dialog id.
+    func askResult(_ target: String, window: String?) -> ControlResponse
+    /// cancelAsk administratively cancels a dialog without answering a named button.
+    func cancelAsk(_ target: String, window: String?) -> ControlResponse
     func clearRestoreCommands() -> ControlResponse
     /// Capture every open pane's foreground command now, the same read `applicationWillTerminate` does. The
     /// host owns the `sysctl` read, the save, and the count it reports back.
@@ -203,7 +210,7 @@ public struct ControlDispatcher {
         case .pickOpen, .pickResult, .pickCancel:
             return dispatchPickCommand(request)
         case .askOpen, .askResult, .askCancel:
-            return nil
+            return dispatchAskCommand(request)
         case .sessionHudOpen, .sessionHudUpdate, .sessionHudClose:
             return dispatchHudCommand(request)
         }

--- a/agtermCore/Sources/agtermCore/ControlProjection.swift
+++ b/agtermCore/Sources/agtermCore/ControlProjection.swift
@@ -382,6 +382,8 @@ public struct ControlTree: Codable, Sendable, Equatable {
     public let dashboardFontMode: String?
     /// The id of the picker currently awaiting a choice, or nil when no picker is open.
     public let pickPending: String?
+    /// askPending identifies the dialog awaiting an answer in this window.
+    public let askPending: String?
     /// The app serving this socket. Constant rather than live like every field above it, and present so an
     /// agent already reading the tree gets its version floor without a second round-trip; `version` answers
     /// the same question for a caller that has no tree, no window, and no JSON parser.
@@ -392,7 +394,7 @@ public struct ControlTree: Codable, Sendable, Equatable {
                 quickVisible: Bool? = nil,
                 zoomedSurface: String? = nil, dashboardMembers: [String]? = nil,
                 dashboardHighlighted: String? = nil, dashboardFontSize: Double? = nil,
-                dashboardFontMode: String? = nil, pickPending: String? = nil,
+                dashboardFontMode: String? = nil, pickPending: String? = nil, askPending: String? = nil,
                 app: AppIdentity? = nil) {
         self.workspaces = workspaces
         self.idleMs = idleMs
@@ -408,6 +410,7 @@ public struct ControlTree: Codable, Sendable, Equatable {
         self.dashboardFontSize = dashboardFontSize
         self.dashboardFontMode = dashboardFontMode
         self.pickPending = pickPending
+        self.askPending = askPending
         self.app = app
     }
 }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -288,8 +288,10 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var buttons: [ControlAskButton]?
     /// defaultButton identifies the initially highlighted ask button.
     public var defaultButton: String?
-    /// cancelButton identifies the ask button returned on user dismissal.
-    public var cancelButton: String?
+    /// style selects terminal or gui ask decoration.
+    public var style: String?
+    /// align positions the ask button block within its panel.
+    public var align: String?
     /// destructiveButton identifies the ask button styled as destructive.
     public var destructiveButton: String?
     /// Target window whose tree a session/workspace/tree/font command operates on: id / prefix / `active`
@@ -348,7 +350,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 items: [ControlPickItem]? = nil, prompt: String? = nil,
                 query: String? = nil, allowCustom: Bool? = nil,
                 buttons: [ControlAskButton]? = nil, defaultButton: String? = nil,
-                cancelButton: String? = nil, destructiveButton: String? = nil, window: String? = nil,
+                destructiveButton: String? = nil, style: String? = nil, align: String? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
                 after: String? = nil, before: String? = nil, run: String? = nil,
                 kinds: [String]? = nil, limit: Int? = nil,
@@ -390,7 +392,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.allowCustom = allowCustom
         self.buttons = buttons
         self.defaultButton = defaultButton
-        self.cancelButton = cancelButton
+        self.style = style
+        self.align = align
         self.destructiveButton = destructiveButton
         self.window = window
         self.pane = pane

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -82,6 +82,9 @@ public enum Command: String, Codable, Sendable {
     case pickOpen = "pick.open"
     case pickResult = "pick.result"
     case pickCancel = "pick.cancel"
+    case askOpen = "ask.open"
+    case askResult = "ask.result"
+    case askCancel = "ask.cancel"
     case restoreClear = "restore.clear"
     case version = "version"
     case restoreCapture = "restore.capture"
@@ -281,6 +284,14 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var query: String?
     /// Whether `pick.open` accepts the current query as a custom result.
     public var allowCustom: Bool?
+    /// buttons are the caller-ordered choices for ask.open.
+    public var buttons: [ControlAskButton]?
+    /// defaultButton identifies the initially highlighted ask button.
+    public var defaultButton: String?
+    /// cancelButton identifies the ask button returned on user dismissal.
+    public var cancelButton: String?
+    /// destructiveButton identifies the ask button styled as destructive.
+    public var destructiveButton: String?
     /// Target window whose tree a session/workspace/tree/font command operates on: id / prefix / `active`
     /// (= frontmost).
     public var window: String?
@@ -335,7 +346,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
                 follow: Bool? = nil, message: String? = nil, detail: String? = nil, spinner: String? = nil,
                 items: [ControlPickItem]? = nil, prompt: String? = nil,
-                query: String? = nil, allowCustom: Bool? = nil, window: String? = nil,
+                query: String? = nil, allowCustom: Bool? = nil,
+                buttons: [ControlAskButton]? = nil, defaultButton: String? = nil,
+                cancelButton: String? = nil, destructiveButton: String? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
                 after: String? = nil, before: String? = nil, run: String? = nil,
                 kinds: [String]? = nil, limit: Int? = nil,
@@ -375,6 +388,10 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.prompt = prompt
         self.query = query
         self.allowCustom = allowCustom
+        self.buttons = buttons
+        self.defaultButton = defaultButton
+        self.cancelButton = cancelButton
+        self.destructiveButton = destructiveButton
         self.window = window
         self.pane = pane
         self.paneID = paneID
@@ -484,6 +501,8 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var keymap: ControlKeymap?
     /// The current or terminal picker outcome for `pick.result`.
     public var pick: ControlPickResult?
+    /// ask is the current or terminal dialog outcome for ask.result.
+    public var ask: ControlAskResult?
     /// The addressed surface's cursor position for `surface.cursor`.
     public var cursor: ControlCursor?
     /// The app serving this socket, for `version`. The same value `tree` carries.
@@ -503,7 +522,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
                 sidebarWidth: Double? = nil, pane: String? = nil,
                 sync: Bool? = nil, light: String? = nil, dark: String? = nil,
                 events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil,
-                pick: ControlPickResult? = nil, cursor: ControlCursor? = nil,
+                pick: ControlPickResult? = nil, ask: ControlAskResult? = nil, cursor: ControlCursor? = nil,
                 app: AppIdentity? = nil, restore: ControlRestoreStatus? = nil,
                 zmx: ControlZmxInventory? = nil, remote: ControlRemoteTree? = nil) {
         self.restore = restore
@@ -527,6 +546,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.events = events
         self.keymap = keymap
         self.pick = pick
+        self.ask = ask
         self.cursor = cursor
         self.app = app
     }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -486,8 +486,8 @@ public struct ControlResult: Codable, Sendable, Equatable {
     /// from. Without the echo a caller cannot tell an out-of-range request from an honored one, both
     /// answering ok.
     public var sidebarWidth: Double?
-    /// The pane `session.restore` wrote, as a `StatusPane` raw value.
-    /// Present on every success, including the `--pane` and default-to-main paths.
+    /// pane is the role written by session.restore or the pane anchor resolved by ask.open.
+    /// session.restore reports it on every success, including the default-to-main path.
     public var pane: String?
     /// The light/dark syncing state for `theme.set`/`theme.list`, from the stored theme: `sync` = whether it
     /// is ghostty's dual `light:,dark:` form (the terminal tracks the macOS appearance), `light`/`dark` its

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -297,8 +297,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// Target window whose tree a session/workspace/tree/font command operates on: id / prefix / `active`
     /// (= frontmost).
     public var window: String?
-    /// New window frame width/height in points for `window.resize`.
+    /// width is window.resize width in points, or ask.open width as an integer percent (10...100).
     public var width: Int?
+    /// New window frame height in points for `window.resize`.
     public var height: Int?
     /// The sidebar divider position in points for `sidebar.width`, clamped server-side to
     /// `AppStore.sidebarWidthMin...sidebarWidthMax`. `Double`, not `width`'s `Int`: the divider drag writes a

--- a/agtermCore/Sources/agtermCore/ControlProtocolCompatibility.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocolCompatibility.swift
@@ -41,6 +41,7 @@ extension AppStore {
                             quickVisible: () -> Bool? = { nil },
                             zoomedSurface: () -> String? = { nil },
                             pickPending: () -> String? = { nil },
+                            askPending: () -> String? = { nil },
                             dashboardMembers: () -> [String]? = { nil },
                             dashboardHighlighted: () -> String? = { nil },
                             dashboardFontSize: () -> Double? = { nil },
@@ -49,6 +50,7 @@ extension AppStore {
                     splitPaneForeground: { splitForeground($0).map { .program($0) } },
                     fontSize: fontSize, splitFontSize: splitFontSize, scratchFontSize: scratchFontSize,
                     quickVisible: quickVisible, zoomedSurface: zoomedSurface, pickPending: pickPending,
+                    askPending: askPending,
                     dashboardMembers: dashboardMembers, dashboardHighlighted: dashboardHighlighted,
                     dashboardFontSize: dashboardFontSize, dashboardFontMode: dashboardFontMode, app: app)
     }

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -31,7 +31,7 @@ public struct PaletteContext: Sendable, Equatable {
     public let hasCurrentWorkspace: Bool
     public let terminalZoomActive: Bool
     public let dashboardOpen: Bool
-    /// Whether a control-API native picker is pending over the window.
+    /// pickerActive covers either a control picker or an ask dialog in the window.
     public let pickerActive: Bool
 
     /// Any cover over the deck. Behind it a keystroke or a menu pick must not mutate what it hides, so all

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -107,6 +107,11 @@ public final class PickController {
         resolveAsk(ControlAskResult(result: .cancelled))
     }
 
+    /// escapeAsk retains a user dismissal separately from administrative cancellation.
+    public func escapeAsk() {
+        resolveAsk(ControlAskResult(result: .escaped))
+    }
+
     /// askResult returns the pending or retained outcome for an exact ask id.
     public func askResult(for id: String) -> ControlAskResult? {
         if pendingAsk?.id == id {

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -41,6 +41,11 @@ public final class PickController {
     public private(set) var recentAskResults: [ResolvedAsk] = []
     /// modalPending prevents pick and ask from presenting competing modals.
     public var modalPending: Bool { pending != nil || pendingAsk != nil }
+    /// pendingModalError names the modal blocking another control action, or nil when the slot is free.
+    public var pendingModalError: String? {
+        guard modalPending else { return nil }
+        return pendingAsk == nil ? "pick pending" : "ask pending"
+    }
 
     public init() {}
 

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -19,7 +19,7 @@ public struct PendingPick: Equatable, Sendable {
     }
 }
 
-/// Owns the pending picker and the recently answered pickers for one window.
+/// PickController owns one pending pick or ask and their retained results for a window.
 @Observable
 @MainActor
 public final class PickController {
@@ -35,13 +35,19 @@ public final class PickController {
     public private(set) var pending: PendingPick?
     /// Terminal results in resolution order, oldest first, capped at `retainedResultLimit`.
     public private(set) var recentResults: [ResolvedPick] = []
+    /// pendingAsk is the dialog currently awaiting an answer.
+    public private(set) var pendingAsk: PendingAsk?
+    /// recentAskResults retains terminal ask outcomes in resolution order.
+    public private(set) var recentAskResults: [ResolvedAsk] = []
+    /// modalPending prevents pick and ask from presenting competing modals.
+    public var modalPending: Bool { pending != nil || pendingAsk != nil }
 
     public init() {}
 
-    /// Opens `pick` unless another picker is already pending. Prior results stay readable by their own id.
+    /// open reserves the modal slot unless a pick or ask already owns it.
     @discardableResult
     public func open(_ pick: PendingPick) -> Bool {
-        guard pending == nil else { return false }
+        guard !modalPending else { return false }
         pending = pick
         return true
     }
@@ -70,9 +76,42 @@ public final class PickController {
         }
         return recentResults.last { $0.id == id }?.result
     }
+
+    /// openAsk reserves the modal slot unless a pick or ask already owns it.
+    @discardableResult
+    public func openAsk(_ ask: PendingAsk) -> Bool {
+        guard !modalPending else { return false }
+        pendingAsk = ask
+        return true
+    }
+
+    /// resolveAsk retains the outcome before releasing the modal slot.
+    public func resolveAsk(_ outcome: ControlAskResult) {
+        guard let pendingAsk else { return }
+        Self.resolutionSequence += 1
+        recentAskResults.removeAll { $0.id == pendingAsk.id }
+        recentAskResults.append(ResolvedAsk(id: pendingAsk.id, result: outcome, sequence: Self.resolutionSequence))
+        if recentAskResults.count > Self.retainedResultLimit {
+            recentAskResults.removeFirst(recentAskResults.count - Self.retainedResultLimit)
+        }
+        self.pendingAsk = nil
+    }
+
+    /// cancelAsk cancels without synthesizing a named button answer.
+    public func cancelAsk() {
+        resolveAsk(ControlAskResult(result: .cancelled))
+    }
+
+    /// askResult returns the pending or retained outcome for an exact ask id.
+    public func askResult(for id: String) -> ControlAskResult? {
+        if pendingAsk?.id == id {
+            return ControlAskResult(result: .pending)
+        }
+        return recentAskResults.last { $0.id == id }?.result
+    }
 }
 
-/// Maps each window to the picker controller rendered in that window.
+/// PickRegistry maps windows to their shared pick and ask controllers.
 @MainActor
 public final class PickRegistry {
     public static let shared = PickRegistry()
@@ -83,6 +122,7 @@ public final class PickRegistry {
     private var controllers: [WindowInfo.ID: PickController] = [:]
     /// Results whose window is gone, oldest first, capped at `retainedResultLimit`.
     private var retainedResults: [(windowID: WindowInfo.ID, pick: ResolvedPick)] = []
+    private var retainedAskResults: [(windowID: WindowInfo.ID, ask: ResolvedAsk)] = []
 
     private init() {}
 
@@ -90,17 +130,23 @@ public final class PickRegistry {
         controllers[id] = controller
     }
 
-    /// Remove a window's live controller, cancelling a pending pick first and retaining its terminal
-    /// results so a control client whose next poll lands after window teardown can still read them.
+    /// unregister cancels pending modals and retains their outcomes for polls after window teardown.
     public func unregister(_ id: WindowInfo.ID) {
         guard let controller = controllers.removeValue(forKey: id) else { return }
         controller.cancel()
+        controller.cancelAsk()
         retainedResults.append(contentsOf: controller.recentResults.map { (windowID: id, pick: $0) })
-        guard retainedResults.count > Self.retainedResultLimit else { return }
-        // order by when each pick was ANSWERED before trimming: a window closing later arrives with a
-        // whole batch, and appending alone would evict a newer result an earlier-closing window held.
-        retainedResults.sort { $0.pick.sequence < $1.pick.sequence }
-        retainedResults.removeFirst(retainedResults.count - Self.retainedResultLimit)
+        if retainedResults.count > Self.retainedResultLimit {
+            // order by when each pick was ANSWERED before trimming: a window closing later arrives with a
+            // whole batch, and appending alone would evict a newer result an earlier-closing window held.
+            retainedResults.sort { $0.pick.sequence < $1.pick.sequence }
+            retainedResults.removeFirst(retainedResults.count - Self.retainedResultLimit)
+        }
+        retainedAskResults.append(contentsOf: controller.recentAskResults.map { (windowID: id, ask: $0) })
+        if retainedAskResults.count > Self.retainedResultLimit {
+            retainedAskResults.sort { $0.ask.sequence < $1.ask.sequence }
+            retainedAskResults.removeFirst(retainedAskResults.count - Self.retainedResultLimit)
+        }
     }
 
     public func controller(for id: WindowInfo.ID?) -> PickController? {
@@ -119,5 +165,17 @@ public final class PickRegistry {
     public func retainedResult(for pickID: String) -> (windowID: WindowInfo.ID, result: ControlPickResult)? {
         retainedResults.last { $0.pick.id == pickID }
             .map { (windowID: $0.windowID, result: $0.pick.result) }
+    }
+
+    /// liveAsk finds a pending or answered ask still owned by a registered window.
+    public func liveAsk(for askID: String) -> (windowID: WindowInfo.ID, controller: PickController)? {
+        controllers.first { $0.value.askResult(for: askID) != nil }
+            .map { (windowID: $0.key, controller: $0.value) }
+    }
+
+    /// retainedAskResult finds an ask whose owning window has unregistered.
+    public func retainedAskResult(for askID: String) -> (windowID: WindowInfo.ID, result: ControlAskResult)? {
+        retainedAskResults.last { $0.ask.id == askID }
+            .map { (windowID: $0.windowID, result: $0.ask.result) }
     }
 }

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -349,6 +349,13 @@ public final class Session: Identifiable {
         return nil
     }
 
+    /// askTargetPane resolves a captured identity after pane roles change.
+    public func askTargetPane(for identity: UUID) -> OverlayPane? {
+        if paneIdentity == identity { return .left }
+        if splitPaneIdentity == identity { return .right }
+        return nil
+    }
+
     /// Path to the rendered-message file the HUD helper re-reads each tick (`AGTERM_HUD_FILE`); `discardHudBody`
     /// deletes it. Per SESSION, so an update rewrites the path the running helper already opened.
     /// `@ObservationIgnored`: the surface factory, the HUD commands and `overlay close` read it, and none of

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -343,14 +343,11 @@ public final class Session: Identifiable {
 
     /// The target identity's current role, nil for session-wide placement or a destroyed target.
     public var hudTargetPane: OverlayPane? {
-        guard let hudPaneIdentity else { return nil }
-        if paneIdentity == hudPaneIdentity { return .left }
-        if splitPaneIdentity == hudPaneIdentity { return .right }
-        return nil
+        hudPaneIdentity.flatMap(paneRole(forIdentity:))
     }
 
-    /// askTargetPane resolves a captured identity after pane roles change.
-    public func askTargetPane(for identity: UUID) -> OverlayPane? {
+    /// paneRole resolves a captured pane identity to its current role, following a promotion.
+    public func paneRole(forIdentity identity: UUID) -> OverlayPane? {
         if paneIdentity == identity { return .left }
         if splitPaneIdentity == identity { return .right }
         return nil

--- a/agtermCore/Sources/agtermctlKit/AskCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/AskCommands.swift
@@ -1,0 +1,120 @@
+import ArgumentParser
+import Foundation
+import agtermCore
+
+struct Ask: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Open, poll, or cancel a themed question dialog.",
+        discussion: "Use ask open TITLE when the title is 'open', 'result', or 'cancel'.",
+        subcommands: [Open.self, Result.self, Cancel.self],
+        defaultSubcommand: Open.self
+    )
+
+    struct Open: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Ask a question and wait for its button answer.")
+        @Argument(help: "Dialog title.") var title: String
+        @Option(name: .long, help: "Optional message below the title.") var message: String?
+        @Option(name: .customLong("button"), help: "Button ID=LABEL, or one token for both. Repeat for each button (max 6).")
+        var buttons: [String] = []
+        @Option(name: .customLong("hotkey"), help: "Button ID=LETTER. Repeat for more buttons.")
+        var hotkeys: [String] = []
+        @Option(name: .customLong("default"), help: "ID of the initially highlighted button.") var defaultButton: String?
+        @Option(name: .customLong("cancel"), help: "Button ID returned on Esc or Command-W.") var cancelButton: String?
+        @Option(name: .customLong("destructive"), help: "ID of the destructive button.") var destructiveButton: String?
+        @Option(name: .long, help: "Visible session id, prefix, or 'active'. Omit to center in the window.") var target: String?
+        @Option(name: .long, help: "Anchor to the session's left or right pane.") var pane: String?
+        @Option(name: .customLong("pane-id"), help: "Stable pane token; takes precedence over --pane.") var paneID: String?
+        @Flag(name: .long, help: "Raise the owning window.") var follow = false
+        @Flag(name: .long, help: "Print the dialog id and return without waiting.") var noBlock = false
+        @OptionGroup var options: ClientOptions
+
+        func validate() throws {
+            guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ValidationError("ask.open requires a title")
+            }
+            if pane != nil || paneID != nil, target == nil {
+                throw ValidationError("--pane requires a session")
+            }
+            if let pane, OverlayPane(controlName: pane) == nil {
+                throw ValidationError("--pane must be left or right")
+            }
+            _ = try parsedButtons()
+        }
+
+        func makeRequest() throws -> ControlRequest {
+            let args = ControlArgs(follow: follow ? true : nil, message: message, buttons: try parsedButtons(),
+                                   defaultButton: defaultButton, cancelButton: cancelButton, destructiveButton: destructiveButton,
+                                   pane: pane, paneID: paneID, title: title)
+            return ControlRequest(cmd: .askOpen, target: target, args: options.withWindow(args))
+        }
+
+        private func parsedButtons() throws -> [ControlAskButton] {
+            guard !buttons.isEmpty else { throw ValidationError("ask requires at least one --button") }
+            var choices = buttons.map { token -> ControlAskButton in
+                guard let equals = token.firstIndex(of: "=") else { return ControlAskButton(id: token, label: token) }
+                return ControlAskButton(id: String(token[..<equals]), label: String(token[token.index(after: equals)...]))
+            }
+            var assigned = Set<String>()
+            for token in hotkeys {
+                guard let equals = token.firstIndex(of: "=") else {
+                    throw ValidationError("--hotkey requires ID=LETTER")
+                }
+                let id = String(token[..<equals])
+                guard let index = choices.firstIndex(where: { $0.id == id }) else {
+                    throw ValidationError("unknown hotkey button: \(id)")
+                }
+                guard assigned.insert(id).inserted else {
+                    throw ValidationError("hotkey already assigned to button: \(id)")
+                }
+                choices[index] = ControlAskButton(id: id, label: choices[index].label,
+                                                 hotkey: String(token[token.index(after: equals)...]))
+            }
+            return choices
+        }
+
+        func run() throws {
+            try execute(send: SocketClient(path: options.socketPath()).send,
+                        sleep: Thread.sleep(forTimeInterval:), output: { print($0) })
+        }
+
+        func execute(send: @escaping (ControlRequest) throws -> ControlResponse,
+                     sleep: @escaping (TimeInterval) -> Void, output: @escaping (String) -> Void,
+                     errorOutput: @escaping (String) -> Void = ModalCommandRunner.writeStandardError) throws {
+            let runner = ModalCommandRunner(family: .ask, json: options.json, send: send, sleep: sleep,
+                                            output: output, errorOutput: errorOutput)
+            try runner.open(makeRequest(), noBlock: noBlock)
+        }
+    }
+
+    struct Result: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Print a dialog's current or terminal result as JSON.")
+        @Argument(help: "Exact dialog id returned by ask open.") var id: String
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .askResult, target: id, args: options.withWindow())
+        }
+
+        func run() throws {
+            try execute(send: SocketClient(path: options.socketPath()).send, output: { print($0) })
+        }
+
+        func execute(send: @escaping (ControlRequest) throws -> ControlResponse,
+                     output: @escaping (String) -> Void,
+                     errorOutput: @escaping (String) -> Void = ModalCommandRunner.writeStandardError) throws {
+            let runner = ModalCommandRunner(family: .ask, json: options.json, send: send, sleep: { _ in },
+                                            output: output, errorOutput: errorOutput)
+            try runner.read(makeRequest())
+        }
+    }
+
+    struct Cancel: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Cancel a dialog without answering a button.")
+        @Argument(help: "Exact dialog id returned by ask open.") var id: String
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .askCancel, target: id, args: options.withWindow())
+        }
+    }
+}

--- a/agtermCore/Sources/agtermctlKit/AskCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/AskCommands.swift
@@ -21,6 +21,8 @@ struct Ask: ParsableCommand {
         @Option(name: .customLong("default"), help: "ID of the initially highlighted button.") var defaultButton: String?
         @Option(name: .long, help: "Dialog style: terminal or gui.") var style = "terminal"
         @Option(name: .long, help: "Button block alignment: left, center, or right.") var align = "right"
+        @Option(name: .long, parsing: .unconditional, help: "Panel width as an integer percent of the anchor (10...100); omit for automatic sizing.")
+        var width: String?
         @Option(name: .customLong("destructive"), help: "ID of the destructive button.") var destructiveButton: String?
         @Option(name: .long, help: "Visible session id, prefix, or 'active'. Omit to center over the terminal area.") var target: String?
         @Option(name: .long, help: "Anchor to the session's left or right pane.") var pane: String?
@@ -41,14 +43,23 @@ struct Ask: ParsableCommand {
             }
             guard ControlAskStyle(rawValue: style) != nil else { throw ValidationError("unknown style") }
             guard ControlAskAlignment(rawValue: align) != nil else { throw ValidationError("unknown align") }
+            _ = try parsedWidth()
             _ = try parsedButtons()
         }
 
         func makeRequest() throws -> ControlRequest {
             let args = ControlArgs(follow: follow ? true : nil, message: message, buttons: try parsedButtons(),
                                    defaultButton: defaultButton, destructiveButton: destructiveButton, style: style, align: align,
-                                   pane: pane, paneID: paneID, title: title)
+                                   pane: pane, paneID: paneID, title: title, width: try parsedWidth())
             return ControlRequest(cmd: .askOpen, target: target, args: options.withWindow(args))
+        }
+
+        private func parsedWidth() throws -> Int? {
+            guard let width else { return nil }
+            guard let value = Int(width), (10...100).contains(value) else {
+                throw ValidationError("width must be 10 to 100")
+            }
+            return value
         }
 
         private func parsedButtons() throws -> [ControlAskButton] {

--- a/agtermCore/Sources/agtermctlKit/AskCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/AskCommands.swift
@@ -19,9 +19,10 @@ struct Ask: ParsableCommand {
         @Option(name: .customLong("hotkey"), help: "Button ID=LETTER. Repeat for more buttons.")
         var hotkeys: [String] = []
         @Option(name: .customLong("default"), help: "ID of the initially highlighted button.") var defaultButton: String?
-        @Option(name: .customLong("cancel"), help: "Button ID returned on Esc or Command-W.") var cancelButton: String?
+        @Option(name: .long, help: "Dialog style: terminal or gui.") var style = "terminal"
+        @Option(name: .long, help: "Button block alignment: left, center, or right.") var align = "right"
         @Option(name: .customLong("destructive"), help: "ID of the destructive button.") var destructiveButton: String?
-        @Option(name: .long, help: "Visible session id, prefix, or 'active'. Omit to center in the window.") var target: String?
+        @Option(name: .long, help: "Visible session id, prefix, or 'active'. Omit to center over the terminal area.") var target: String?
         @Option(name: .long, help: "Anchor to the session's left or right pane.") var pane: String?
         @Option(name: .customLong("pane-id"), help: "Stable pane token; takes precedence over --pane.") var paneID: String?
         @Flag(name: .long, help: "Raise the owning window.") var follow = false
@@ -38,12 +39,14 @@ struct Ask: ParsableCommand {
             if let pane, OverlayPane(controlName: pane) == nil {
                 throw ValidationError("--pane must be left or right")
             }
+            guard ControlAskStyle(rawValue: style) != nil else { throw ValidationError("unknown style") }
+            guard ControlAskAlignment(rawValue: align) != nil else { throw ValidationError("unknown align") }
             _ = try parsedButtons()
         }
 
         func makeRequest() throws -> ControlRequest {
             let args = ControlArgs(follow: follow ? true : nil, message: message, buttons: try parsedButtons(),
-                                   defaultButton: defaultButton, cancelButton: cancelButton, destructiveButton: destructiveButton,
+                                   defaultButton: defaultButton, destructiveButton: destructiveButton, style: style, align: align,
                                    pane: pane, paneID: paneID, title: title)
             return ControlRequest(cmd: .askOpen, target: target, args: options.withWindow(args))
         }

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -89,7 +89,7 @@ public struct Agtermctl: ParsableCommand {
         commandName: "agtermctl",
         abstract: "Drive agterm over its control socket.",
         subcommands: [Tree.self, Events.self, Workspace.self, Session.self, Surface.self, Dashboard.self, Window.self, Quick.self,
-                      Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Pick.self, Restore.self,
+                      Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Pick.self, Ask.self, Restore.self,
                       Zmx.self, Version.self]
     )
 

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -421,7 +421,7 @@ struct Pick: ParsableCommand {
                 send: client.send,
                 sleep: Thread.sleep(forTimeInterval:),
                 output: { print($0) },
-                errorOutput: Self.writeStandardError
+                errorOutput: ModalCommandRunner.writeStandardError
             )
         }
 
@@ -429,82 +429,14 @@ struct Pick: ParsableCommand {
         /// real delays or process fds.
         func execute(
             input: Data,
-            send: (ControlRequest) throws -> ControlResponse,
-            sleep: (TimeInterval) -> Void,
-            output: (String) -> Void,
-            errorOutput: (String) -> Void = Self.writeStandardError
+            send: @escaping (ControlRequest) throws -> ControlResponse,
+            sleep: @escaping (TimeInterval) -> Void,
+            output: @escaping (String) -> Void,
+            errorOutput: @escaping (String) -> Void = ModalCommandRunner.writeStandardError
         ) throws {
-            let opened = try send(makeRequest(input: input))
-            guard opened.ok else {
-                Self.writeResponse(opened, json: options.json, output: output, errorOutput: errorOutput)
-                throw ExitCode.failure
-            }
-            guard let pickID = opened.result?.id else {
-                errorOutput("error: pick.open result missing id")
-                throw ExitCode.failure
-            }
-            if noBlock {
-                output(try SocketClient.formatPickID(pickID))
-                return
-            }
-
-            var pendingPolls = 0
-            while true {
-                let response: ControlResponse
-                do {
-                    response = try send(ControlRequest(cmd: .pickResult, target: pickID))
-                } catch {
-                    // a transport failure mid-wait leaves the picker up with nobody waiting; every request
-                    // opens its own connection, so the cancel can still land though this poll could not.
-                    abandon(pickID, send: send)
-                    throw error
-                }
-                // the poll carries no window selector, so a pending picker is always found by id and answers
-                // ok; a not-ok response means the server no longer holds one, with nothing left to dismiss.
-                guard response.ok else {
-                    Self.writeResponse(response, json: options.json, output: output, errorOutput: errorOutput)
-                    throw ExitCode.failure
-                }
-                guard let result = response.result?.pick else {
-                    errorOutput("error: pick.result missing result")
-                    abandon(pickID, send: send)
-                    throw ExitCode.failure
-                }
-                if result.result == .pending {
-                    pendingPolls += 1
-                    sleep(SocketClient.pickPollDelay(afterPendingPoll: pendingPolls))
-                    continue
-                }
-
-                output(try SocketClient.formatPickResult(result))
-                let code = SocketClient.pickExitCode(for: result.result)
-                if code.rawValue != 0 { throw code }
-                return
-            }
-        }
-
-        /// Dismiss a picker this command opened but can no longer wait on: else the window holds one whose
-        /// owner is gone and refuses the next `pick.open`. Best effort — the poll already failed anyway.
-        private func abandon(_ pickID: String, send: (ControlRequest) throws -> ControlResponse) {
-            _ = try? send(ControlRequest(cmd: .pickCancel, target: pickID))
-        }
-
-        private static func writeResponse(
-            _ response: ControlResponse,
-            json: Bool,
-            output: (String) -> Void,
-            errorOutput: (String) -> Void
-        ) {
-            let line = SocketClient.formatResponse(response, json: json)
-            if json {
-                output(line)
-            } else {
-                errorOutput(line)
-            }
-        }
-
-        private static func writeStandardError(_ line: String) {
-            FileHandle.standardError.write(Data("\(line)\n".utf8))
+            let runner = ModalCommandRunner(family: .pick, json: options.json, send: send, sleep: sleep,
+                                            output: output, errorOutput: errorOutput)
+            try runner.open(makeRequest(input: input), noBlock: noBlock)
         }
     }
 
@@ -523,38 +455,20 @@ struct Pick: ParsableCommand {
             try execute(
                 send: SocketClient(path: options.socketPath()).send,
                 output: { print($0) },
-                errorOutput: Self.writeStandardError
+                errorOutput: ModalCommandRunner.writeStandardError
             )
         }
 
         /// One-shot read with injectable transport/stdout/stderr, so every wire outcome and exit mapping is
         /// covered without replacing process file descriptors.
         func execute(
-            send: (ControlRequest) throws -> ControlResponse,
-            output: (String) -> Void,
-            errorOutput: (String) -> Void = Self.writeStandardError
+            send: @escaping (ControlRequest) throws -> ControlResponse,
+            output: @escaping (String) -> Void,
+            errorOutput: @escaping (String) -> Void = ModalCommandRunner.writeStandardError
         ) throws {
-            let response = try send(makeRequest())
-            guard response.ok else {
-                let line = SocketClient.formatResponse(response, json: options.json)
-                if options.json {
-                    output(line)
-                } else {
-                    errorOutput(line)
-                }
-                throw ExitCode.failure
-            }
-            guard let result = response.result?.pick else {
-                errorOutput("error: pick.result missing result")
-                throw ExitCode.failure
-            }
-            output(try SocketClient.formatPickResult(result))
-            let code = SocketClient.pickExitCode(for: result.result)
-            if code.rawValue != 0 { throw code }
-        }
-
-        private static func writeStandardError(_ line: String) {
-            FileHandle.standardError.write(Data("\(line)\n".utf8))
+            let runner = ModalCommandRunner(family: .pick, json: options.json, send: send, sleep: { _ in },
+                                            output: output, errorOutput: errorOutput)
+            try runner.read(makeRequest())
         }
     }
 
@@ -566,6 +480,107 @@ struct Pick: ParsableCommand {
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .pickCancel, target: id, args: options.withWindow())
         }
+    }
+}
+
+struct ModalCommandRunner {
+    enum Family: String {
+        case pick, ask
+
+        var resultCommand: Command { self == .pick ? .pickResult : .askResult }
+        var cancelCommand: Command { self == .pick ? .pickCancel : .askCancel }
+    }
+
+    let family: Family
+    let json: Bool
+    let send: (ControlRequest) throws -> ControlResponse
+    let sleep: (TimeInterval) -> Void
+    let output: (String) -> Void
+    let errorOutput: (String) -> Void
+
+    func open(_ request: ControlRequest, noBlock: Bool) throws {
+        let opened = try send(request)
+        try requireSuccess(opened)
+        guard let id = opened.result?.id else {
+            errorOutput("error: \(family.rawValue).open result missing id")
+            throw ExitCode.failure
+        }
+        if noBlock {
+            output(try SocketClient.formatPickID(id))
+            return
+        }
+        var pendingPolls = 0
+        while true {
+            let response: ControlResponse
+            do {
+                response = try send(ControlRequest(cmd: family.resultCommand, target: id))
+            } catch {
+                // each request opens its own connection, so cancellation can still reach the host after a failed poll.
+                abandon(id)
+                throw error
+            }
+            // the id-only poll cannot resolve to another window; failure means the host no longer holds the dialog.
+            try requireSuccess(response)
+            guard let result = try reply(from: response) else {
+                errorOutput("error: \(family.rawValue).result missing result")
+                abandon(id)
+                throw ExitCode.failure
+            }
+            if result.pending {
+                pendingPolls += 1
+                sleep(SocketClient.pickPollDelay(afterPendingPoll: pendingPolls))
+                continue
+            }
+            output(result.line)
+            if result.code.rawValue != 0 { throw result.code }
+            return
+        }
+    }
+
+    func read(_ request: ControlRequest) throws {
+        let response = try send(request)
+        try requireSuccess(response)
+        guard let result = try reply(from: response) else {
+            errorOutput("error: \(family.rawValue).result missing result")
+            throw ExitCode.failure
+        }
+        output(result.line)
+        if result.code.rawValue != 0 { throw result.code }
+    }
+
+    private struct Reply {
+        let pending: Bool
+        let line: String
+        let code: ExitCode
+    }
+
+    private func reply(from response: ControlResponse) throws -> Reply? {
+        switch family {
+        case .pick:
+            guard let result = response.result?.pick else { return nil }
+            return Reply(pending: result.result == .pending, line: try SocketClient.formatPickResult(result),
+                         code: SocketClient.pickExitCode(for: result.result))
+        case .ask:
+            guard let result = response.result?.ask else { return nil }
+            return Reply(pending: result.result == .pending, line: try SocketClient.formatAskResult(result),
+                         code: SocketClient.askExitCode(for: result.result))
+        }
+    }
+
+    private func requireSuccess(_ response: ControlResponse) throws {
+        guard !response.ok else { return }
+        let line = SocketClient.formatResponse(response, json: json)
+        if json { output(line) } else { errorOutput(line) }
+        throw ExitCode.failure
+    }
+
+    // otherwise an abandoned caller leaves the shared modal slot occupied; cancellation stays best effort.
+    private func abandon(_ id: String) {
+        _ = try? send(ControlRequest(cmd: family.cancelCommand, target: id))
+    }
+
+    static func writeStandardError(_ line: String) {
+        FileHandle.standardError.write(Data("\(line)\n".utf8))
     }
 }
 

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -140,7 +140,7 @@ struct SocketClient {
         print(formatResponse(response, json: json, echoID: echoID))
     }
 
-    /// Render the immediate `pick.open` response as the documented `{"id":"…"}` JSON object.
+    /// Render a pick or ask open response as the documented `{"id":"…"}` JSON object.
     static func formatPickID(_ id: String) throws -> String {
         String(decoding: try JSONEncoder().encode(ControlResult(id: id)), as: UTF8.self)
     }
@@ -148,6 +148,20 @@ struct SocketClient {
     /// Render the nested `pick.result` payload itself, rather than the enclosing control response.
     static func formatPickResult(_ result: ControlPickResult) throws -> String {
         String(decoding: try JSONEncoder().encode(result), as: UTF8.self)
+    }
+
+    /// formatAskResult emits the nested ask payload without the control response wrapper.
+    static func formatAskResult(_ result: ControlAskResult) throws -> String {
+        String(decoding: try JSONEncoder().encode(result), as: UTF8.self)
+    }
+
+    /// askExitCode matches pick's success, pending, and cancellation process statuses.
+    static func askExitCode(for outcome: ControlAskOutcome) -> ExitCode {
+        switch outcome {
+        case .answered: .success
+        case .pending: .failure
+        case .cancelled: ExitCode(rawValue: 2)
+        }
     }
 
     /// Map every picker state to a process status. `pending` is non-terminal in the blocking loop; if

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -155,10 +155,11 @@ struct SocketClient {
         String(decoding: try JSONEncoder().encode(result), as: UTF8.self)
     }
 
-    /// askExitCode matches pick's success, pending, and cancellation process statuses.
+    /// askExitCode distinguishes user dismissal from administrative cancellation.
     static func askExitCode(for outcome: ControlAskOutcome) -> ExitCode {
         switch outcome {
         case .answered: .success
+        case .escaped: ExitCode(rawValue: 3)
         case .pending: .failure
         case .cancelled: ExitCode(rawValue: 2)
         }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTreeProjectionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTreeProjectionTests.swift
@@ -168,6 +168,14 @@ struct AppStoreTreeProjectionTests {
         #expect(store.controlTree(pickPending: { nil }).pickPending == nil)
     }
 
+    @Test(arguments: [Optional("ask-42"), nil])
+    func controlTreeReportsAskPendingThroughBothBuilders(pending: String?) {
+        let store = makeStore()
+        #expect(store.controlTree(paneForeground: { _ in nil }, askPending: { pending }).askPending == pending)
+        #expect(store.controlTree(askPending: { pending }).askPending == pending)
+        #expect(store.controlTree().askPending == nil)
+    }
+
     @Test func controlTreeReportsDashboardFieldsFromClosures() {
         let store = makeStore()
         let bare = store.controlTree()

--- a/agtermCore/Tests/agtermCoreTests/AskTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AskTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct AskTests {
+    @Test func openCarriesDialogFieldsAndReservesModalSlot() {
+        let controller = PickController()
+        let anchor = AskAnchor(sessionID: UUID(), pane: .right, paneIdentity: UUID())
+        let ask = PendingAsk(
+            id: "anchored", title: "Save changes?", message: "Changes have not been saved.",
+            buttons: buttons(count: 3), defaultID: "button-0", cancelID: "button-1",
+            destructiveID: "button-2", anchor: anchor
+        )
+
+        #expect(!controller.modalPending)
+        #expect(controller.openAsk(ask))
+        #expect(controller.modalPending)
+        #expect(controller.pendingAsk == ask)
+        #expect(controller.pending == nil)
+        #expect(controller.askResult(for: ask.id) == ControlAskResult(result: .pending))
+        #expect(controller.askResult(for: "unknown") == nil)
+        #expect(controller.result(for: ask.id) == nil)
+    }
+
+    @Test func resolveRetainsTheAnswerAndReleasesModalSlot() {
+        let controller = PickController()
+        let ask = makeAsk(id: "answered")
+        let answer = ControlAskResult(result: .answered, id: "button-0", label: "Button 0", index: 0)
+        #expect(controller.openAsk(ask))
+
+        controller.resolveAsk(answer)
+
+        #expect(!controller.modalPending)
+        #expect(controller.pendingAsk == nil)
+        #expect(controller.recentAskResults.map(\.id) == [ask.id])
+        #expect(controller.recentAskResults.map(\.result) == [answer])
+        #expect(controller.askResult(for: ask.id) == answer)
+        controller.cancelAsk()
+        #expect(controller.askResult(for: ask.id) == answer)
+    }
+
+    @Test func cancelDoesNotAnswerTheNamedCancelButton() {
+        let controller = PickController()
+        let ask = PendingAsk(id: "cancelled", title: "Continue?", buttons: buttons(count: 1),
+                             cancelID: "button-0")
+        #expect(controller.openAsk(ask))
+
+        controller.cancelAsk()
+        controller.cancelAsk()
+
+        #expect(controller.pendingAsk == nil)
+        #expect(!controller.modalPending)
+        #expect(controller.recentAskResults.count == 1)
+        #expect(controller.askResult(for: ask.id) == ControlAskResult(result: .cancelled))
+    }
+
+    @Test func openRejectsWhileAnotherAskIsPending() {
+        let controller = PickController()
+        let first = makeAsk(id: "first")
+        #expect(controller.openAsk(first))
+        #expect(!controller.openAsk(makeAsk(id: "second")))
+        #expect(controller.pendingAsk == first)
+        #expect(controller.askResult(for: "second") == nil)
+    }
+
+    @Test func askRejectsWhilePickOwnsModalSlot() {
+        let controller = PickController()
+        let pick = PendingPick(id: "pick", items: [ControlPickItem(id: "one", label: "One")])
+        #expect(controller.open(pick))
+        #expect(controller.modalPending)
+        #expect(!controller.openAsk(makeAsk(id: "ask")))
+        #expect(controller.pending == pick)
+        #expect(controller.pendingAsk == nil)
+
+        controller.cancelAsk()
+        #expect(controller.pending == pick)
+        controller.cancel()
+        #expect(controller.openAsk(makeAsk(id: "ask")))
+    }
+
+    @Test func nextAskKeepsPriorAnswerReadableByID() {
+        let controller = PickController()
+        #expect(controller.openAsk(makeAsk(id: "first")))
+        controller.cancelAsk()
+        #expect(controller.openAsk(makeAsk(id: "second")))
+
+        #expect(controller.askResult(for: "first") == ControlAskResult(result: .cancelled))
+        #expect(controller.askResult(for: "second") == ControlAskResult(result: .pending))
+    }
+
+    @Test func retainedAnswersDropOldestAtControllerLimit() {
+        let controller = PickController()
+        for index in 0..<(PickController.retainedResultLimit + 2) {
+            #expect(controller.openAsk(makeAsk(id: "ask-\(index)")))
+            controller.cancelAsk()
+        }
+
+        #expect(controller.recentAskResults.count == PickController.retainedResultLimit)
+        #expect(controller.askResult(for: "ask-0") == nil)
+        #expect(controller.askResult(for: "ask-1") == nil)
+        #expect(controller.askResult(for: "ask-2") == ControlAskResult(result: .cancelled))
+        #expect(controller.recentAskResults.last?.id == "ask-9")
+    }
+
+    @Test func registryFindsPendingAndAnsweredAsksByID() {
+        let registry = PickRegistry.shared
+        let windowID = UUID()
+        let controller = PickController()
+        let ask = makeAsk(id: UUID().uuidString)
+        registry.register(windowID, controller: controller)
+        defer { registry.unregister(windowID) }
+        #expect(controller.openAsk(ask))
+
+        #expect(registry.liveAsk(for: ask.id)?.windowID == windowID)
+        #expect(registry.liveAsk(for: ask.id)?.controller === controller)
+        #expect(registry.livePick(for: ask.id) == nil)
+        #expect(registry.retainedAskResult(for: ask.id) == nil)
+        #expect(registry.liveAsk(for: UUID().uuidString) == nil)
+        controller.cancelAsk()
+        #expect(registry.liveAsk(for: ask.id)?.controller === controller)
+    }
+
+    @Test func unregisterCancelsAskAndRetainsBothFamilies() {
+        let registry = PickRegistry.shared
+        let windowID = UUID()
+        let controller = PickController()
+        let pickID = UUID().uuidString
+        let askID = UUID().uuidString
+        registry.register(windowID, controller: controller)
+        #expect(controller.open(PendingPick(id: pickID, items: [ControlPickItem(id: "one", label: "One")])))
+        controller.cancel()
+        #expect(controller.openAsk(PendingAsk(id: askID, title: "Continue?", buttons: buttons(count: 1),
+                                             cancelID: "button-0")))
+
+        registry.unregister(windowID)
+        registry.unregister(windowID)
+
+        #expect(registry.controller(for: windowID) == nil)
+        #expect(registry.liveAsk(for: askID) == nil)
+        #expect(!controller.modalPending)
+        #expect(registry.retainedAskResult(for: askID)?.windowID == windowID)
+        #expect(registry.retainedAskResult(for: askID)?.result == ControlAskResult(result: .cancelled))
+        #expect(registry.retainedResult(for: pickID)?.result == ControlPickResult(result: .cancelled))
+        #expect(registry.retainedAskResult(for: UUID().uuidString) == nil)
+    }
+
+    @Test func registryTrimsOldestResolutionEvenWhenItsWindowClosesLast() {
+        let registry = PickRegistry.shared
+        let marker = UUID().uuidString
+        let olderWindows = (0..<PickRegistry.retainedResultLimit).map { index -> UUID in
+            let windowID = UUID()
+            let controller = PickController()
+            registry.register(windowID, controller: controller)
+            #expect(controller.openAsk(makeAsk(id: "\(marker)-\(index)")))
+            controller.cancelAsk()
+            return windowID
+        }
+        let newestWindow = UUID()
+        let newest = PickController()
+        let answer = ControlAskResult(result: .answered, id: "button-0", label: "Button 0", index: 0)
+        registry.register(newestWindow, controller: newest)
+        #expect(newest.openAsk(makeAsk(id: "\(marker)-newest")))
+        newest.resolveAsk(answer)
+
+        registry.unregister(newestWindow)
+        for windowID in olderWindows { registry.unregister(windowID) }
+
+        #expect(registry.retainedAskResult(for: "\(marker)-0") == nil)
+        #expect(registry.retainedAskResult(for: "\(marker)-1") != nil)
+        #expect(registry.retainedAskResult(for: "\(marker)-newest")?.result == answer)
+    }
+
+    @Test(arguments: [1, 6])
+    func navigationWithoutDefaultLeavesReturnInert(count: Int) {
+        let navigation = AskNavigation(buttons: buttons(count: count))
+        #expect(navigation.highlighted == nil)
+        #expect(navigation.activate() == nil)
+    }
+
+    @Test(arguments: [(1, "button-0", 0), (6, "button-4", 4)])
+    func navigationSeedsHighlightFromDefault(count: Int, defaultID: String, expectedIndex: Int) {
+        let navigation = AskNavigation(buttons: buttons(count: count), defaultID: defaultID)
+        #expect(navigation.highlighted == expectedIndex)
+        #expect(navigation.activate() == expectedIndex)
+    }
+
+    @Test(arguments: [(1, [0, 0]), (6, [0, 1, 2, 3, 4, 5, 0])])
+    func forwardNavigationEntersFirstAndWraps(count: Int, expectedIndices: [Int]) {
+        var navigation = AskNavigation(buttons: buttons(count: count))
+        for expected in expectedIndices {
+            navigation.moveForward()
+            #expect(navigation.highlighted == expected)
+            #expect(navigation.activate() == expected)
+        }
+    }
+
+    @Test(arguments: [(1, [0, 0]), (6, [5, 4, 3, 2, 1, 0, 5])])
+    func backwardNavigationEntersLastAndWraps(count: Int, expectedIndices: [Int]) {
+        var navigation = AskNavigation(buttons: buttons(count: count))
+        for expected in expectedIndices {
+            navigation.moveBackward()
+            #expect(navigation.highlighted == expected)
+            #expect(navigation.activate() == expected)
+        }
+    }
+
+    @Test func navigationMovesAwayFromDefault() {
+        var navigation = AskNavigation(buttons: buttons(count: 6), defaultID: "button-2")
+        navigation.moveForward()
+        #expect(navigation.activate() == 3)
+        navigation.moveBackward()
+        #expect(navigation.activate() == 2)
+    }
+
+    @Test(arguments: [("y", 0), ("Y", 0), ("n", 1), ("N", 1)])
+    func hotkeysAreCaseInsensitiveAndNeedNoHighlight(letter: String, expectedIndex: Int) {
+        let navigation = AskNavigation(buttons: [
+            ControlAskButton(id: "yes", label: "Yes", hotkey: "Y"),
+            ControlAskButton(id: "no", label: "No", hotkey: "n"),
+        ])
+        #expect(navigation.hotkey(letter) == expectedIndex)
+        #expect(navigation.highlighted == nil)
+    }
+
+    @Test func undeclaredHotkeyDoesNotMatchALabelOrChangeSelection() {
+        let navigation = AskNavigation(buttons: [
+            ControlAskButton(id: "yes", label: "Yes"),
+            ControlAskButton(id: "no", label: "No", hotkey: "n"),
+        ], defaultID: "no")
+        #expect(navigation.hotkey("y") == nil)
+        #expect(navigation.hotkey("") == nil)
+        #expect(navigation.activate() == 1)
+    }
+
+    @Test func destructiveChoiceRemainsReachableAfterDeliberateNavigation() {
+        let ask = PendingAsk(id: "delete", title: "Delete?", buttons: [
+            ControlAskButton(id: "cancel", label: "Cancel"),
+            ControlAskButton(id: "delete", label: "Delete", hotkey: "d"),
+        ], cancelID: "cancel", destructiveID: "delete")
+        var navigation = AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID)
+        #expect(navigation.activate() == nil)
+        navigation.moveBackward()
+        #expect(navigation.activate() == 1)
+        #expect(navigation.hotkey("d") == 1)
+    }
+
+    @Test func emptyNavigationRemainsInert() {
+        var navigation = AskNavigation(buttons: [])
+        navigation.moveForward()
+        navigation.moveBackward()
+        #expect(navigation.activate() == nil)
+        #expect(navigation.hotkey("a") == nil)
+    }
+
+    private func makeAsk(id: String) -> PendingAsk {
+        PendingAsk(id: id, title: "Choose", buttons: buttons(count: 1))
+    }
+
+    private func buttons(count: Int) -> [ControlAskButton] {
+        (0..<count).map { ControlAskButton(id: "button-\($0)", label: "Button \($0)") }
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/AskTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AskTests.swift
@@ -4,12 +4,23 @@ import Testing
 
 @MainActor
 struct AskTests {
+    @Test func escapeRetainsAButtonlessResultAndReleasesTheSlot() {
+        let controller = PickController()
+        #expect(controller.openAsk(makeAsk(id: "escaped")))
+        controller.escapeAsk()
+        controller.cancelAsk()
+        #expect(!controller.modalPending)
+        #expect(controller.askResult(for: "escaped") == ControlAskResult(result: .escaped))
+        #expect(controller.recentAskResults.count == 1)
+        #expect(controller.openAsk(makeAsk(id: "next")))
+    }
+
     @Test func openCarriesDialogFieldsAndReservesModalSlot() {
         let controller = PickController()
         let anchor = AskAnchor(sessionID: UUID(), pane: .right, paneIdentity: UUID())
         let ask = PendingAsk(
             id: "anchored", title: "Save changes?", message: "Changes have not been saved.",
-            buttons: buttons(count: 3), defaultID: "button-0", cancelID: "button-1",
+            buttons: buttons(count: 3), defaultID: "button-0",
             destructiveID: "button-2", anchor: anchor
         )
 
@@ -40,10 +51,9 @@ struct AskTests {
         #expect(controller.askResult(for: ask.id) == answer)
     }
 
-    @Test func cancelDoesNotAnswerTheNamedCancelButton() {
+    @Test func cancelRetainsAdministrativeOutcome() {
         let controller = PickController()
-        let ask = PendingAsk(id: "cancelled", title: "Continue?", buttons: buttons(count: 1),
-                             cancelID: "button-0")
+        let ask = PendingAsk(id: "cancelled", title: "Continue?", buttons: buttons(count: 1))
         #expect(controller.openAsk(ask))
 
         controller.cancelAsk()
@@ -130,8 +140,7 @@ struct AskTests {
         registry.register(windowID, controller: controller)
         #expect(controller.open(PendingPick(id: pickID, items: [ControlPickItem(id: "one", label: "One")])))
         controller.cancel()
-        #expect(controller.openAsk(PendingAsk(id: askID, title: "Continue?", buttons: buttons(count: 1),
-                                             cancelID: "button-0")))
+        #expect(controller.openAsk(PendingAsk(id: askID, title: "Continue?", buttons: buttons(count: 1))))
 
         registry.unregister(windowID)
         registry.unregister(windowID)
@@ -172,10 +181,10 @@ struct AskTests {
     }
 
     @Test(arguments: [1, 6])
-    func navigationWithoutDefaultLeavesReturnInert(count: Int) {
-        let navigation = AskNavigation(buttons: buttons(count: count))
-        #expect(navigation.highlighted == nil)
-        #expect(navigation.activate() == nil)
+    func navigationWithoutDefaultAnswersFirstNonDestructiveButton(count: Int) {
+        let navigation = AskNavigation(buttons: buttons(count: count), destructiveID: "button-0")
+        #expect(navigation.highlighted == (count == 1 ? 0 : 1))
+        #expect(navigation.activate() == (count == 1 ? 0 : 1))
     }
 
     @Test(arguments: [(1, "button-0", 0), (6, "button-4", 4)])
@@ -185,8 +194,8 @@ struct AskTests {
         #expect(navigation.activate() == expectedIndex)
     }
 
-    @Test(arguments: [(1, [0, 0]), (6, [0, 1, 2, 3, 4, 5, 0])])
-    func forwardNavigationEntersFirstAndWraps(count: Int, expectedIndices: [Int]) {
+    @Test(arguments: [(1, [0, 0]), (6, [1, 2, 3, 4, 5, 0, 1])])
+    func forwardNavigationAdvancesAndWraps(count: Int, expectedIndices: [Int]) {
         var navigation = AskNavigation(buttons: buttons(count: count))
         for expected in expectedIndices {
             navigation.moveForward()
@@ -196,7 +205,7 @@ struct AskTests {
     }
 
     @Test(arguments: [(1, [0, 0]), (6, [5, 4, 3, 2, 1, 0, 5])])
-    func backwardNavigationEntersLastAndWraps(count: Int, expectedIndices: [Int]) {
+    func backwardNavigationWrapsToLast(count: Int, expectedIndices: [Int]) {
         var navigation = AskNavigation(buttons: buttons(count: count))
         for expected in expectedIndices {
             navigation.moveBackward()
@@ -214,13 +223,13 @@ struct AskTests {
     }
 
     @Test(arguments: [("y", 0), ("Y", 0), ("n", 1), ("N", 1)])
-    func hotkeysAreCaseInsensitiveAndNeedNoHighlight(letter: String, expectedIndex: Int) {
+    func hotkeysAreCaseInsensitiveAndIndependentOfHighlight(letter: String, expectedIndex: Int) {
         let navigation = AskNavigation(buttons: [
             ControlAskButton(id: "yes", label: "Yes", hotkey: "Y"),
             ControlAskButton(id: "no", label: "No", hotkey: "n"),
         ])
         #expect(navigation.hotkey(letter) == expectedIndex)
-        #expect(navigation.highlighted == nil)
+        #expect(navigation.highlighted == 0)
     }
 
     @Test func undeclaredHotkeyDoesNotMatchALabelOrChangeSelection() {
@@ -237,9 +246,9 @@ struct AskTests {
         let ask = PendingAsk(id: "delete", title: "Delete?", buttons: [
             ControlAskButton(id: "cancel", label: "Cancel"),
             ControlAskButton(id: "delete", label: "Delete", hotkey: "d"),
-        ], cancelID: "cancel", destructiveID: "delete")
-        var navigation = AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID)
-        #expect(navigation.activate() == nil)
+        ], destructiveID: "delete")
+        var navigation = AskNavigation(buttons: ask.buttons, defaultID: ask.defaultID, destructiveID: ask.destructiveID)
+        #expect(navigation.activate() == 0)
         navigation.moveBackward()
         #expect(navigation.activate() == 1)
         #expect(navigation.hotkey("d") == 1)

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct ControlDispatcherAskTests {
+    @Test(arguments: [
+        (ControlArgs(), "ask.open requires a title"),
+        (ControlArgs(title: ""), "ask.open requires a title"),
+        (ControlArgs(title: "  "), "ask.open requires a title"),
+        (ControlArgs(title: "\t\n"), "ask.open requires a title"),
+        (ControlArgs(title: "Choose"), "ask.open requires buttons"),
+        (ControlArgs(buttons: [], title: "Choose"), "ask.open requires at least one button"),
+        (ControlArgs(buttons: (0..<7).map { ControlAskButton(id: "\($0)", label: "Button \($0)") }, title: "Choose"),
+         "too many buttons (max 6)"),
+        (ControlArgs(buttons: [ControlAskButton(id: "empty", label: "")], title: "Choose"),
+         "ask button label must not be empty"),
+        (ControlArgs(buttons: [ControlAskButton(id: "same", label: "First"), ControlAskButton(id: "same", label: "Second")],
+                     title: "Choose"), "ask button ids must be unique"),
+        (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], title: "Bad\ntitle"),
+         "ask text must not contain control characters"),
+        (ControlArgs(message: "Bad\tmessage", buttons: [ControlAskButton(id: "yes", label: "Yes")], title: "Choose"),
+         "ask text must not contain control characters"),
+        (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Bad\u{7f}label")], title: "Choose"),
+         "ask text must not contain control characters"),
+        (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], defaultButton: "missing", title: "Choose"),
+         "unknown default button: missing"),
+        (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], cancelButton: "missing", title: "Choose"),
+         "unknown cancel button: missing"),
+        (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], destructiveButton: "missing", title: "Choose"),
+         "unknown destructive button: missing"),
+        (ControlArgs(buttons: [ControlAskButton(id: "delete", label: "Delete")],
+                     defaultButton: "delete", destructiveButton: "delete", title: "Choose"),
+         "default button must not be destructive"),
+        (ControlArgs(buttons: [ControlAskButton(id: "delete", label: "Delete")],
+                     cancelButton: "delete", destructiveButton: "delete", title: "Choose"),
+         "cancel button must not be destructive"),
+        (ControlArgs(buttons: [ControlAskButton(id: "one", label: "One", hotkey: "y"),
+                              ControlAskButton(id: "two", label: "Two", hotkey: "Y")], title: "Choose"),
+         "ask button hotkeys must be unique"),
+    ])
+    func invalidOpenDoesNotReachHost(args: ControlArgs, error: String) async {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: args))
+
+        #expect(response == ControlResponse(ok: false, error: error))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func openWithoutArgsDoesNotReachHost() async {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen))
+
+        #expect(response == ControlResponse(ok: false, error: "ask.open requires a title"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test(arguments: ["", "yes", "1", "!", " ", "\r", "\t", "\u{1b}", "→", "é", "a\u{301}", "🦊"])
+    func hotkeysMustBeSingleASCIILetters(hotkey: String) async {
+        let actions = MockControlActions()
+        let args = ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes", hotkey: hotkey)], title: "Choose")
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: args))
+
+        #expect(response == ControlResponse(ok: false, error: "ask button hotkey must be one ASCII letter"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test(arguments: [(Optional("right"), Optional<String>.none), (nil, "pane-id"), (nil, "")])
+    func paneSelectorsRequireSession(pane: String?, paneID: String?) async {
+        let actions = MockControlActions()
+        let args = ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")],
+                               pane: pane, paneID: paneID, title: "Choose")
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: args))
+
+        #expect(response == ControlResponse(ok: false, error: "--pane requires a session"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test(arguments: ["", "scratch", "overlay", "unknown", "RIGHT"])
+    func invalidPaneDoesNotReachHost(pane: String) async {
+        let actions = MockControlActions()
+        let args = ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], pane: pane, title: "Choose")
+        let response = await ControlDispatcher(actions: actions).dispatch(
+            ControlRequest(cmd: .askOpen, target: "active", args: args)
+        )
+
+        #expect(response == ControlResponse(ok: false, error: "--pane must be left or right"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test(arguments: [(Command.askResult, "ask.result requires an ask id"), (.askCancel, "ask.cancel requires an ask id")])
+    func lookupsRequireAnAskID(command: Command, error: String) async {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: command))
+
+        #expect(response == ControlResponse(ok: false, error: error))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func validOpenPreservesFieldsAndNormalizesHotkeys() async throws {
+        let actions = MockControlActions()
+        let expected = ControlResponse(ok: true, result: ControlResult(id: "ask-id", pane: "right"))
+        actions.nextAskOpenResponse = expected
+        let args = ControlArgs(
+            follow: true, message: "Changes are unsaved.",
+            buttons: [
+                ControlAskButton(id: "Save", label: "Save", hotkey: "S"),
+                ControlAskButton(id: "cancel", label: "Not now", hotkey: "n"),
+                ControlAskButton(id: "delete", label: "Delete"),
+            ],
+            defaultButton: "Save", cancelButton: "cancel", destructiveButton: "delete",
+            window: "window-id", pane: "right", paneID: "pane-id", title: "  Choose  "
+        )
+        let response = await ControlDispatcher(actions: actions).dispatch(
+            ControlRequest(cmd: .askOpen, target: "session-id", args: args)
+        )
+
+        #expect(response == expected)
+        #expect(actions.calls.count == 1)
+        guard case let .askOpen(ask, target, window, placement, follow) = try #require(actions.calls.first) else {
+            Issue.record("expected ask.open host call")
+            return
+        }
+        #expect(UUID(uuidString: ask.id) != nil)
+        #expect(ask.title == "  Choose  ")
+        #expect(ask.message == "Changes are unsaved.")
+        #expect(ask.buttons == [
+            ControlAskButton(id: "Save", label: "Save", hotkey: "s"),
+            ControlAskButton(id: "cancel", label: "Not now", hotkey: "n"),
+            ControlAskButton(id: "delete", label: "Delete"),
+        ])
+        #expect(ask.defaultID == "Save")
+        #expect(ask.cancelID == "cancel")
+        #expect(ask.destructiveID == "delete")
+        #expect(ask.anchor == nil)
+        #expect(target == "session-id")
+        #expect(window == "window-id")
+        #expect(placement == ControlAskPlacement(pane: .right, paneID: "pane-id"))
+        #expect(follow)
+    }
+
+    @Test(arguments: [1, 6])
+    func validButtonCountsLeaveOmittedOptionsUnset(count: Int) async throws {
+        let actions = MockControlActions()
+        let buttons = (0..<count).map { ControlAskButton(id: "\($0)", label: "Button \($0)") }
+        let response = await ControlDispatcher(actions: actions).dispatch(
+            ControlRequest(cmd: .askOpen, args: ControlArgs(buttons: buttons, title: "Choose"))
+        )
+
+        #expect(response == ControlResponse(ok: true))
+        guard case let .askOpen(ask, target, window, placement, follow) = try #require(actions.calls.first) else {
+            Issue.record("expected ask.open host call")
+            return
+        }
+        #expect(ask.buttons == buttons)
+        #expect(ask.message == nil)
+        #expect(ask.defaultID == nil)
+        #expect(ask.cancelID == nil)
+        #expect(ask.destructiveID == nil)
+        #expect(ask.anchor == nil)
+        #expect(target == nil)
+        #expect(window == nil)
+        #expect(placement == ControlAskPlacement())
+        #expect(!follow)
+    }
+
+    @Test(arguments: [("left", OverlayPane.left), ("primary", .left), ("top", .left),
+                      ("right", .right), ("split", .right), ("bottom", .right)])
+    func paneAliasesReachHostAsCanonicalRoles(raw: String, expected: OverlayPane) async throws {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
+            cmd: .askOpen, target: "active",
+            args: ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], pane: raw, title: "Choose")
+        ))
+
+        #expect(response == ControlResponse(ok: true))
+        guard case let .askOpen(_, target, _, placement, _) = try #require(actions.calls.first) else {
+            Issue.record("expected ask.open host call")
+            return
+        }
+        #expect(target == "active")
+        #expect(placement.pane == expected)
+    }
+
+    @Test func paneIDPassesThroughWithoutAPaneFallback() async throws {
+        let actions = MockControlActions()
+        _ = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
+            cmd: .askOpen, target: "session-id",
+            args: ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], paneID: "identity", title: "Choose")
+        ))
+        guard case let .askOpen(_, target, _, placement, _) = try #require(actions.calls.first) else {
+            Issue.record("expected ask.open host call")
+            return
+        }
+        #expect(target == "session-id")
+        #expect(placement == ControlAskPlacement(paneID: "identity"))
+    }
+
+    @Test func defaultAndCancelMayNameTheSameSafeButton() async {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
+            cmd: .askOpen,
+            args: ControlArgs(buttons: [ControlAskButton(id: "cancel", label: "Cancel")],
+                              defaultButton: "cancel", cancelButton: "cancel", title: "Choose")
+        ))
+        #expect(response == ControlResponse(ok: true))
+        #expect(actions.calls.count == 1)
+    }
+
+    @Test func repeatedOpenGeneratesDistinctRequestIDs() async throws {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let request = ControlRequest(cmd: .askOpen,
+                                     args: ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], title: "Choose"))
+        _ = await dispatcher.dispatch(request)
+        _ = await dispatcher.dispatch(request)
+        #expect(actions.calls.count == 2)
+        guard case let .askOpen(first, _, _, _, _) = try #require(actions.calls.first),
+              case let .askOpen(second, _, _, _, _) = try #require(actions.calls.last) else {
+            Issue.record("expected two ask.open host calls")
+            return
+        }
+        #expect(first.id != second.id)
+    }
+
+    @Test func openReturnsHostFailureUnchanged() async {
+        let actions = MockControlActions()
+        let expected = ControlResponse(ok: false, error: "ask already pending")
+        actions.nextAskOpenResponse = expected
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
+            cmd: .askOpen, args: ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], title: "Choose")
+        ))
+        #expect(response == expected)
+        #expect(actions.calls.count == 1)
+    }
+
+    @Test(arguments: [
+        ControlResponse(ok: true, result: ControlResult(ask: ControlAskResult(result: .pending))),
+        ControlResponse(ok: true, result: ControlResult(ask: ControlAskResult(result: .answered, id: "ok", label: "OK", index: 0))),
+        ControlResponse(ok: true, result: ControlResult(ask: ControlAskResult(result: .cancelled))),
+        ControlResponse(ok: false, error: "unknown ask: ask-id"),
+    ])
+    func resultRoutesIDAndPreservesHostResponse(expected: ControlResponse) async {
+        let actions = MockControlActions()
+        actions.nextAskResultResponse = expected
+        let response = await ControlDispatcher(actions: actions).dispatch(
+            ControlRequest(cmd: .askResult, target: "ask-id", args: ControlArgs(window: "window-id"))
+        )
+        #expect(response == expected)
+        #expect(actions.calls == [.askResult(target: "ask-id", window: "window-id")])
+    }
+
+    @Test(arguments: [ControlResponse(ok: true), ControlResponse(ok: false, error: "unknown ask: ask-id")])
+    func cancelRoutesIDAndPreservesHostResponse(expected: ControlResponse) async {
+        let actions = MockControlActions()
+        actions.nextAskCancelResponse = expected
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askCancel, target: "ask-id"))
+        #expect(response == expected)
+        #expect(actions.calls == [.askCancel(target: "ask-id", window: nil)])
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift
@@ -4,6 +4,31 @@ import Testing
 
 @MainActor
 struct ControlDispatcherAskTests {
+    @Test(arguments: ["", "GUI", "other"])
+    func invalidStyleOrAlignmentNeverReachesTheHost(value: String) async {
+        for args in [ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], style: value, title: "Choose"),
+                     ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], align: value, title: "Choose")] {
+            let actions = MockControlActions()
+            let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: args))
+            #expect(response == ControlResponse(ok: false, error: args.style == nil ? "unknown align" : "unknown style"))
+            #expect(actions.calls.isEmpty)
+        }
+    }
+
+    @Test(arguments: ControlAskStyle.allCases, ControlAskAlignment.allCases)
+    func decorationReachesHost(style: ControlAskStyle, align: ControlAskAlignment) async throws {
+        let actions = MockControlActions()
+        _ = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: ControlArgs(
+            buttons: [ControlAskButton(id: "ok", label: "OK")], style: style.rawValue, align: align.rawValue, title: "Choose"
+        )))
+        guard case let .askOpen(ask, _, _, _, _) = try #require(actions.calls.first) else {
+            Issue.record("expected ask.open")
+            return
+        }
+        #expect(ask.style == style)
+        #expect(ask.align == align)
+    }
+
     @Test(arguments: [
         (ControlArgs(), "ask.open requires a title"),
         (ControlArgs(title: ""), "ask.open requires a title"),
@@ -25,16 +50,11 @@ struct ControlDispatcherAskTests {
          "ask text must not contain control characters"),
         (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], defaultButton: "missing", title: "Choose"),
          "unknown default button: missing"),
-        (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], cancelButton: "missing", title: "Choose"),
-         "unknown cancel button: missing"),
         (ControlArgs(buttons: [ControlAskButton(id: "yes", label: "Yes")], destructiveButton: "missing", title: "Choose"),
          "unknown destructive button: missing"),
         (ControlArgs(buttons: [ControlAskButton(id: "delete", label: "Delete")],
                      defaultButton: "delete", destructiveButton: "delete", title: "Choose"),
          "default button must not be destructive"),
-        (ControlArgs(buttons: [ControlAskButton(id: "delete", label: "Delete")],
-                     cancelButton: "delete", destructiveButton: "delete", title: "Choose"),
-         "cancel button must not be destructive"),
         (ControlArgs(buttons: [ControlAskButton(id: "one", label: "One", hotkey: "y"),
                               ControlAskButton(id: "two", label: "Two", hotkey: "Y")], title: "Choose"),
          "ask button hotkeys must be unique"),
@@ -108,7 +128,7 @@ struct ControlDispatcherAskTests {
                 ControlAskButton(id: "cancel", label: "Not now", hotkey: "n"),
                 ControlAskButton(id: "delete", label: "Delete"),
             ],
-            defaultButton: "Save", cancelButton: "cancel", destructiveButton: "delete",
+            defaultButton: "Save", destructiveButton: "delete", style: "gui", align: "center",
             window: "window-id", pane: "right", paneID: "pane-id", title: "  Choose  "
         )
         let response = await ControlDispatcher(actions: actions).dispatch(
@@ -130,7 +150,8 @@ struct ControlDispatcherAskTests {
             ControlAskButton(id: "delete", label: "Delete"),
         ])
         #expect(ask.defaultID == "Save")
-        #expect(ask.cancelID == "cancel")
+        #expect(ask.style == .gui)
+        #expect(ask.align == .center)
         #expect(ask.destructiveID == "delete")
         #expect(ask.anchor == nil)
         #expect(target == "session-id")
@@ -155,7 +176,8 @@ struct ControlDispatcherAskTests {
         #expect(ask.buttons == buttons)
         #expect(ask.message == nil)
         #expect(ask.defaultID == nil)
-        #expect(ask.cancelID == nil)
+        #expect(ask.style == .terminal)
+        #expect(ask.align == .right)
         #expect(ask.destructiveID == nil)
         #expect(ask.anchor == nil)
         #expect(target == nil)
@@ -196,12 +218,12 @@ struct ControlDispatcherAskTests {
         #expect(placement == ControlAskPlacement(paneID: "identity"))
     }
 
-    @Test func defaultAndCancelMayNameTheSameSafeButton() async {
+    @Test func cancelLabelIsAnOrdinaryDefaultButton() async {
         let actions = MockControlActions()
         let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
             cmd: .askOpen,
             args: ControlArgs(buttons: [ControlAskButton(id: "cancel", label: "Cancel")],
-                              defaultButton: "cancel", cancelButton: "cancel", title: "Choose")
+                              defaultButton: "cancel", title: "Choose")
         ))
         #expect(response == ControlResponse(ok: true))
         #expect(actions.calls.count == 1)

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift
@@ -4,6 +4,29 @@ import Testing
 
 @MainActor
 struct ControlDispatcherAskTests {
+    @Test(arguments: [-1, 0, 9, 101, Int.max])
+    func invalidWidthNeverReachesHost(width: Int) async {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: ControlArgs(
+            buttons: [ControlAskButton(id: "ok", label: "OK")], title: "Choose", width: width
+        )))
+        #expect(response == ControlResponse(ok: false, error: "width must be 10 to 100"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test(arguments: [10, 50, 100])
+    func fixedWidthReachesHost(width: Int) async throws {
+        let actions = MockControlActions()
+        _ = await ControlDispatcher(actions: actions).dispatch(ControlRequest(cmd: .askOpen, args: ControlArgs(
+            buttons: [ControlAskButton(id: "ok", label: "OK")], title: "Choose", width: width
+        )))
+        guard case let .askOpen(ask, _, _, _, _) = try #require(actions.calls.first) else {
+            Issue.record("expected ask.open")
+            return
+        }
+        #expect(ask.width == width)
+    }
+
     @Test(arguments: ["", "GUI", "other"])
     func invalidStyleOrAlignmentNeverReachesTheHost(value: String) async {
         for args in [ControlArgs(buttons: [ControlAskButton(id: "ok", label: "OK")], style: value, title: "Choose"),
@@ -178,6 +201,7 @@ struct ControlDispatcherAskTests {
         #expect(ask.defaultID == nil)
         #expect(ask.style == .terminal)
         #expect(ask.align == .right)
+        #expect(ask.width == nil)
         #expect(ask.destructiveID == nil)
         #expect(ask.anchor == nil)
         #expect(target == nil)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -170,6 +170,19 @@ struct ControlProtocolTests {
         #expect(try JSONDecoder().decode(ControlTree.self, from: Data(json.utf8)).pickPending == nil)
     }
 
+    @Test func controlTreeAskPendingRoundTripsAndOmitsWhenNil() throws {
+        let populated = ControlTree(workspaces: [], askPending: "ask-id")
+        let data = try JSONEncoder().encode(populated)
+        let fields = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(fields["askPending"] as? String == "ask-id")
+        #expect(try JSONDecoder().decode(ControlTree.self, from: data) == populated)
+
+        let absentData = try JSONEncoder().encode(ControlTree(workspaces: []))
+        let absent = try #require(try JSONSerialization.jsonObject(with: absentData) as? [String: Any])
+        #expect(absent["askPending"] == nil)
+        #expect(try JSONDecoder().decode(ControlTree.self, from: absentData).askPending == nil)
+    }
+
     @Test func controlArgsDistinguishesEmptyItemsFromAbsentItems() throws {
         let empty = String(decoding: try JSONEncoder().encode(ControlArgs(items: [])), as: UTF8.self)
         let absent = String(decoding: try JSONEncoder().encode(ControlArgs(allowCustom: true)), as: UTF8.self)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -29,7 +29,7 @@ struct ControlProtocolTests {
                     ControlAskButton(id: "cancel", label: "Not now"),
                     ControlAskButton(id: "discard", label: "Discard", hotkey: "d"),
                 ],
-                defaultButton: "save", cancelButton: "cancel", destructiveButton: "discard",
+                defaultButton: "save", destructiveButton: "discard", style: "gui", align: "left",
                 window: "window-id", pane: "right", paneID: "pane-id", title: "Unsaved changes"
             )
         )
@@ -41,7 +41,7 @@ struct ControlProtocolTests {
                 {"id":"cancel","label":"Not now"},
                 {"id":"discard","label":"Discard","hotkey":"d"}
             ],
-            "defaultButton":"save","cancelButton":"cancel","destructiveButton":"discard",
+            "defaultButton":"save","destructiveButton":"discard","style":"gui","align":"left",
             "window":"window-id","pane":"right","paneID":"pane-id"
         }}
         """
@@ -66,6 +66,7 @@ struct ControlProtocolTests {
         (ControlAskResult(result: .answered, id: "save", label: "Save", index: 0),
          #"{"ok":true,"result":{"ask":{"result":"answered","id":"save","label":"Save","index":0}}}"#),
         (ControlAskResult(result: .cancelled), #"{"ok":true,"result":{"ask":{"result":"cancelled"}}}"#),
+        (ControlAskResult(result: .escaped), #"{"ok":true,"result":{"ask":{"result":"escaped"}}}"#),
     ])
     func askResultRoundTripsEveryOutcomeShape(ask: ControlAskResult, json: String) throws {
         let response = ControlResponse(ok: true, result: ControlResult(ask: ask))

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -19,6 +19,97 @@ struct ControlProtocolTests {
         #expect(try roundTrip(request) == request)
     }
 
+    @Test func askOpenRoundTripsEveryArgument() throws {
+        let request = ControlRequest(
+            cmd: .askOpen, target: "session-id",
+            args: ControlArgs(
+                follow: true, message: "Keep the current changes?",
+                buttons: [
+                    ControlAskButton(id: "save", label: "Save", hotkey: "s"),
+                    ControlAskButton(id: "cancel", label: "Not now"),
+                    ControlAskButton(id: "discard", label: "Discard", hotkey: "d"),
+                ],
+                defaultButton: "save", cancelButton: "cancel", destructiveButton: "discard",
+                window: "window-id", pane: "right", paneID: "pane-id", title: "Unsaved changes"
+            )
+        )
+        let json = """
+        {"cmd":"ask.open","target":"session-id","args":{
+            "title":"Unsaved changes","message":"Keep the current changes?","follow":true,
+            "buttons":[
+                {"id":"save","label":"Save","hotkey":"s"},
+                {"id":"cancel","label":"Not now"},
+                {"id":"discard","label":"Discard","hotkey":"d"}
+            ],
+            "defaultButton":"save","cancelButton":"cancel","destructiveButton":"discard",
+            "window":"window-id","pane":"right","paneID":"pane-id"
+        }}
+        """
+
+        #expect(try JSONDecoder().decode(ControlRequest.self, from: Data(json.utf8)) == request)
+        #expect(try roundTrip(request) == request)
+    }
+
+    @Test(arguments: [(Command.askResult, "ask.result"), (.askCancel, "ask.cancel")])
+    func askLookupCommandsRoundTrip(command: Command, wireName: String) throws {
+        let request = ControlRequest(cmd: command, target: "ask-id", args: ControlArgs(window: "window-id"))
+        let json = """
+        {"cmd":"\(wireName)","target":"ask-id","args":{"window":"window-id"}}
+        """
+
+        #expect(try JSONDecoder().decode(ControlRequest.self, from: Data(json.utf8)) == request)
+        #expect(try roundTrip(request) == request)
+    }
+
+    @Test(arguments: [
+        (ControlAskResult(result: .pending), #"{"ok":true,"result":{"ask":{"result":"pending"}}}"#),
+        (ControlAskResult(result: .answered, id: "save", label: "Save", index: 0),
+         #"{"ok":true,"result":{"ask":{"result":"answered","id":"save","label":"Save","index":0}}}"#),
+        (ControlAskResult(result: .cancelled), #"{"ok":true,"result":{"ask":{"result":"cancelled"}}}"#),
+    ])
+    func askResultRoundTripsEveryOutcomeShape(ask: ControlAskResult, json: String) throws {
+        let response = ControlResponse(ok: true, result: ControlResult(ask: ask))
+        let encoded = try #require(try JSONSerialization.jsonObject(with: JSONEncoder().encode(response)) as? NSDictionary)
+        let expected = try #require(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? NSDictionary)
+
+        #expect(encoded == expected)
+        #expect(try roundTrip(response) == response)
+    }
+
+    @Test func controlResultAskOmitsWhenNil() throws {
+        let result = ControlResult(id: "ask-id")
+        let data = try JSONEncoder().encode(result)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: String])
+
+        #expect(json == ["id": "ask-id"])
+        #expect(try JSONDecoder().decode(ControlResult.self, from: data).ask == nil)
+    }
+
+    @Test func askOpenResponseRoundTripsPaneReadBack() throws {
+        let response = ControlResponse(ok: true, result: ControlResult(id: "ask-id", pane: "right"))
+        #expect(try roundTrip(response) == response)
+    }
+
+    @Test func askOptionalFieldsRemainAbsent() throws {
+        let request = ControlRequest(cmd: .askOpen, args: ControlArgs(
+            buttons: [ControlAskButton(id: "ok", label: "OK")], title: "Ready"
+        ))
+        let data = try JSONEncoder().encode(request)
+        let encoded = try #require(try JSONSerialization.jsonObject(with: data) as? NSDictionary)
+        let json = #"{"cmd":"ask.open","args":{"title":"Ready","buttons":[{"id":"ok","label":"OK"}]}}"#
+        let expected = try #require(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? NSDictionary)
+
+        #expect(encoded == expected)
+        #expect(try roundTrip(request) == request)
+        #expect(try JSONDecoder().decode(ControlArgs.self, from: Data("{}".utf8)) == ControlArgs())
+    }
+
+    @Test(arguments: [(ControlArgs(), "{}"), (ControlArgs(buttons: []), #"{"buttons":[]}"#)])
+    func controlArgsDistinguishesEmptyButtonsFromAbsentButtons(args: ControlArgs, json: String) throws {
+        #expect(String(decoding: try JSONEncoder().encode(args), as: UTF8.self) == json)
+        #expect(try JSONDecoder().decode(ControlArgs.self, from: Data(json.utf8)) == args)
+    }
+
     @Test func pickCommandsRoundTrip() throws {
         let items = [
             ControlPickItem(id: "first", label: "First choice", subtitle: "recommended"),

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import agtermCore
 
 struct ControlProtocolTests {
+    @Test func askWidthRoundTripsAndNullMeansAuto() throws {
+        let request = ControlRequest(cmd: .askOpen, args: ControlArgs(width: 50))
+        #expect(try roundTrip(request) == request)
+        let data = Data(#"{"cmd":"ask.open","args":{"width":null}}"#.utf8)
+        #expect(try JSONDecoder().decode(ControlRequest.self, from: data).args?.width == nil)
+    }
+
     // round-trip a request through JSON and back, asserting equality with the original.
     private func roundTrip(_ request: ControlRequest) throws -> ControlRequest {
         let data = try JSONEncoder().encode(request)

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -97,6 +97,9 @@ final class MockControlActions: ControlActions {
         case pickOpen(PendingPick, window: String?, follow: Bool)
         case pickResult(target: String, window: String?)
         case pickCancel(target: String, window: String?)
+        case askOpen(PendingAsk, target: String?, window: String?, placement: ControlAskPlacement, follow: Bool)
+        case askResult(target: String, window: String?)
+        case askCancel(target: String, window: String?)
         case restoreClear
         case restoreCapture
     }
@@ -172,6 +175,9 @@ final class MockControlActions: ControlActions {
     var nextPickOpenResponse = ControlResponse(ok: true)
     var nextPickResultResponse = ControlResponse(ok: true)
     var nextPickCancelResponse = ControlResponse(ok: true)
+    var nextAskOpenResponse = ControlResponse(ok: true)
+    var nextAskResultResponse = ControlResponse(ok: true)
+    var nextAskCancelResponse = ControlResponse(ok: true)
     var nextRestoreClearResponse = ControlResponse(ok: true)
     var nextRestoreCaptureResponse = ControlResponse(ok: true)
     var nextSessionRestoreResponse = ControlResponse(ok: true)
@@ -648,6 +654,22 @@ final class MockControlActions: ControlActions {
     func cancelPick(_ target: String, window: String?) -> ControlResponse {
         calls.append(.pickCancel(target: target, window: window))
         return nextPickCancelResponse
+    }
+
+    func openAsk(_ ask: PendingAsk, target: String?, window: String?,
+                 placement: ControlAskPlacement, follow: Bool) -> ControlResponse {
+        calls.append(.askOpen(ask, target: target, window: window, placement: placement, follow: follow))
+        return nextAskOpenResponse
+    }
+
+    func askResult(_ target: String, window: String?) -> ControlResponse {
+        calls.append(.askResult(target: target, window: window))
+        return nextAskResultResponse
+    }
+
+    func cancelAsk(_ target: String, window: String?) -> ControlResponse {
+        calls.append(.askCancel(target: target, window: window))
+        return nextAskCancelResponse
     }
 
     func clearRestoreCommands() -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -234,6 +234,24 @@ struct PaletteCatalogTests {
         }
     }
 
+    @MainActor @Test func aPendingAskUsesTheSharedModalPredicate() {
+        let controller = PickController()
+        #expect(controller.openAsk(PendingAsk(id: "ask", title: "Continue?",
+                                             buttons: [ControlAskButton(id: "yes", label: "Yes")])))
+        let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
+                                     sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                     canStepWorkspaces: true,
+                                     activeSessionHasSplit: true, hasPendingClose: true,
+                                     hasRecentClosed: true, hasActiveSession: true,
+                                     hasCurrentWorkspace: true, pickerActive: controller.modalPending)
+        #expect(context.modalActive)
+        for command in PaletteCommand.allCases {
+            #expect(command.isEnabled(in: context) == Self.coverProof.contains(command), "\(command)")
+        }
+        controller.cancelAsk()
+        #expect(!PaletteContext(pickerActive: controller.modalPending).modalActive)
+    }
+
     // Navigate ▸ Dashboard is the open grid's own escape hatch, so its item alone survives that one cover.
     @Test func theOpenDashboardSparesItsOwnToggle() {
         let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -21,6 +21,20 @@ struct PickTests {
         #expect(controller.result(for: pick.id) == outcome)
     }
 
+    @Test func pendingModalErrorNamesTheCurrentOwner() {
+        let controller = PickController()
+        #expect(controller.pendingModalError == nil)
+        #expect(controller.open(makePick(id: "pick")))
+        #expect(controller.pendingModalError == "pick pending")
+        controller.cancel()
+        #expect(controller.pendingModalError == nil)
+        #expect(controller.openAsk(PendingAsk(id: "ask", title: "Continue?",
+                                             buttons: [ControlAskButton(id: "yes", label: "Yes")])))
+        #expect(controller.pendingModalError == "ask pending")
+        controller.cancelAsk()
+        #expect(controller.pendingModalError == nil)
+    }
+
     @Test func cancelRetainsCancelledResult() {
         let controller = PickController()
         let pick = makePick(id: "pick-cancel")

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -43,6 +43,68 @@ struct PickTests {
         #expect(controller.result(for: "second") == nil)
     }
 
+    @Test func pickRejectsWhileAskOwnsModalSlot() {
+        let controller = PickController()
+        let ask = PendingAsk(id: "ask", title: "Continue?", buttons: [ControlAskButton(id: "yes", label: "Yes")])
+        #expect(controller.openAsk(ask))
+        #expect(!controller.open(makePick(id: "pick")))
+        #expect(controller.pending == nil)
+        #expect(controller.pendingAsk == ask)
+
+        controller.cancel()
+        #expect(controller.pendingAsk == ask)
+        controller.cancelAsk()
+        #expect(controller.open(makePick(id: "pick")))
+        #expect(controller.askResult(for: ask.id) == ControlAskResult(result: .cancelled))
+    }
+
+    @Test func alternatingFamiliesPreservePriorResultsAndShareResolutionOrder() throws {
+        let firstWindow = PickController()
+        let secondWindow = PickController()
+        #expect(firstWindow.open(makePick(id: "first-pick")))
+        firstWindow.cancel()
+        let firstSequence = try #require(firstWindow.recentResults.last?.sequence)
+        #expect(secondWindow.openAsk(PendingAsk(id: "ask", title: "Continue?",
+                                               buttons: [ControlAskButton(id: "yes", label: "Yes")])))
+        secondWindow.cancelAsk()
+        let askSequence = try #require(secondWindow.recentAskResults.last?.sequence)
+        #expect(secondWindow.open(makePick(id: "last-pick")))
+        secondWindow.cancel()
+        let lastSequence = try #require(secondWindow.recentResults.last?.sequence)
+
+        #expect(firstSequence < askSequence)
+        #expect(askSequence < lastSequence)
+        #expect(firstWindow.result(for: "first-pick") == ControlPickResult(result: .cancelled))
+        #expect(secondWindow.askResult(for: "ask") == ControlAskResult(result: .cancelled))
+        #expect(secondWindow.result(for: "last-pick") == ControlPickResult(result: .cancelled))
+        #expect(!firstWindow.modalPending)
+        #expect(!secondWindow.modalPending)
+    }
+
+    @Test func eachFamilyRetainsItsAnswersWhileTheOtherTurnsOver() {
+        let controller = PickController()
+        #expect(controller.open(makePick(id: "first-pick")))
+        controller.cancel()
+        let total = PickController.retainedResultLimit + 1
+        for index in 0..<total {
+            #expect(controller.openAsk(PendingAsk(id: "ask-\(index)", title: "Continue?",
+                                                  buttons: [ControlAskButton(id: "yes", label: "Yes")])))
+            controller.cancelAsk()
+        }
+        #expect(controller.result(for: "first-pick") == ControlPickResult(result: .cancelled))
+        #expect(controller.askResult(for: "ask-0") == nil)
+
+        for index in 0..<total {
+            #expect(controller.open(makePick(id: "pick-\(index)")))
+            controller.cancel()
+        }
+        #expect(controller.result(for: "first-pick") == nil)
+        #expect(controller.result(for: "pick-0") == nil)
+        #expect(controller.askResult(for: "ask-1") == ControlAskResult(result: .cancelled))
+        #expect(controller.recentAskResults.count == PickController.retainedResultLimit)
+        #expect(controller.recentResults.count == PickController.retainedResultLimit)
+    }
+
     @Test func pendingPickCarriesQueryAndDefaultsItToNil() {
         let controller = PickController()
         let prefilled = PendingPick(

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -4,6 +4,26 @@ import Testing
 
 @MainActor
 struct SessionTests {
+    @Test func askTargetPaneFollowsPromotedSurvivorUntilItsPaneIsRemoved() throws {
+        let store = makeStore()
+        let workspace = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/tmp"))
+        session.surface = SpySurface()
+        store.toggleSplit(session.id)
+        session.splitSurface = SpySurface()
+        let identity = try #require(session.splitPaneIdentity)
+        #expect(session.askTargetPane(for: identity) == .right)
+
+        store.closePrimaryPane(session.id)
+
+        #expect(store.session(withID: session.id) != nil)
+        #expect(session.askTargetPane(for: identity) == .left)
+        store.toggleSplit(session.id)
+        session.splitSurface = SpySurface()
+        store.closePrimaryPane(session.id)
+        #expect(session.askTargetPane(for: identity) == nil)
+    }
+
     @Test(arguments: [
         ("/Users/user/dev/foo", "foo"),
         ("/", "/"),

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @MainActor
 struct SessionTests {
-    @Test func askTargetPaneFollowsPromotedSurvivorUntilItsPaneIsRemoved() throws {
+    @Test func paneRoleFollowsPromotedSurvivorUntilItsPaneIsRemoved() throws {
         let store = makeStore()
         let workspace = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/tmp"))
@@ -12,16 +12,16 @@ struct SessionTests {
         store.toggleSplit(session.id)
         session.splitSurface = SpySurface()
         let identity = try #require(session.splitPaneIdentity)
-        #expect(session.askTargetPane(for: identity) == .right)
+        #expect(session.paneRole(forIdentity: identity) == .right)
 
         store.closePrimaryPane(session.id)
 
         #expect(store.session(withID: session.id) != nil)
-        #expect(session.askTargetPane(for: identity) == .left)
+        #expect(session.paneRole(forIdentity: identity) == .left)
         store.toggleSplit(session.id)
         session.splitSurface = SpySurface()
         store.closePrimaryPane(session.id)
-        #expect(session.askTargetPane(for: identity) == nil)
+        #expect(session.paneRole(forIdentity: identity) == nil)
     }
 
     @Test(arguments: [

--- a/agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift
@@ -9,7 +9,7 @@ struct AskCommandsTests {
         let command = try open(["Continue?", "--button", "yes=Yes"])
         let request = try command.makeRequest()
         #expect(request == ControlRequest(cmd: .askOpen, args: ControlArgs(
-            buttons: [ControlAskButton(id: "yes", label: "Yes")], title: "Continue?"
+            buttons: [ControlAskButton(id: "yes", label: "Yes")], style: "terminal", align: "right", title: "Continue?"
         )))
         #expect(!command.noBlock)
         let json = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: Any])
@@ -20,7 +20,7 @@ struct AskCommandsTests {
         let command = try open([
             "Keep changes?", "--message", "Choose an action.", "--button", "save=Save=keep",
             "--button", "no", "--button", "discard=Discard", "--hotkey", "save=S", "--hotkey", "no=n",
-            "--default", "save", "--cancel", "no", "--destructive", "discard",
+            "--default", "save", "--destructive", "discard", "--style", "gui", "--align", "left",
             "--target", "session-id", "--pane", "right", "--pane-id", "pane-token", "--window", "window-id",
             "--follow", "--no-block", "--socket", "/tmp/ask-cli.sock", "--json",
         ])
@@ -29,7 +29,7 @@ struct AskCommandsTests {
             buttons: [ControlAskButton(id: "save", label: "Save=keep", hotkey: "S"),
                       ControlAskButton(id: "no", label: "no", hotkey: "n"),
                       ControlAskButton(id: "discard", label: "Discard")],
-            defaultButton: "save", cancelButton: "no", destructiveButton: "discard",
+            defaultButton: "save", destructiveButton: "discard", style: "gui", align: "left",
             window: "window-id", pane: "right", paneID: "pane-token", title: "Keep changes?"
         )))
         #expect(command.noBlock)
@@ -44,6 +44,8 @@ struct AskCommandsTests {
     }
 
     @Test(arguments: [
+        (["Question", "--button", "ok", "--style", "other"], "unknown style"),
+        (["Question", "--button", "ok", "--align", "other"], "unknown align"),
         (["Question"], "ask requires at least one --button"),
         ([" ", "--button", "ok"], "ask.open requires a title"),
         (["Question", "--button", "ok", "--hotkey", "o"], "--hotkey requires ID=LETTER"),
@@ -109,17 +111,18 @@ struct AskCommandsTests {
         #expect(try JSONDecoder().decode(ControlAskResult.self, from: Data(#require(lines.first).utf8)) == answer)
     }
 
-    @Test func cancelledAnswerPrintsBeforeExitTwo() throws {
+    @Test(arguments: [(ControlAskOutcome.cancelled, Int32(2)), (.escaped, Int32(3))])
+    func dismissalPrintsBeforeExit(outcome: ControlAskOutcome, code: Int32) throws {
         let command = try open(["Continue?", "--button", "yes=Yes"])
         var lines: [String] = []
-        #expect(throws: ExitCode(rawValue: 2)) {
+        #expect(throws: ExitCode(rawValue: code)) {
             try command.execute(send: {
                 $0.cmd == .askOpen
                     ? ControlResponse(ok: true, result: ControlResult(id: "ask-id"))
-                    : ControlResponse(ok: true, result: ControlResult(ask: ControlAskResult(result: .cancelled)))
+                    : ControlResponse(ok: true, result: ControlResult(ask: ControlAskResult(result: outcome)))
             }, sleep: { _ in }, output: { lines.append($0) })
         }
-        #expect(lines == [#"{"result":"cancelled"}"#])
+        #expect(lines == ["{\"result\":\"\(outcome.rawValue)\"}"])
     }
 
     @Test(arguments: [false, true])
@@ -208,6 +211,7 @@ struct AskCommandsTests {
         (ControlAskResult(result: .pending), Int32(1)),
         (ControlAskResult(result: .answered, id: "yes", label: "Yes", index: 0), Int32(0)),
         (ControlAskResult(result: .cancelled), Int32(2)),
+        (ControlAskResult(result: .escaped), Int32(3)),
     ])
     func oneShotResultPrintsEveryOutcomeAndMapsExit(result: ControlAskResult, expectedExit: Int32) throws {
         let command = try #require(try Agtermctl.parseAsRoot(["ask", "result", "ask-id", "--window", "w"]) as? Ask.Result)

--- a/agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift
@@ -5,6 +5,22 @@ import agtermCore
 @testable import agtermctlKit
 
 struct AskCommandsTests {
+    @Test(arguments: [10, 50, 100])
+    func rootMapsFixedWidth(width: Int) throws {
+        let command = try open(["Choose", "--button", "ok", "--width", String(width)])
+        #expect(try command.makeRequest().args?.width == width)
+    }
+
+    @Test(arguments: ["-1", "0", "9", "101", "50.5", "wide", "", "999999999999999999999"])
+    func rootRejectsInvalidWidth(width: String) {
+        do {
+            _ = try open(["Choose", "--button", "ok", "--width", width])
+            Issue.record("expected invalid width")
+        } catch {
+            #expect(Agtermctl.message(for: error) == "width must be 10 to 100")
+        }
+    }
+
     @Test func rootDefaultsToBlockingOpenWithoutATarget() throws {
         let command = try open(["Continue?", "--button", "yes=Yes"])
         let request = try command.makeRequest()

--- a/agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift
@@ -1,0 +1,248 @@
+import ArgumentParser
+import Foundation
+import Testing
+import agtermCore
+@testable import agtermctlKit
+
+struct AskCommandsTests {
+    @Test func rootDefaultsToBlockingOpenWithoutATarget() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes"])
+        let request = try command.makeRequest()
+        #expect(request == ControlRequest(cmd: .askOpen, args: ControlArgs(
+            buttons: [ControlAskButton(id: "yes", label: "Yes")], title: "Continue?"
+        )))
+        #expect(!command.noBlock)
+        let json = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: Any])
+        #expect(json["target"] == nil)
+    }
+
+    @Test func rootMapsEveryOpenOption() throws {
+        let command = try open([
+            "Keep changes?", "--message", "Choose an action.", "--button", "save=Save=keep",
+            "--button", "no", "--button", "discard=Discard", "--hotkey", "save=S", "--hotkey", "no=n",
+            "--default", "save", "--cancel", "no", "--destructive", "discard",
+            "--target", "session-id", "--pane", "right", "--pane-id", "pane-token", "--window", "window-id",
+            "--follow", "--no-block", "--socket", "/tmp/ask-cli.sock", "--json",
+        ])
+        #expect(try command.makeRequest() == ControlRequest(cmd: .askOpen, target: "session-id", args: ControlArgs(
+            follow: true, message: "Choose an action.",
+            buttons: [ControlAskButton(id: "save", label: "Save=keep", hotkey: "S"),
+                      ControlAskButton(id: "no", label: "no", hotkey: "n"),
+                      ControlAskButton(id: "discard", label: "Discard")],
+            defaultButton: "save", cancelButton: "no", destructiveButton: "discard",
+            window: "window-id", pane: "right", paneID: "pane-token", title: "Keep changes?"
+        )))
+        #expect(command.noBlock)
+        #expect(command.options.json)
+        #expect(command.options.socketPath() == "/tmp/ask-cli.sock")
+    }
+
+    @Test(arguments: ["open", "result", "cancel"])
+    func explicitOpenAcceptsReservedWordsAsTitles(title: String) throws {
+        let command = try open(["open", title, "--button", "ok"])
+        #expect(try command.makeRequest().args?.title == title)
+    }
+
+    @Test(arguments: [
+        (["Question"], "ask requires at least one --button"),
+        ([" ", "--button", "ok"], "ask.open requires a title"),
+        (["Question", "--button", "ok", "--hotkey", "o"], "--hotkey requires ID=LETTER"),
+        (["Question", "--button", "ok", "--hotkey", "missing=x"], "unknown hotkey button: missing"),
+        (["Question", "--button", "ok", "--hotkey", "ok=o", "--hotkey", "ok=k"], "hotkey already assigned to button: ok"),
+        (["Question", "--button", "ok", "--pane", "right"], "--pane requires a session"),
+        (["Question", "--button", "ok", "--pane-id", "token"], "--pane requires a session"),
+        (["Question", "--button", "ok", "--target", "active", "--pane", "scratch"], "--pane must be left or right"),
+    ])
+    func rootRejectsInvalidSyntax(argv: [String], expected: String) {
+        do {
+            _ = try Agtermctl.parseAsRoot(["ask"] + argv)
+            Issue.record("expected validation failure")
+        } catch {
+            #expect(Agtermctl.message(for: error) == expected)
+        }
+    }
+
+    @Test func resultAndCancelRouteIDsAndWindowOptions() throws {
+        let result = try #require(try Agtermctl.parseAsRoot(["ask", "result", "ask-id", "--window", "w"]) as? Ask.Result)
+        let cancel = try #require(try Agtermctl.parseAsRoot(["ask", "cancel", "ask-id", "--window", "w"]) as? Ask.Cancel)
+        #expect(try result.makeRequest() == ControlRequest(cmd: .askResult, target: "ask-id", args: ControlArgs(window: "w")))
+        #expect(try cancel.makeRequest() == ControlRequest(cmd: .askCancel, target: "ask-id", args: ControlArgs(window: "w")))
+    }
+
+    @Test func noBlockPrintsOnlyIDWithoutPolling() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes", "--no-block", "--json"])
+        var requests: [ControlRequest] = []
+        var lines: [String] = []
+        try command.execute(send: {
+            requests.append($0)
+            return ControlResponse(ok: true, result: ControlResult(id: "ask-id", pane: "right"))
+        }, sleep: { _ in Issue.record("no-block must not sleep") }, output: { lines.append($0) })
+
+        #expect(requests.count == 1)
+        #expect(requests.first?.cmd == .askOpen)
+        #expect(lines.count == 1)
+        let line = try #require(lines.first)
+        let fields = try #require(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: String])
+        #expect(fields == ["id": "ask-id"])
+    }
+
+    @Test func blockingPollUsesGlobalIDBackoffAndPrintsOneAnswer() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes", "--window", "w"])
+        var requests: [ControlRequest] = []
+        var delays: [TimeInterval] = []
+        var lines: [String] = []
+        var polls = 0
+        let answer = ControlAskResult(result: .answered, id: "yes", label: "Yes", index: 0)
+        try command.execute(send: { request in
+            requests.append(request)
+            if request.cmd == .askOpen { return ControlResponse(ok: true, result: ControlResult(id: "ask-id")) }
+            polls += 1
+            return ControlResponse(ok: true, result: ControlResult(
+                ask: polls <= 11 ? ControlAskResult(result: .pending) : answer
+            ))
+        }, sleep: { delays.append($0) }, output: { lines.append($0) })
+
+        #expect(requests.first?.args?.window == "w")
+        #expect(requests.dropFirst().allSatisfy { $0 == ControlRequest(cmd: .askResult, target: "ask-id") })
+        #expect(delays == Array(repeating: 0.1, count: 10) + [0.5])
+        #expect(lines.count == 1)
+        #expect(try JSONDecoder().decode(ControlAskResult.self, from: Data(#require(lines.first).utf8)) == answer)
+    }
+
+    @Test func cancelledAnswerPrintsBeforeExitTwo() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes"])
+        var lines: [String] = []
+        #expect(throws: ExitCode(rawValue: 2)) {
+            try command.execute(send: {
+                $0.cmd == .askOpen
+                    ? ControlResponse(ok: true, result: ControlResult(id: "ask-id"))
+                    : ControlResponse(ok: true, result: ControlResult(ask: ControlAskResult(result: .cancelled)))
+            }, sleep: { _ in }, output: { lines.append($0) })
+        }
+        #expect(lines == [#"{"result":"cancelled"}"#])
+    }
+
+    @Test(arguments: [false, true])
+    func serverErrorsFollowTheJSONFlag(json: Bool) throws {
+        let command = try open(["Continue?", "--button", "yes=Yes"] + (json ? ["--json"] : []))
+        var lines: [String] = []
+        var errors: [String] = []
+        let response = ControlResponse(ok: false, error: "ask already pending")
+        #expect(throws: ExitCode.failure) {
+            try command.execute(send: { _ in response }, sleep: { _ in }, output: { lines.append($0) },
+                                errorOutput: { errors.append($0) })
+        }
+        #expect(lines.count == (json ? 1 : 0))
+        #expect(errors == (json ? [] : ["error: ask already pending"]))
+        if json {
+            #expect(try JSONDecoder().decode(ControlResponse.self, from: Data(#require(lines.first).utf8)) == response)
+        }
+    }
+
+    @Test func missingOpenIDFailsBeforePolling() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes"])
+        var requests: [ControlRequest] = []
+        var errors: [String] = []
+        #expect(throws: ExitCode.failure) {
+            try command.execute(send: {
+                requests.append($0)
+                return ControlResponse(ok: true)
+            }, sleep: { _ in }, output: { _ in Issue.record("malformed open must not print an answer") },
+            errorOutput: { errors.append($0) })
+        }
+        #expect(requests.map(\.cmd) == [.askOpen])
+        #expect(errors == ["error: ask.open result missing id"])
+    }
+
+    @Test func malformedPollCancelsTheExactAsk() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes", "--window", "w"])
+        var requests: [ControlRequest] = []
+        var errors: [String] = []
+        #expect(throws: ExitCode.failure) {
+            try command.execute(send: {
+                requests.append($0)
+                return $0.cmd == .askOpen ? ControlResponse(ok: true, result: ControlResult(id: "ask-id")) : ControlResponse(ok: true)
+            }, sleep: { _ in }, output: { _ in Issue.record("malformed poll must not print an answer") },
+            errorOutput: { errors.append($0) })
+        }
+        #expect(requests.map(\.cmd) == [.askOpen, .askResult, .askCancel])
+        #expect(requests.last == ControlRequest(cmd: .askCancel, target: "ask-id"))
+        #expect(errors == ["error: ask.result missing result"])
+    }
+
+    @Test func failedCancellationPreservesTheTransportFailure() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes"])
+        var requests: [ControlRequest] = []
+        do {
+            try command.execute(send: {
+                requests.append($0)
+                switch $0.cmd {
+                case .askOpen: return ControlResponse(ok: true, result: ControlResult(id: "ask-id"))
+                case .askResult: throw SocketClientError("poll failed")
+                default: throw SocketClientError("cancel failed")
+                }
+            }, sleep: { _ in }, output: { _ in })
+            Issue.record("expected transport failure")
+        } catch let error as SocketClientError {
+            #expect(error.description == "poll failed")
+        }
+        #expect(requests.map(\.cmd) == [.askOpen, .askResult, .askCancel])
+        #expect(requests.last?.target == "ask-id")
+    }
+
+    @Test func unknownAskResponseDoesNotAttemptCancellation() throws {
+        let command = try open(["Continue?", "--button", "yes=Yes"])
+        var requests: [ControlRequest] = []
+        #expect(throws: ExitCode.failure) {
+            try command.execute(send: {
+                requests.append($0)
+                return $0.cmd == .askOpen
+                    ? ControlResponse(ok: true, result: ControlResult(id: "ask-id"))
+                    : ControlResponse(ok: false, error: "unknown ask: ask-id")
+            }, sleep: { _ in }, output: { _ in }, errorOutput: { _ in })
+        }
+        #expect(requests.map(\.cmd) == [.askOpen, .askResult])
+    }
+
+    @Test(arguments: [
+        (ControlAskResult(result: .pending), Int32(1)),
+        (ControlAskResult(result: .answered, id: "yes", label: "Yes", index: 0), Int32(0)),
+        (ControlAskResult(result: .cancelled), Int32(2)),
+    ])
+    func oneShotResultPrintsEveryOutcomeAndMapsExit(result: ControlAskResult, expectedExit: Int32) throws {
+        let command = try #require(try Agtermctl.parseAsRoot(["ask", "result", "ask-id", "--window", "w"]) as? Ask.Result)
+        var requests: [ControlRequest] = []
+        var lines: [String] = []
+        var exit: Int32 = 0
+        do {
+            try command.execute(send: {
+                requests.append($0)
+                return ControlResponse(ok: true, result: ControlResult(ask: result))
+            }, output: { lines.append($0) })
+        } catch let code as ExitCode {
+            exit = code.rawValue
+        }
+        #expect(exit == expectedExit)
+        #expect(requests == [ControlRequest(cmd: .askResult, target: "ask-id", args: ControlArgs(window: "w"))])
+        #expect(lines.count == 1)
+        #expect(try JSONDecoder().decode(ControlAskResult.self, from: Data(#require(lines.first).utf8)) == result)
+    }
+
+    @Test func oneShotMalformedResultDoesNotCancelSomeoneElsesDialog() throws {
+        let command = try #require(try Agtermctl.parseAsRoot(["ask", "result", "ask-id"]) as? Ask.Result)
+        var requests: [ControlRequest] = []
+        var errors: [String] = []
+        #expect(throws: ExitCode.failure) {
+            try command.execute(send: {
+                requests.append($0)
+                return ControlResponse(ok: true)
+            }, output: { _ in }, errorOutput: { errors.append($0) })
+        }
+        #expect(requests.map(\.cmd) == [.askResult])
+        #expect(errors == ["error: ask.result missing result"])
+    }
+
+    private func open(_ argv: [String]) throws -> Ask.Open {
+        try #require(try Agtermctl.parseAsRoot(["ask"] + argv) as? Ask.Open)
+    }
+}

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -423,7 +423,7 @@ struct SocketClientTests {
         #expect(SocketClient.pickExitCode(for: outcome).rawValue == expected)
     }
 
-    @Test(arguments: [(ControlAskOutcome.pending, Int32(1)), (.answered, Int32(0)), (.cancelled, Int32(2))])
+    @Test(arguments: [(ControlAskOutcome.pending, Int32(1)), (.answered, Int32(0)), (.cancelled, Int32(2)), (.escaped, Int32(3))])
     func askExitCodeMapsEveryOutcome(outcome: ControlAskOutcome, expected: Int32) {
         #expect(SocketClient.askExitCode(for: outcome).rawValue == expected)
     }

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -423,6 +423,21 @@ struct SocketClientTests {
         #expect(SocketClient.pickExitCode(for: outcome).rawValue == expected)
     }
 
+    @Test(arguments: [(ControlAskOutcome.pending, Int32(1)), (.answered, Int32(0)), (.cancelled, Int32(2))])
+    func askExitCodeMapsEveryOutcome(outcome: ControlAskOutcome, expected: Int32) {
+        #expect(SocketClient.askExitCode(for: outcome).rawValue == expected)
+    }
+
+    @Test func formatsAskResultAsBareJSON() throws {
+        let result = ControlAskResult(result: .answered, id: "save", label: "Save", index: 0)
+        let line = try SocketClient.formatAskResult(result)
+        #expect(try JSONDecoder().decode(ControlAskResult.self, from: Data(line.utf8)) == result)
+        let fields = try #require(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+        #expect(fields["result"] as? String == "answered")
+        #expect(fields["ask"] == nil)
+        #expect(fields["ok"] == nil)
+    }
+
     @Test func pickPollBackoffUsesTenFastSleepsThenSlowSleeps() {
         #expect((1...10).map(SocketClient.pickPollDelay(afterPendingPoll:)) ==
             Array(repeating: 0.1, count: 10))

--- a/agtermTests/AskDialogViewTests.swift
+++ b/agtermTests/AskDialogViewTests.swift
@@ -42,6 +42,16 @@ final class AskDialogViewTests: XCTestCase {
         }
     }
 
+    func testSharedButtonWidthTakesTheWidestAndCapsAColumnAtTheProposal() {
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [30, 120, 64], proposal: 500, axis: .horizontal), 120)
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [30, 120, 64], proposal: nil, axis: .horizontal), 120)
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [30, 120, 64], proposal: 90, axis: .horizontal), 120)
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [30, 120, 64], proposal: 500, axis: .vertical), 120)
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [30, 120, 64], proposal: 90, axis: .vertical), 90)
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [30, 120, 64], proposal: nil, axis: .vertical), 120)
+        XCTAssertEqual(AskButtonLayout.sharedWidth(natural: [], proposal: 90, axis: .horizontal), 0)
+    }
+
     func testTerminalPanelFitsShortContentAndCapsLongLabelsInBothAppearances() throws {
         for dark in [false, true] {
             for long in [false, true] {

--- a/agtermTests/AskDialogViewTests.swift
+++ b/agtermTests/AskDialogViewTests.swift
@@ -6,13 +6,84 @@ import agtermCore
 
 @MainActor
 final class AskDialogViewTests: XCTestCase {
+    func testEqualButtonsRenderInBothLayoutsAndStyles() throws {
+        for style in ControlAskStyle.allCases {
+            for width: CGFloat in [700, 140] {
+                let ask = PendingAsk(id: "equal-buttons", title: "Choose", buttons: [
+                    ControlAskButton(id: "ok", label: "OK"), ControlAskButton(id: "cancel", label: "Cancel everything"),
+                ], style: style)
+                let view = AskDialogView(ask: ask, anchorFrame: CGRect(x: (700 - width) / 2, y: 0, width: width, height: 400),
+                                         font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                                         foreground: .white, background: .black, focusAllowed: false,
+                                         onAnswer: { _ in }, onDismiss: {})
+                    .frame(width: 700, height: 400)
+                    .environment(\.colorScheme, .dark)
+                    .environment(\.controlActiveState, .key)
+                let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 700, height: 400),
+                                      styleMask: [.titled], backing: .buffered, defer: false)
+                window.isReleasedWhenClosed = false
+                defer { window.close() }
+                window.appearance = NSAppearance(named: .darkAqua)
+                let host = NSHostingView(rootView: view)
+                window.contentView = host
+                window.orderFront(nil)
+                host.layoutSubtreeIfNeeded()
+                host.displayIfNeeded()
+                let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+                host.cacheDisplay(in: host.bounds, to: bitmap)
+                XCTAssertGreaterThan(brightSamples(in: bitmap), 10)
+                let image = NSImage(size: host.bounds.size)
+                image.addRepresentation(bitmap)
+                let attachment = XCTAttachment(image: image)
+                attachment.name = "ask-equal-buttons-\(style.rawValue)-\(Int(width))"
+                attachment.lifetime = .keepAlways
+                add(attachment)
+            }
+        }
+    }
+
+    func testTerminalPanelFitsShortContentAndCapsLongLabelsInBothAppearances() throws {
+        for dark in [false, true] {
+            for long in [false, true] {
+                let buttons = long
+                    ? [ControlAskButton(id: "long", label: String(repeating: "A long button label ", count: 4))]
+                    : [ControlAskButton(id: "yes", label: "Yes"), ControlAskButton(id: "no", label: "No")]
+                let ask = PendingAsk(id: "sizing", title: "Continue?", message: "Choose.", buttons: buttons)
+                let background: CGFloat = dark ? 0.08 : 0.95
+                let view = AskDialogView(ask: ask, anchorFrame: CGRect(x: 50, y: 0, width: 300, height: 400),
+                                         font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                                         foreground: dark ? .white : .black, background: Color(white: background),
+                                         focusAllowed: false, onAnswer: { _ in }, onDismiss: {})
+                    .frame(width: 400, height: 400)
+                    .background(Color(white: 0.5))
+                let image = try XCTUnwrap(ImageRenderer(content: view).nsImage)
+                let bitmap = try XCTUnwrap(NSBitmapImageRep(data: try XCTUnwrap(image.tiffRepresentation)))
+                let panelPixels = (0..<bitmap.pixelsWide).filter { x in
+                    guard let color = bitmap.colorAt(x: x, y: bitmap.pixelsHigh / 2)?.usingColorSpace(.deviceRGB) else { return false }
+                    return abs(color.redComponent - background) < 0.03
+                }
+                let width = try XCTUnwrap(panelPixels.last) - XCTUnwrap(panelPixels.first) + 1
+                XCTAssertLessThanOrEqual(width, 270)
+                if long {
+                    XCTAssertGreaterThanOrEqual(width, 266)
+                } else {
+                    XCTAssertLessThan(width, 210)
+                }
+                let attachment = XCTAttachment(image: image)
+                attachment.name = "ask-sized-\(long ? "long" : "short")-\(dark ? "dark" : "light")"
+                attachment.lifetime = .keepAlways
+                add(attachment)
+            }
+        }
+    }
+
     func testBothStylesRenderInLightAndDarkAppearance() throws {
         for style in ControlAskStyle.allCases {
-            for dark in [false, true] {
+            for (dark, width) in [(false, Int?.none), (true, nil), (false, 50), (true, 50)] {
                 let ask = PendingAsk(id: "appearance", title: "Keep these changes?", message: "Choose what happens next.",
                                      buttons: [ControlAskButton(id: "keep", label: "Keep", hotkey: "k"),
                                                ControlAskButton(id: "delete", label: "Delete", hotkey: "d")],
-                                     defaultID: "keep", destructiveID: "delete", style: style)
+                                     defaultID: "keep", destructiveID: "delete", style: style, width: width)
                 let view = AskDialogView(ask: ask, anchorFrame: CGRect(x: 0, y: 0, width: 700, height: 400),
                                          font: .monospacedSystemFont(ofSize: 13, weight: .regular),
                                          foreground: dark ? .white : .black, background: dark ? .black : .white,
@@ -37,7 +108,7 @@ final class AskDialogViewTests: XCTestCase {
                 let image = NSImage(size: host.bounds.size)
                 image.addRepresentation(bitmap)
                 let attachment = XCTAttachment(image: image)
-                attachment.name = "ask-\(style.rawValue)-\(dark ? "dark" : "light")"
+                attachment.name = "ask-\(style.rawValue)-\(dark ? "dark" : "light")-\(width == nil ? "auto" : "50-percent")"
                 attachment.lifetime = .keepAlways
                 add(attachment)
             }
@@ -159,14 +230,16 @@ final class AskDialogViewTests: XCTestCase {
     func testButtonLabelsShowDestructiveAndMissingLetterHotkey() throws {
         let destructive = AskDialogView.buttonLabel(ControlAskButton(id: "delete", label: "Delete", hotkey: "d"),
                                                     destructive: true)
-        XCTAssertEqual(String(destructive.characters), "[ ! Delete ]")
+        XCTAssertEqual(String(destructive.characters), "! Delete")
         let letter = try XCTUnwrap(destructive.range(of: "D"))
         XCTAssertNotNil(destructive[letter].underlineStyle)
         let fallback = AskDialogView.buttonLabel(ControlAskButton(id: "save", label: "Save", hotkey: "x"),
                                                  destructive: false)
-        XCTAssertEqual(String(fallback.characters), "[ Save (X) ]")
+        XCTAssertEqual(String(fallback.characters), "Save (X)")
         let hint = try XCTUnwrap(fallback.range(of: "X"))
         XCTAssertNotNil(fallback[hint].underlineStyle)
+        let plain = AskDialogView.buttonLabel(ControlAskButton(id: "yes", label: "Yes"), destructive: false)
+        XCTAssertEqual(String(plain.characters), "Yes")
     }
 
     private func event(_ keyCode: UInt16, text: String = "", modifiers: NSEvent.ModifierFlags = []) throws -> NSEvent {

--- a/agtermTests/AskDialogViewTests.swift
+++ b/agtermTests/AskDialogViewTests.swift
@@ -6,6 +6,44 @@ import agtermCore
 
 @MainActor
 final class AskDialogViewTests: XCTestCase {
+    func testBothStylesRenderInLightAndDarkAppearance() throws {
+        for style in ControlAskStyle.allCases {
+            for dark in [false, true] {
+                let ask = PendingAsk(id: "appearance", title: "Keep these changes?", message: "Choose what happens next.",
+                                     buttons: [ControlAskButton(id: "keep", label: "Keep", hotkey: "k"),
+                                               ControlAskButton(id: "delete", label: "Delete", hotkey: "d")],
+                                     defaultID: "keep", destructiveID: "delete", style: style)
+                let view = AskDialogView(ask: ask, anchorFrame: CGRect(x: 0, y: 0, width: 700, height: 400),
+                                         font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                                         foreground: dark ? .white : .black, background: dark ? .black : .white,
+                                         focusAllowed: true, onAnswer: { _ in }, onDismiss: {})
+                    .frame(width: 700, height: 400)
+                    .environment(\.colorScheme, dark ? .dark : .light)
+                    .environment(\.controlActiveState, .key)
+                let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 700, height: 400),
+                                      styleMask: [.titled], backing: .buffered, defer: false)
+                window.isReleasedWhenClosed = false
+                defer { window.close() }
+                window.appearance = NSAppearance(named: dark ? .darkAqua : .aqua)
+                let host = NSHostingView(rootView: view)
+                window.contentView = host
+                window.orderFront(nil)
+                host.layoutSubtreeIfNeeded()
+                host.displayIfNeeded()
+                XCTAssertTrue(window.firstResponder is AskKeyCatcher.KeyCatcherView)
+                let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+                host.cacheDisplay(in: host.bounds, to: bitmap)
+                XCTAssertGreaterThan(brightSamples(in: bitmap), 10)
+                let image = NSImage(size: host.bounds.size)
+                image.addRepresentation(bitmap)
+                let attachment = XCTAttachment(image: image)
+                attachment.name = "ask-\(style.rawValue)-\(dark ? "dark" : "light")"
+                attachment.lifetime = .keepAlways
+                add(attachment)
+            }
+        }
+    }
+
     func testOverflowDialogRendersInNativeHost() throws {
         var selected: Int?
         let ask = PendingAsk(id: "overflow", title: "Choose an action",
@@ -28,7 +66,7 @@ final class AskDialogViewTests: XCTestCase {
         host.displayIfNeeded()
         let catcher = try XCTUnwrap(window.firstResponder as? AskKeyCatcher.KeyCatcherView)
         catcher.keyDown(with: try event(36))
-        XCTAssertNil(selected)
+        XCTAssertEqual(selected, 0)
         catcher.keyDown(with: try event(48, modifiers: .shift))
         let scroll = try XCTUnwrap(descendant(NSScrollView.self, in: host))
         for _ in 0..<30 where scroll.contentView.bounds.minY == 0 {
@@ -57,11 +95,15 @@ final class AskDialogViewTests: XCTestCase {
                              buttons: [ControlAskButton(id: "save", label: "Save workspace", hotkey: "s"),
                                        ControlAskButton(id: "cancel", label: "Keep editing", hotkey: "k"),
                                        ControlAskButton(id: "discard", label: "Discard changes", hotkey: "d")],
-                             defaultID: "save", cancelID: "cancel", destructiveID: "discard")
+                             defaultID: "save", destructiveID: "discard")
         let frames = [
             ("wide", CGRect(x: 0, y: 30, width: 900, height: 570), ask),
             ("pane", CGRect(x: 565, y: 30, width: 335, height: 570), ask),
             ("short-pane", CGRect(x: 565, y: 280, width: 335, height: 220), ask),
+            ("long-label-terminal", CGRect(x: 565, y: 30, width: 335, height: 570),
+             PendingAsk(id: "long-terminal", title: "Confirm", buttons: [ControlAskButton(id: "long", label: String(repeating: "A long button label ", count: 8))])),
+            ("long-label-gui", CGRect(x: 565, y: 30, width: 335, height: 570),
+             PendingAsk(id: "long-gui", title: "Confirm", buttons: [ControlAskButton(id: "long", label: String(repeating: "A long button label ", count: 8))], style: .gui)),
         ]
         for (name, frame, question) in frames {
             let view = AskDialogView(ask: question, anchorFrame: frame, font: .monospacedSystemFont(ofSize: 13, weight: .regular),

--- a/agtermTests/AskDialogViewTests.swift
+++ b/agtermTests/AskDialogViewTests.swift
@@ -1,0 +1,155 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import agterm
+import agtermCore
+
+@MainActor
+final class AskDialogViewTests: XCTestCase {
+    func testOverflowDialogRendersInNativeHost() throws {
+        var selected: Int?
+        let ask = PendingAsk(id: "overflow", title: "Choose an action",
+                             message: "All six actions remain available in a small pane.",
+                             buttons: (0..<6).map { ControlAskButton(id: "\($0)", label: "Action \($0)") })
+        let view = AskDialogView(ask: ask, anchorFrame: CGRect(x: 565, y: 280, width: 335, height: 160),
+                                 font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                                 foreground: Color(white: 0.85), background: Color(white: 0.08),
+                                 focusAllowed: true, onAnswer: { selected = $0 }, onDismiss: {})
+            .frame(width: 900, height: 600)
+            .background(Color(white: 0.15))
+        let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 900, height: 600),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        let host = NSHostingView(rootView: view)
+        window.contentView = host
+        window.orderFront(nil)
+        host.layoutSubtreeIfNeeded()
+        host.displayIfNeeded()
+        let catcher = try XCTUnwrap(window.firstResponder as? AskKeyCatcher.KeyCatcherView)
+        catcher.keyDown(with: try event(36))
+        XCTAssertNil(selected)
+        catcher.keyDown(with: try event(48, modifiers: .shift))
+        let scroll = try XCTUnwrap(descendant(NSScrollView.self, in: host))
+        for _ in 0..<30 where scroll.contentView.bounds.minY == 0 {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            host.layoutSubtreeIfNeeded()
+        }
+        XCTAssertGreaterThan(scroll.contentView.bounds.minY, 0)
+        catcher.keyDown(with: try event(36))
+        XCTAssertEqual(selected, 5)
+        host.displayIfNeeded()
+        let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        let image = NSImage(size: host.bounds.size)
+        image.addRepresentation(bitmap)
+        XCTAssertEqual(image.size, CGSize(width: 900, height: 600))
+        XCTAssertGreaterThan(brightSamples(in: bitmap), 10)
+        let attachment = XCTAttachment(image: image)
+        attachment.name = "ask-native-overflow"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    func testDialogRendersAtWindowPaneAndShortPaneSizes() throws {
+        let ask = PendingAsk(id: "render", title: "Keep these changes?",
+                             message: "Save this workspace, keep editing, or discard the current changes. Choose an action below.",
+                             buttons: [ControlAskButton(id: "save", label: "Save workspace", hotkey: "s"),
+                                       ControlAskButton(id: "cancel", label: "Keep editing", hotkey: "k"),
+                                       ControlAskButton(id: "discard", label: "Discard changes", hotkey: "d")],
+                             defaultID: "save", cancelID: "cancel", destructiveID: "discard")
+        let frames = [
+            ("wide", CGRect(x: 0, y: 30, width: 900, height: 570), ask),
+            ("pane", CGRect(x: 565, y: 30, width: 335, height: 570), ask),
+            ("short-pane", CGRect(x: 565, y: 280, width: 335, height: 220), ask),
+        ]
+        for (name, frame, question) in frames {
+            let view = AskDialogView(ask: question, anchorFrame: frame, font: .monospacedSystemFont(ofSize: 13, weight: .regular),
+                                     foreground: Color(white: 0.85), background: Color(white: 0.08),
+                                     focusAllowed: false, onAnswer: { _ in }, onDismiss: {})
+                .frame(width: 900, height: 600)
+                .background(Color(white: 0.15))
+            let renderer = ImageRenderer(content: view)
+            let image = try XCTUnwrap(renderer.nsImage)
+            XCTAssertEqual(image.size, CGSize(width: 900, height: 600))
+            let bitmap = try XCTUnwrap(NSBitmapImageRep(data: try XCTUnwrap(image.tiffRepresentation)))
+            XCTAssertGreaterThan(brightSamples(in: bitmap), 10)
+            let attachment = XCTAttachment(image: image)
+            attachment.name = "ask-\(name)"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+    }
+
+    func testNavigationKeysMapToActions() throws {
+        let cases: [(UInt16, NSEvent.ModifierFlags, AskKey)] = [
+            (48, [], .forward), (48, .shift, .backward),
+            (124, [], .forward), (125, [], .forward),
+            (123, [], .backward), (126, [], .backward),
+            (36, [], .activate), (76, [], .activate), (53, [], .cancel),
+        ]
+        for (key, modifiers, expected) in cases {
+            XCTAssertEqual(AskKeyCatcher.key(for: try event(key, modifiers: modifiers)), expected)
+        }
+    }
+
+    func testHotkeysFoldCaseAndIgnoreCommandControlOrOption() throws {
+        XCTAssertEqual(AskKeyCatcher.key(for: try event(0, text: "A", modifiers: .shift)), .hotkey("a"))
+        XCTAssertEqual(AskKeyCatcher.key(for: try event(0, text: "a")), .hotkey("a"))
+        for modifiers: NSEvent.ModifierFlags in [.command, .control, .option, [.shift, .command]] {
+            XCTAssertNil(AskKeyCatcher.key(for: try event(0, text: "a", modifiers: modifiers)))
+            XCTAssertNil(AskKeyCatcher.key(for: try event(36, modifiers: modifiers)))
+        }
+    }
+
+    func testUnknownKeysDoNotProduceActions() throws {
+        let view = AskKeyCatcher.KeyCatcherView()
+        var actions: [AskKey] = []
+        view.onKey = { actions.append($0) }
+        for text in ["1", "!", "é", "", "\u{7f}"] {
+            view.keyDown(with: try event(51, text: text))
+        }
+        XCTAssertTrue(actions.isEmpty)
+        view.keyDown(with: try event(53))
+        XCTAssertEqual(actions, [.cancel])
+    }
+
+    func testButtonLabelsShowDestructiveAndMissingLetterHotkey() throws {
+        let destructive = AskDialogView.buttonLabel(ControlAskButton(id: "delete", label: "Delete", hotkey: "d"),
+                                                    destructive: true)
+        XCTAssertEqual(String(destructive.characters), "[ ! Delete ]")
+        let letter = try XCTUnwrap(destructive.range(of: "D"))
+        XCTAssertNotNil(destructive[letter].underlineStyle)
+        let fallback = AskDialogView.buttonLabel(ControlAskButton(id: "save", label: "Save", hotkey: "x"),
+                                                 destructive: false)
+        XCTAssertEqual(String(fallback.characters), "[ Save (X) ]")
+        let hint = try XCTUnwrap(fallback.range(of: "X"))
+        XCTAssertNotNil(fallback[hint].underlineStyle)
+    }
+
+    private func event(_ keyCode: UInt16, text: String = "", modifiers: NSEvent.ModifierFlags = []) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: modifiers, timestamp: 0,
+                                      windowNumber: 0, context: nil, characters: text, charactersIgnoringModifiers: text,
+                                      isARepeat: false, keyCode: keyCode))
+    }
+
+    private func descendant<T: NSView>(_ type: T.Type, in view: NSView) -> T? {
+        if let match = view as? T { return match }
+        for child in view.subviews {
+            if let match = descendant(type, in: child) { return match }
+        }
+        return nil
+    }
+
+    private func brightSamples(in bitmap: NSBitmapImageRep) -> Int {
+        var count = 0
+        for y in stride(from: 0, to: bitmap.pixelsHigh, by: 4) {
+            for x in stride(from: 0, to: bitmap.pixelsWide, by: 4) {
+                if let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB), color.redComponent > 0.65 {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+}

--- a/agtermTests/ControlServerAskTests.swift
+++ b/agtermTests/ControlServerAskTests.swift
@@ -1,0 +1,314 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+@MainActor
+final class ControlServerAskTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+    private var server: ControlServer!
+    private var registeredIDs: Set<UUID> = []
+    private var windows: [UUID: NSWindow] = [:]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-ask-\(UUID().uuidString)")
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+            let settings = SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir))
+            server = ControlServer(library: library, actions: actions, settingsModel: settings,
+                                   identity: AppIdentity(version: "9.9.9", commit: "testsha"),
+                                   socketPath: stateDir.appendingPathComponent("control.sock").path)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            for id in registeredIDs {
+                PickRegistry.shared.unregister(id)
+                TerminalZoomRegistry.shared.unregister(id)
+                DashboardControllerRegistry.shared.unregister(id)
+            }
+            for (id, window) in windows {
+                WindowRegistry.shared.unregister(id)
+                window.close()
+            }
+            registeredIDs.removeAll()
+            windows.removeAll()
+            server = nil
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testOpenWithoutRegisteredControllerFails() {
+        XCTAssertEqual(open(makeAsk()), ControlResponse(ok: false, error: "no ask surface"))
+    }
+
+    func testUnanchoredOpenReservesTheWindowAndClosesItsPalette() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let palette = PaletteController()
+        palette.open(.actions)
+        actions.palette = palette
+        let ask = makeAsk()
+
+        XCTAssertEqual(open(ask), ControlResponse(ok: true, result: ControlResult(id: ask.id)))
+        XCTAssertEqual(controller.pendingAsk, ask)
+        XCTAssertNil(controller.pendingAsk?.anchor)
+        XCTAssertNil(palette.mode)
+        XCTAssertEqual(server.controlTree(window: nil).result?.tree?.askPending, ask.id)
+        XCTAssertNil(server.controlTree(window: nil).result?.tree?.pickPending)
+    }
+
+    func testSessionTargetPinsOwnerAcrossFrontmostWindowChange() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let controller = register(ownerID)
+        let frontmostID = library.newWindow(name: "frontmost").id
+        let palette = PaletteController()
+        palette.open(.actions)
+        actions.palette = palette
+        let ask = makeAsk()
+
+        XCTAssertEqual(open(ask, target: session.id.uuidString), ControlResponse(ok: true, result: ControlResult(id: ask.id)))
+        XCTAssertEqual(controller.pendingAsk?.anchor, AskAnchor(sessionID: session.id))
+        XCTAssertEqual(library.activeWindowID, frontmostID)
+        XCTAssertEqual(palette.mode, .actions)
+        XCTAssertEqual(server.controlTree(window: ownerID.uuidString).result?.tree?.askPending, ask.id)
+        XCTAssertNil(server.controlTree(window: frontmostID.uuidString).result?.tree?.askPending)
+    }
+
+    func testFollowRaisesOwnerAndClosesPalette() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        _ = register(ownerID)
+        _ = library.newWindow(name: "frontmost")
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        windows[ownerID] = window
+        WindowRegistry.shared.register(ownerID, window: window)
+        let palette = PaletteController()
+        palette.open(.sessions)
+        actions.palette = palette
+
+        XCTAssertTrue(open(makeAsk(), window: ownerID.uuidString, follow: true).ok)
+        XCTAssertEqual(library.frontmostWindowID, ownerID)
+        XCTAssertTrue(window.isVisible)
+        XCTAssertNil(palette.mode)
+    }
+
+    func testHiddenSessionRejectsWithoutSelectingIt() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let store = try XCTUnwrap(library.activeStore)
+        let hidden = try XCTUnwrap(store.activeSession)
+        let workspace = try XCTUnwrap(store.workspaces.first)
+        let selected = try XCTUnwrap(store.addSession(toWorkspace: workspace.id, cwd: "/tmp"))
+        let controller = register(windowID)
+
+        XCTAssertEqual(open(makeAsk(), target: hidden.id.uuidString),
+                       ControlResponse(ok: false, error: "session not visible"))
+        XCTAssertEqual(store.selectedSessionID, selected.id)
+        XCTAssertNil(controller.pendingAsk)
+    }
+
+    func testPaneTokenOverridesRoleAndCapturesStableIdentity() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        configureSplit(session)
+        let ask = makeAsk()
+        let response = open(ask, target: session.id.uuidString,
+                            placement: ControlAskPlacement(pane: .left, paneID: "right-token"))
+
+        XCTAssertEqual(response, ControlResponse(ok: true, result: ControlResult(id: ask.id, pane: "right")))
+        XCTAssertEqual(controller.pendingAsk?.anchor,
+                       AskAnchor(sessionID: session.id, pane: .right, paneIdentity: session.splitPaneIdentity))
+        XCTAssertEqual(controller.pendingAsk?.title, ask.title)
+        XCTAssertEqual(controller.pendingAsk?.message, ask.message)
+        XCTAssertEqual(controller.pendingAsk?.buttons, ask.buttons)
+        XCTAssertEqual(controller.pendingAsk?.defaultID, ask.defaultID)
+        XCTAssertEqual(controller.pendingAsk?.cancelID, ask.cancelID)
+        XCTAssertEqual(controller.pendingAsk?.destructiveID, ask.destructiveID)
+    }
+
+    func testHiddenPaneRejectsButVisibleMaximizedPaneOpens() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        configureSplit(session)
+        session.isSplit = false
+        session.splitFocused = false
+        let placement = ControlAskPlacement(pane: .right)
+
+        XCTAssertEqual(open(makeAsk(), target: session.id.uuidString, placement: placement),
+                       ControlResponse(ok: false, error: "pane not visible"))
+        XCTAssertNil(controller.pendingAsk)
+        session.splitFocused = true
+        XCTAssertTrue(open(makeAsk(), target: session.id.uuidString, placement: placement).ok)
+        XCTAssertEqual(controller.pendingAsk?.anchor?.paneIdentity, session.splitPaneIdentity)
+    }
+
+    func testUnknownAndScratchTokensRejectWithoutTakingSlot() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        session.scratchSurface = AskTestSurface(token: "scratch-token")
+
+        XCTAssertEqual(open(makeAsk(), target: session.id.uuidString, placement: ControlAskPlacement(paneID: "missing")),
+                       ControlResponse(ok: false, error: "unknown pane id: missing"))
+        XCTAssertEqual(open(makeAsk(), target: session.id.uuidString, placement: ControlAskPlacement(paneID: "scratch-token")),
+                       ControlResponse(ok: false, error: "ask pane must be left or right"))
+        XCTAssertNil(controller.pendingAsk)
+    }
+
+    func testUnresolvedTokenUsesExplicitRoleFallback() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let ask = makeAsk()
+
+        XCTAssertEqual(open(ask, target: session.id.uuidString, placement: ControlAskPlacement(pane: .left, paneID: "old")),
+                       ControlResponse(ok: true, result: ControlResult(id: ask.id, pane: "left")))
+        XCTAssertEqual(controller.pendingAsk?.anchor?.paneIdentity, session.paneIdentity)
+    }
+
+    func testAnchoredOpenRejectsZoomWhileUnanchoredOpenRemainsAvailable() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        _ = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let zoom = TerminalZoomController()
+        TerminalZoomRegistry.shared.register(windowID, controller: zoom)
+        zoom.set(.on, target: .session(session.id, .primary))
+
+        XCTAssertEqual(open(makeAsk(), target: session.id.uuidString),
+                       ControlResponse(ok: false, error: "session not visible"))
+        XCTAssertTrue(open(makeAsk()).ok)
+        XCTAssertEqual(zoom.target, .session(session.id, .primary))
+    }
+
+    func testAnchoredOpenRejectsDashboardWhileUnanchoredOpenRemainsAvailable() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        _ = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let dashboard = DashboardController()
+        DashboardControllerRegistry.shared.register(windowID, controller: dashboard)
+        dashboard.open(members: [DashboardMember(session: session.id, surface: .primary)])
+
+        XCTAssertEqual(open(makeAsk(), target: session.id.uuidString),
+                       ControlResponse(ok: false, error: "session not visible"))
+        XCTAssertTrue(open(makeAsk()).ok)
+        XCTAssertTrue(dashboard.isOpen)
+    }
+
+    func testOpenRejectsEitherExistingModalOwner() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let pick = PendingPick(id: "pick", items: [ControlPickItem(id: "one", label: "One")])
+        XCTAssertTrue(controller.open(pick))
+        XCTAssertEqual(open(makeAsk()), ControlResponse(ok: false, error: "pick already pending"))
+        XCTAssertEqual(controller.pending, pick)
+        controller.cancel()
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+        XCTAssertEqual(open(makeAsk()), ControlResponse(ok: false, error: "ask already pending"))
+        XCTAssertEqual(controller.pendingAsk?.id, ask.id)
+    }
+
+    func testResultsAndCancellationFollowIDAndRejectWindowMismatch() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        let owner = register(ownerID)
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+        let otherID = library.newWindow(name: "other").id
+        _ = register(otherID)
+
+        XCTAssertEqual(server.askResult(ask.id, window: nil).result?.ask, ControlAskResult(result: .pending))
+        XCTAssertEqual(server.askResult(ask.id, window: otherID.uuidString),
+                       ControlResponse(ok: false, error: "unknown ask: \(ask.id)"))
+        XCTAssertFalse(server.cancelAsk(ask.id, window: otherID.uuidString).ok)
+        XCTAssertEqual(owner.pendingAsk?.id, ask.id)
+        XCTAssertTrue(server.cancelAsk(ask.id, window: nil).ok)
+        XCTAssertEqual(server.askResult(ask.id, window: ownerID.uuidString).result?.ask, ControlAskResult(result: .cancelled))
+        XCTAssertTrue(server.cancelAsk(ask.id, window: ownerID.uuidString).ok)
+        XCTAssertNil(server.controlTree(window: ownerID.uuidString).result?.tree?.askPending)
+        XCTAssertFalse(server.askResult("unknown", window: nil).ok)
+        XCTAssertFalse(server.cancelAsk("unknown", window: nil).ok)
+    }
+
+    func testRetainedResultSurvivesClosingAllWindows() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        _ = register(ownerID)
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+        PickRegistry.shared.unregister(ownerID)
+        library.closeWindow(ownerID)
+
+        XCTAssertNil(library.activeStore)
+        XCTAssertEqual(server.askResult(ask.id, window: nil).result?.ask, ControlAskResult(result: .cancelled))
+        XCTAssertEqual(server.askResult(ask.id, window: ownerID.uuidString).result?.ask, ControlAskResult(result: .cancelled))
+        XCTAssertTrue(server.cancelAsk(ask.id, window: nil).ok)
+        XCTAssertTrue(server.cancelAsk(ask.id, window: ownerID.uuidString).ok)
+        let otherID = library.newWindow(name: "other").id
+        XCTAssertFalse(server.askResult(ask.id, window: otherID.uuidString).ok)
+        XCTAssertFalse(server.cancelAsk(ask.id, window: otherID.uuidString).ok)
+    }
+
+    func testCancellingAnAnsweredAskLeavesTheNextPendingAskAlone() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(ownerID)
+        let first = makeAsk()
+        XCTAssertTrue(open(first).ok)
+        let answer = ControlAskResult(result: .answered, id: "yes", label: "Yes", index: 0)
+        controller.resolveAsk(answer)
+        let next = makeAsk()
+        XCTAssertTrue(open(next).ok)
+
+        XCTAssertTrue(server.cancelAsk(first.id, window: nil).ok)
+        XCTAssertEqual(server.askResult(first.id, window: nil).result?.ask, answer)
+        XCTAssertEqual(controller.pendingAsk?.id, next.id)
+    }
+
+    private func register(_ windowID: UUID) -> PickController {
+        let controller = PickController()
+        PickRegistry.shared.register(windowID, controller: controller)
+        registeredIDs.insert(windowID)
+        return controller
+    }
+
+    private func configureSplit(_ session: Session) {
+        session.hasSplit = true
+        session.isSplit = true
+        session.splitPaneIdentity = UUID()
+        session.surface = AskTestSurface(token: "left-token")
+        session.splitSurface = AskTestSurface(token: "right-token")
+    }
+
+    private func makeAsk() -> PendingAsk {
+        PendingAsk(id: UUID().uuidString, title: "Continue?", message: "Choose an action.", buttons: [
+            ControlAskButton(id: "yes", label: "Yes"), ControlAskButton(id: "no", label: "No"),
+            ControlAskButton(id: "delete", label: "Delete"),
+        ], defaultID: "yes", cancelID: "no", destructiveID: "delete")
+    }
+
+    private func open(_ ask: PendingAsk, target: String? = nil, window: String? = nil,
+                      placement: ControlAskPlacement = ControlAskPlacement(), follow: Bool = false) -> ControlResponse {
+        server.openAsk(ask, target: target, window: window, placement: placement, follow: follow)
+    }
+}
+
+@MainActor
+private final class AskTestSurface: TerminalSurface {
+    let paneToken: String
+    let isRealized = true
+
+    init(token: String) { paneToken = token }
+    func teardown() {}
+    func promoteToPrimaryPane() {}
+}

--- a/agtermTests/ControlServerAskTests.swift
+++ b/agtermTests/ControlServerAskTests.swift
@@ -134,7 +134,8 @@ final class ControlServerAskTests: XCTestCase {
         XCTAssertEqual(controller.pendingAsk?.message, ask.message)
         XCTAssertEqual(controller.pendingAsk?.buttons, ask.buttons)
         XCTAssertEqual(controller.pendingAsk?.defaultID, ask.defaultID)
-        XCTAssertEqual(controller.pendingAsk?.cancelID, ask.cancelID)
+        XCTAssertEqual(controller.pendingAsk?.style, .gui)
+        XCTAssertEqual(controller.pendingAsk?.align, .left)
         XCTAssertEqual(controller.pendingAsk?.destructiveID, ask.destructiveID)
     }
 
@@ -306,7 +307,7 @@ final class ControlServerAskTests: XCTestCase {
         XCTAssertEqual(controller.pendingAsk?.id, ask.id)
     }
 
-    func testCommandWAnswersCancelWithoutClosingSessionOrZoom() throws {
+    func testCommandWEscapesWithoutClosingSessionOrZoom() throws {
         let windowID = try XCTUnwrap(library.activeWindowID)
         let controller = register(windowID)
         let session = try XCTUnwrap(library.activeStore?.activeSession)
@@ -319,27 +320,27 @@ final class ControlServerAskTests: XCTestCase {
         XCTAssertTrue(actions.closeActiveSession())
 
         XCTAssertEqual(controller.askResult(for: ask.id),
-                       ControlAskResult(result: .answered, id: "no", label: "No", index: 1))
+                       ControlAskResult(result: .escaped))
         XCTAssertEqual(zoom.target, .session(session.id, .primary))
         XCTAssertEqual(library.activeStore?.activeSession?.id, session.id)
     }
 
-    func testCommandWWithoutCancelButtonReturnsCancelled() throws {
+    func testCommandWReturnsEscaped() throws {
         let windowID = try XCTUnwrap(library.activeWindowID)
         let controller = register(windowID)
         let ask = PendingAsk(id: UUID().uuidString, title: "Continue?", buttons: [ControlAskButton(id: "yes", label: "Yes")])
         XCTAssertTrue(open(ask).ok)
         XCTAssertTrue(actions.closeActiveSession())
-        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .cancelled))
+        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .escaped))
     }
 
-    func testAdministrativeDismissalNeverAnswersTheCancelButton() throws {
+    func testEscapeReleasesTheModalSlot() throws {
         let windowID = try XCTUnwrap(library.activeWindowID)
         let controller = register(windowID)
         let ask = makeAsk()
         XCTAssertTrue(open(ask).ok)
-        XCTAssertTrue(actions.dismissPendingAsk(for: windowID, userInitiated: false))
-        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .cancelled))
+        XCTAssertTrue(actions.escapePendingAsk(for: windowID))
+        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .escaped))
     }
 
     func testTerminationCancelsBothFamiliesAcrossWindows() throws {
@@ -401,7 +402,7 @@ final class ControlServerAskTests: XCTestCase {
         PendingAsk(id: UUID().uuidString, title: "Continue?", message: "Choose an action.", buttons: [
             ControlAskButton(id: "yes", label: "Yes"), ControlAskButton(id: "no", label: "No"),
             ControlAskButton(id: "delete", label: "Delete"),
-        ], defaultID: "yes", cancelID: "no", destructiveID: "delete")
+        ], defaultID: "yes", destructiveID: "delete", style: .gui, align: .left)
     }
 
     private func open(_ ask: PendingAsk, target: String? = nil, window: String? = nil,

--- a/agtermTests/ControlServerAskTests.swift
+++ b/agtermTests/ControlServerAskTests.swift
@@ -136,6 +136,7 @@ final class ControlServerAskTests: XCTestCase {
         XCTAssertEqual(controller.pendingAsk?.defaultID, ask.defaultID)
         XCTAssertEqual(controller.pendingAsk?.style, .gui)
         XCTAssertEqual(controller.pendingAsk?.align, .left)
+        XCTAssertEqual(controller.pendingAsk?.width, 50)
         XCTAssertEqual(controller.pendingAsk?.destructiveID, ask.destructiveID)
     }
 
@@ -402,7 +403,7 @@ final class ControlServerAskTests: XCTestCase {
         PendingAsk(id: UUID().uuidString, title: "Continue?", message: "Choose an action.", buttons: [
             ControlAskButton(id: "yes", label: "Yes"), ControlAskButton(id: "no", label: "No"),
             ControlAskButton(id: "delete", label: "Delete"),
-        ], defaultID: "yes", destructiveID: "delete", style: .gui, align: .left)
+        ], defaultID: "yes", destructiveID: "delete", style: .gui, align: .left, width: 50)
     }
 
     private func open(_ ask: PendingAsk, target: String? = nil, window: String? = nil,

--- a/agtermTests/ControlServerAskTests.swift
+++ b/agtermTests/ControlServerAskTests.swift
@@ -275,6 +275,113 @@ final class ControlServerAskTests: XCTestCase {
         XCTAssertEqual(controller.pendingAsk?.id, next.id)
     }
 
+    func testAskBlocksControlCoversAndSearchButAllowsDismissals() async throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        configureSplit(session)
+        let controller = register(windowID)
+        TerminalZoomRegistry.shared.register(windowID, controller: TerminalZoomController())
+        DashboardControllerRegistry.shared.register(windowID, controller: DashboardController())
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+        let blocked = ControlResponse(ok: false, error: "ask pending")
+
+        XCTAssertEqual(server.setQuickTerminal(mode: "show"), blocked)
+        XCTAssertEqual(server.setSurfaceZoom(nil, window: windowID.uuidString, mode: .on), blocked)
+        XCTAssertEqual(server.setSurfaceZoom(TerminalZoomTarget.session(session.id, .primary).controlID,
+                                             window: windowID.uuidString, mode: .on), blocked)
+        XCTAssertEqual(server.setDashboard(targets: [session.id.uuidString], window: windowID.uuidString,
+                                           close: false, fontMode: .untouched, mru: false), blocked)
+        let searchOpen = await server.searchSession(session.id, store: store, text: "needle", to: nil)
+        XCTAssertEqual(searchOpen, blocked)
+        let searchNext = await server.searchSession(session.id, store: store, text: nil, to: "next")
+        XCTAssertEqual(searchNext, blocked)
+        let searchClose = await server.searchSession(session.id, store: store, text: nil, to: "close")
+        XCTAssertTrue(searchClose.ok)
+        XCTAssertTrue(server.setQuickTerminal(mode: "hide").ok)
+        XCTAssertTrue(server.setSurfaceZoom(nil, window: windowID.uuidString, mode: .off).ok)
+        XCTAssertTrue(server.setDashboard(targets: [], window: windowID.uuidString,
+                                          close: true, fontMode: .untouched, mru: false).ok)
+        XCTAssertEqual(controller.pendingAsk?.id, ask.id)
+    }
+
+    func testCommandWAnswersCancelWithoutClosingSessionOrZoom() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let zoom = TerminalZoomController()
+        TerminalZoomRegistry.shared.register(windowID, controller: zoom)
+        zoom.set(.on, target: .session(session.id, .primary))
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+
+        XCTAssertTrue(actions.closeActiveSession())
+
+        XCTAssertEqual(controller.askResult(for: ask.id),
+                       ControlAskResult(result: .answered, id: "no", label: "No", index: 1))
+        XCTAssertEqual(zoom.target, .session(session.id, .primary))
+        XCTAssertEqual(library.activeStore?.activeSession?.id, session.id)
+    }
+
+    func testCommandWWithoutCancelButtonReturnsCancelled() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let ask = PendingAsk(id: UUID().uuidString, title: "Continue?", buttons: [ControlAskButton(id: "yes", label: "Yes")])
+        XCTAssertTrue(open(ask).ok)
+        XCTAssertTrue(actions.closeActiveSession())
+        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .cancelled))
+    }
+
+    func testAdministrativeDismissalNeverAnswersTheCancelButton() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(windowID)
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+        XCTAssertTrue(actions.dismissPendingAsk(for: windowID, userInitiated: false))
+        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .cancelled))
+    }
+
+    func testTerminationCancelsBothFamiliesAcrossWindows() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        let controller = register(ownerID)
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+        let otherID = library.newWindow(name: "other").id
+        let pick = register(otherID)
+        XCTAssertTrue(pick.open(PendingPick(id: "termination-pick", items: [ControlPickItem(id: "one", label: "One")])))
+        let counts = library.openCounts()
+
+        NotificationCenter.default.post(name: NSApplication.willTerminateNotification, object: NSApp)
+
+        XCTAssertEqual(controller.askResult(for: ask.id), ControlAskResult(result: .cancelled))
+        XCTAssertEqual(pick.result(for: "termination-pick"), ControlPickResult(result: .cancelled))
+        XCTAssertEqual(library.openCounts().windows, counts.windows)
+        XCTAssertEqual(library.openCounts().sessions, counts.sessions)
+    }
+
+    func testAskUsesSharedMenuAndWindowFocusGates() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        _ = register(ownerID)
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        windows[ownerID] = window
+        WindowRegistry.shared.register(ownerID, window: window)
+        let ask = makeAsk()
+        XCTAssertTrue(open(ask).ok)
+
+        XCTAssertFalse(actions.uiActionsEnabled)
+        XCTAssertTrue(actions.paletteContext.modalActive)
+        XCTAssertTrue(actions.pickActive(for: ownerID))
+        XCTAssertTrue(GhosttySurfaceView.pickOwnsFocus(in: window))
+        XCTAssertFalse(actions.pickActive(for: UUID()))
+        XCTAssertTrue(server.cancelAsk(ask.id, window: nil).ok)
+        XCTAssertTrue(actions.uiActionsEnabled)
+        XCTAssertFalse(actions.paletteContext.modalActive)
+        XCTAssertFalse(GhosttySurfaceView.pickOwnsFocus(in: window))
+    }
+
     private func register(_ windowID: UUID) -> PickController {
         let controller = PickController()
         PickRegistry.shared.register(windowID, controller: controller)

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -97,6 +97,20 @@ final class ControlServerPickTests: XCTestCase {
         XCTAssertEqual(controller.pending, first)
     }
 
+    func testOpenRefusedByPendingAskNamesTheAsk() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(windowID)
+        let ask = PendingAsk(id: "ask", title: "Continue?", buttons: [ControlAskButton(id: "yes", label: "Yes")])
+        XCTAssertTrue(controller.openAsk(ask))
+
+        XCTAssertEqual(
+            server.openPick(makePick("second"), window: nil, follow: false),
+            ControlResponse(ok: false, error: "ask already pending")
+        )
+        XCTAssertEqual(controller.pendingAsk, ask)
+        XCTAssertNil(controller.pending)
+    }
+
     func testOpenOnFrontmostWindowClosesBuiltInPaletteAndReturnsID() throws {
         let windowID = try XCTUnwrap(library.activeWindowID)
         let controller = registerPick(windowID)

--- a/agtermUITests/ControlAPITestCase.swift
+++ b/agtermUITests/ControlAPITestCase.swift
@@ -468,6 +468,63 @@ class ControlAPITestCase: XCTestCase {
 
     // MARK: - Socket client
 
+    var askDialog: XCUIElement {
+        app.descendants(matching: .any).matching(identifier: "ask-dialog").firstMatch
+    }
+
+    func askButton(_ id: String) -> XCUIElement {
+        app.buttons.matching(identifier: "ask-button-\(id)").firstMatch
+    }
+
+    func clickAskButton(_ id: String) {
+        XCTAssertTrue(askButton(id).waitForExistence(timeout: 5))
+        let matches = app.buttons.matching(identifier: "ask-button-\(id)")
+        (matches.allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch).click()
+    }
+
+    func sendControlCommand(_ command: String, target: String? = nil,
+                            args: [String: Any]? = nil) throws -> [String: Any] {
+        var request: [String: Any] = ["cmd": command]
+        if let target { request["target"] = target }
+        if let args { request["args"] = args }
+        let data = try JSONSerialization.data(withJSONObject: request)
+        return try sendCommand(String(decoding: data, as: UTF8.self))
+    }
+
+    func openAsk(_ buttons: [[String: Any]], title: String = "Choose an action",
+                 target: String? = nil, options: [String: Any] = [:]) throws -> String {
+        var args = options
+        args["buttons"] = buttons
+        args["title"] = title
+        let response = try sendControlCommand("ask.open", target: target, args: args)
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        return try XCTUnwrap((response["result"] as? [String: Any])?["id"] as? String)
+    }
+
+    func askResult(_ id: String, window: String? = nil) throws -> [String: Any] {
+        let response = try sendControlCommand("ask.result", target: id, args: window.map { ["window": $0] })
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        return try XCTUnwrap((response["result"] as? [String: Any])?["ask"] as? [String: Any])
+    }
+
+    func awaitAskResult(_ id: String, window: String? = nil, timeout: TimeInterval = 10) throws -> [String: Any] {
+        let deadline = Date().addingTimeInterval(timeout)
+        var result = try askResult(id, window: window)
+        while result["result"] as? String == "pending", Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            result = try askResult(id, window: window)
+        }
+        XCTAssertNotEqual(result["result"] as? String, "pending")
+        return result
+    }
+
+    func treeAskPending(window: String? = nil) throws -> String? {
+        let response = try sendControlCommand("tree", args: window.map { ["window": $0] })
+        XCTAssertEqual(response["ok"] as? Bool, true, "\(response)")
+        let tree = try XCTUnwrap((response["result"] as? [String: Any])?["tree"] as? [String: Any])
+        return tree["askPending"] as? String
+    }
+
     /// Connect to the app's control socket, send `line` (newline-terminated), read the single response
     /// line, and parse it as JSON. Retries the connect briefly since the server's scene `.task` may bind a
     /// beat after the window appears.

--- a/agtermUITests/ControlAPITestCase.swift
+++ b/agtermUITests/ControlAPITestCase.swift
@@ -507,6 +507,22 @@ class ControlAPITestCase: XCTestCase {
         return try XCTUnwrap((response["result"] as? [String: Any])?["ask"] as? [String: Any])
     }
 
+    func openAskCLI(_ arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = Bundle.main.bundleURL.deletingLastPathComponent()
+            .appendingPathComponent("agterm.app/Contents/MacOS/agtermctl")
+        process.arguments = ["ask", "Choose an action", "--no-block", "--socket", socketPath] + arguments
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, String(decoding: data, as: UTF8.self))
+        let result = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return try XCTUnwrap(result["id"] as? String)
+    }
+
     func awaitAskResult(_ id: String, window: String? = nil, timeout: TimeInterval = 10) throws -> [String: Any] {
         let deadline = Date().addingTimeInterval(timeout)
         var result = try askResult(id, window: window)

--- a/agtermUITests/ControlAskUITests.swift
+++ b/agtermUITests/ControlAskUITests.swift
@@ -2,6 +2,76 @@ import XCTest
 
 @MainActor
 final class ControlAskUITests: ControlAPITestCase {
+    func testButtonBlockAlignmentInBothStylesAndLayouts() throws {
+        for style in ["terminal", "gui"] {
+            for vertical in [false, true] {
+                let label = vertical ? "A longer choice that forces the button row to wrap" : "First"
+                for align in ["left", "center", "right"] {
+                    let id = try openAsk([["id": "first", "label": label], ["id": "last", "label": label]],
+                                         options: ["style": style, "align": align])
+                    XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+                    let first = askButton("first").frame
+                    let last = askButton("last").frame
+                    let block = first.union(last)
+                    let panel = askDialog.frame
+                    if vertical {
+                        XCTAssertGreaterThan(last.midY, first.midY)
+                    } else {
+                        XCTAssertEqual(first.midY, last.midY, accuracy: 1)
+                        XCTAssertGreaterThan(last.midX, first.midX)
+                    }
+                    switch align {
+                    case "left": XCTAssertLessThan(block.midX, panel.midX - 5)
+                    case "right": XCTAssertGreaterThan(block.midX, panel.midX + 5)
+                    default: XCTAssertEqual(block.midX, panel.midX, accuracy: 2)
+                    }
+                    clickAskButton("last")
+                    XCTAssertEqual(try awaitAskResult(id)["index"] as? Int, 1)
+                    XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+                }
+            }
+        }
+    }
+
+    func testCLIDefaultThenReturnAnswersDefault() throws {
+        let id = try openAskCLI(["--button", "yes=Yes", "--button", "no=No", "--default", "no"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "no")
+    }
+
+    func testUnanchoredDialogExcludesVisibleSidebar() throws {
+        let response = try sendControlCommand("tree")
+        let tree = try XCTUnwrap((response["result"] as? [String: Any])?["tree"] as? [String: Any])
+        XCTAssertEqual(tree["sidebarVisible"] as? Bool, true)
+        let width = try XCTUnwrap(tree["sidebarWidth"] as? Double)
+        let id = try openAsk([["id": "ok", "label": "OK"]])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertGreaterThanOrEqual(askDialog.frame.minX, app.windows.firstMatch.frame.minX + width)
+        clickAskButton("ok")
+        XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "ok")
+    }
+
+    func testCLIArrowMovesFromDefaultToSecondButton() throws {
+        let id = try openAskCLI(["--button", "yes=Yes", "--button", "no=No", "--default", "yes"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        app.typeKey(.rightArrow, modifierFlags: [])
+        app.typeKey(.return, modifierFlags: [])
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["id"] as? String, "no")
+        XCTAssertEqual(result["index"] as? Int, 1)
+    }
+
+    func testCLIGUIStyleAnswersByNativeButtonClick() throws {
+        let id = try openAskCLI(["--style", "gui", "--button", "yes=Yes", "--button", "no=No", "--default", "yes"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["ask-button-no"].waitForExistence(timeout: 5))
+        clickAskButton("no")
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "answered")
+        XCTAssertEqual(result["id"] as? String, "no")
+    }
+
     func testRenderClickReturnsCallerButtonAndClearsPending() throws {
         let id = try openAsk([
             ["id": "save", "label": "Save"],
@@ -24,23 +94,55 @@ final class ControlAskUITests: ControlAPITestCase {
         XCTAssertNil(try treeAskPending())
     }
 
-    func testReturnIsInertUntilTabSelectsFirstButton() throws {
-        let id = try openAsk([["id": "yes", "label": "Yes"], ["id": "no", "label": "No"]])
-        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
-
-        app.typeKey(.return, modifierFlags: [])
-
-        XCTAssertFalse(askDialog.waitForNonExistence(timeout: 1))
-        XCTAssertEqual(try askResult(id)["result"] as? String, "pending")
-        app.typeKey(.tab, modifierFlags: [])
-        app.typeKey(.return, modifierFlags: [])
-        let result = try awaitAskResult(id)
-        XCTAssertEqual(result["result"] as? String, "answered")
-        XCTAssertEqual(result["id"] as? String, "yes")
-        XCTAssertEqual(result["index"] as? Int, 0)
+    func testReturnWithoutDefaultAnswersFirstNonDestructiveButton() throws {
+        for style in ["terminal", "gui"] {
+            let id = try openAsk([["id": "delete", "label": "Delete"], ["id": "keep", "label": "Keep"]],
+                                 options: ["style": style, "destructiveButton": "delete"])
+            XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+            XCTAssertEqual(askButton("keep").value as? String, "selected")
+            XCTAssertEqual(askButton("delete").value as? String, "")
+            app.typeKey(.return, modifierFlags: [])
+            let result = try awaitAskResult(id)
+            XCTAssertEqual(result["result"] as? String, "answered")
+            XCTAssertEqual(result["id"] as? String, "keep")
+            XCTAssertEqual(result["index"] as? Int, 1)
+            XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+        }
     }
 
-    func testHotkeyAnswersWithoutAnInitialHighlight() throws {
+    func testGUIHighlightMovesWithArrowsAndTab() throws {
+        let id = try openAsk([["id": "keep", "label": "Keep"], ["id": "delete", "label": "Delete", "hotkey": "d"]],
+                             options: ["style": "gui", "destructiveButton": "delete"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertEqual(askButton("keep").value as? String, "selected")
+        app.typeKey(.rightArrow, modifierFlags: [])
+        XCTAssertEqual(askButton("delete").value as? String, "selected")
+        XCTAssertEqual(askButton("keep").value as? String, "")
+        app.typeKey(.tab, modifierFlags: [])
+        XCTAssertEqual(askButton("keep").value as? String, "selected")
+        app.typeKey(.tab, modifierFlags: .shift)
+        XCTAssertEqual(askButton("delete").value as? String, "selected")
+        app.typeKey(.leftArrow, modifierFlags: [])
+        XCTAssertEqual(askButton("keep").value as? String, "selected")
+        app.typeKey("d", modifierFlags: [])
+        XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "delete")
+    }
+
+    func testGUICLIRightThenReturnAndEscape() throws {
+        let arguments = ["--style", "gui", "--button", "first=First", "--button", "second=Second"]
+        let id = try openAskCLI(arguments)
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        app.typeKey(.rightArrow, modifierFlags: [])
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "second")
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+        let escaped = try openAskCLI(arguments)
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertEqual(try awaitAskResult(escaped)["result"] as? String, "escaped")
+    }
+
+    func testHotkeyAnswersIndependentlyOfHighlight() throws {
         let id = try openAsk([
             ["id": "yes", "label": "Yes", "hotkey": "y"],
             ["id": "no", "label": "No", "hotkey": "n"],
@@ -55,42 +157,32 @@ final class ControlAskUITests: ControlAPITestCase {
         XCTAssertEqual(result["index"] as? Int, 1)
     }
 
-    func testEscapeUsesNamedCancelOrReturnsCancelled() throws {
-        let named = try openAsk([["id": "yes", "label": "Yes"], ["id": "later", "label": "Later"]],
-                                options: ["cancelButton": "later"])
+    func testEscapeReturnsEscapedWithoutAButtonAnswer() throws {
+        let id = try openAsk([["id": "cancel", "label": "Cancel"]])
         XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
         app.typeKey(.escape, modifierFlags: [])
-        let answer = try awaitAskResult(named)
-        XCTAssertEqual(answer["result"] as? String, "answered")
-        XCTAssertEqual(answer["id"] as? String, "later")
-        XCTAssertEqual(answer["index"] as? Int, 1)
-        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
-
-        let unnamed = try openAsk([["id": "yes", "label": "Yes"]])
-        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
-        app.typeKey(.escape, modifierFlags: [])
-        let cancelled = try awaitAskResult(unnamed)
-        XCTAssertEqual(cancelled["result"] as? String, "cancelled")
-        XCTAssertNil(cancelled["id"])
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "escaped")
+        XCTAssertNil(result["id"])
         XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
     }
 
-    func testCommandWAnswersCancelWithoutClosingTheWindow() throws {
+    func testCommandWEscapesWithoutClosingTheWindow() throws {
         let session = try activeSessionID()
-        let id = try openAsk([["id": "later", "label": "Later"]], options: ["cancelButton": "later"])
+        let id = try openAsk([["id": "later", "label": "Later"]])
         XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
 
         app.typeKey("w", modifierFlags: .command)
 
         let result = try awaitAskResult(id)
-        XCTAssertEqual(result["result"] as? String, "answered")
-        XCTAssertEqual(result["id"] as? String, "later")
+        XCTAssertEqual(result["result"] as? String, "escaped")
+        XCTAssertNil(result["id"])
         XCTAssertTrue(app.windows.firstMatch.exists)
         XCTAssertEqual(try sessionNode(id: session)["active"] as? Bool, true)
     }
 
     func testOutsideClickKeepsTheQuestionPending() throws {
-        let id = try openAsk([["id": "ok", "label": "OK"]], options: ["cancelButton": "ok"])
+        let id = try openAsk([["id": "ok", "label": "OK"]])
         XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
         let window = app.windows.firstMatch
         let corner = window.coordinate(withNormalizedOffset: CGVector(dx: 0.98, dy: 0.98))
@@ -143,8 +235,8 @@ final class ControlAskUITests: ControlAPITestCase {
         XCTAssertTrue(askDialog.exists)
     }
 
-    func testAdministrativeCancelDoesNotAnswerTheCancelButton() throws {
-        let id = try openAsk([["id": "later", "label": "Later"]], options: ["cancelButton": "later"])
+    func testAdministrativeCancelReturnsCancelled() throws {
+        let id = try openAsk([["id": "later", "label": "Later"]])
         XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
 
         XCTAssertEqual(try sendControlCommand("ask.cancel", target: id)["ok"] as? Bool, true)
@@ -160,7 +252,7 @@ final class ControlAskUITests: ControlAPITestCase {
         let windows = try XCTUnwrap((listed["result"] as? [String: Any])?["windows"] as? [[String: Any]])
         let owner = try XCTUnwrap(windows.first?["id"] as? String)
         XCTAssertEqual(try sendControlCommand("window.new", args: ["name": "keeper", "minimized": true])["ok"] as? Bool, true)
-        let id = try openAsk([["id": "later", "label": "Later"]], options: ["cancelButton": "later", "window": owner])
+        let id = try openAsk([["id": "later", "label": "Later"]], options: ["window": owner])
         XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
 
         XCTAssertEqual(try sendControlCommand("window.close", target: owner)["ok"] as? Bool, true)

--- a/agtermUITests/ControlAskUITests.swift
+++ b/agtermUITests/ControlAskUITests.swift
@@ -1,0 +1,260 @@
+import XCTest
+
+@MainActor
+final class ControlAskUITests: ControlAPITestCase {
+    func testRenderClickReturnsCallerButtonAndClearsPending() throws {
+        let id = try openAsk([
+            ["id": "save", "label": "Save"],
+            ["id": "later", "label": "Not now"],
+        ], title: "Keep these changes?", options: ["message": "Choose what happens next."])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertEqual(app.staticTexts.matching(identifier: "ask-title").firstMatch.value as? String, "Keep these changes?")
+        XCTAssertEqual(app.staticTexts.matching(identifier: "ask-message").firstMatch.value as? String, "Choose what happens next.")
+        XCTAssertEqual(try treeAskPending(), id)
+        XCTAssertTrue(askButton("later").waitForExistence(timeout: 5))
+
+        clickAskButton("later")
+
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "answered")
+        XCTAssertEqual(result["id"] as? String, "later")
+        XCTAssertEqual(result["label"] as? String, "Not now")
+        XCTAssertEqual(result["index"] as? Int, 1)
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+        XCTAssertNil(try treeAskPending())
+    }
+
+    func testReturnIsInertUntilTabSelectsFirstButton() throws {
+        let id = try openAsk([["id": "yes", "label": "Yes"], ["id": "no", "label": "No"]])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+
+        app.typeKey(.return, modifierFlags: [])
+
+        XCTAssertFalse(askDialog.waitForNonExistence(timeout: 1))
+        XCTAssertEqual(try askResult(id)["result"] as? String, "pending")
+        app.typeKey(.tab, modifierFlags: [])
+        app.typeKey(.return, modifierFlags: [])
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "answered")
+        XCTAssertEqual(result["id"] as? String, "yes")
+        XCTAssertEqual(result["index"] as? Int, 0)
+    }
+
+    func testHotkeyAnswersWithoutAnInitialHighlight() throws {
+        let id = try openAsk([
+            ["id": "yes", "label": "Yes", "hotkey": "y"],
+            ["id": "no", "label": "No", "hotkey": "n"],
+        ])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+
+        app.typeKey("n", modifierFlags: .shift)
+
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "answered")
+        XCTAssertEqual(result["id"] as? String, "no")
+        XCTAssertEqual(result["index"] as? Int, 1)
+    }
+
+    func testEscapeUsesNamedCancelOrReturnsCancelled() throws {
+        let named = try openAsk([["id": "yes", "label": "Yes"], ["id": "later", "label": "Later"]],
+                                options: ["cancelButton": "later"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        app.typeKey(.escape, modifierFlags: [])
+        let answer = try awaitAskResult(named)
+        XCTAssertEqual(answer["result"] as? String, "answered")
+        XCTAssertEqual(answer["id"] as? String, "later")
+        XCTAssertEqual(answer["index"] as? Int, 1)
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+
+        let unnamed = try openAsk([["id": "yes", "label": "Yes"]])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        app.typeKey(.escape, modifierFlags: [])
+        let cancelled = try awaitAskResult(unnamed)
+        XCTAssertEqual(cancelled["result"] as? String, "cancelled")
+        XCTAssertNil(cancelled["id"])
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+    }
+
+    func testCommandWAnswersCancelWithoutClosingTheWindow() throws {
+        let session = try activeSessionID()
+        let id = try openAsk([["id": "later", "label": "Later"]], options: ["cancelButton": "later"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+
+        app.typeKey("w", modifierFlags: .command)
+
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "answered")
+        XCTAssertEqual(result["id"] as? String, "later")
+        XCTAssertTrue(app.windows.firstMatch.exists)
+        XCTAssertEqual(try sessionNode(id: session)["active"] as? Bool, true)
+    }
+
+    func testOutsideClickKeepsTheQuestionPending() throws {
+        let id = try openAsk([["id": "ok", "label": "OK"]], options: ["cancelButton": "ok"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        let window = app.windows.firstMatch
+        let corner = window.coordinate(withNormalizedOffset: CGVector(dx: 0.98, dy: 0.98))
+        corner.click()
+
+        XCTAssertFalse(askDialog.waitForNonExistence(timeout: 1))
+        XCTAssertEqual(try askResult(id)["result"] as? String, "pending")
+        XCTAssertEqual(try treeAskPending(), id)
+        XCTAssertEqual(try sendControlCommand("ask.cancel", target: id)["ok"] as? Bool, true)
+    }
+
+    func testAskAndPickRejectCompetingOpenRequests() throws {
+        let picked = try sendControlCommand("pick.open", args: ["items": [["id": "one", "label": "One"]]])
+        XCTAssertEqual(picked["ok"] as? Bool, true)
+        let pickID = try XCTUnwrap((picked["result"] as? [String: Any])?["id"] as? String)
+        let picker = app.descendants(matching: .any).matching(identifier: "pick-palette").firstMatch
+        XCTAssertTrue(picker.waitForExistence(timeout: 10))
+        let rejectedAsk = try sendControlCommand("ask.open", args: [
+            "title": "Competing question", "buttons": [["id": "ok", "label": "OK"]],
+        ])
+        XCTAssertEqual(rejectedAsk["ok"] as? Bool, false)
+        XCTAssertNil(try treeAskPending())
+        XCTAssertEqual(try sendControlCommand("pick.cancel", target: pickID)["ok"] as? Bool, true)
+        XCTAssertTrue(picker.waitForNonExistence(timeout: 10))
+
+        let askID = try openAsk([["id": "ok", "label": "OK"]])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        let rejectedPick = try sendControlCommand("pick.open", args: ["items": [["id": "one", "label": "One"]]])
+        XCTAssertEqual(rejectedPick["ok"] as? Bool, false)
+        XCTAssertEqual(try treeAskPending(), askID)
+        XCTAssertEqual(try askResult(askID)["result"] as? String, "pending")
+    }
+
+    func testPendingAskRefusesControlDrivenCovers() throws {
+        let session = try activeSessionID()
+        let id = try openAsk([["id": "ok", "label": "OK"]])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        let requests: [(String, String?, [String: Any])] = [
+            ("dashboard", nil, ["mru": true]),
+            ("quick", nil, ["mode": "show"]),
+            ("session.search", session, ["text": "needle"]),
+            ("surface.zoom", nil, ["mode": "show"]),
+        ]
+        for (command, target, args) in requests {
+            let response = try sendControlCommand(command, target: target, args: args)
+            XCTAssertEqual(response["ok"] as? Bool, false, command)
+            XCTAssertEqual(response["error"] as? String, "ask pending", command)
+        }
+        XCTAssertEqual(try treeAskPending(), id)
+        XCTAssertTrue(askDialog.exists)
+    }
+
+    func testAdministrativeCancelDoesNotAnswerTheCancelButton() throws {
+        let id = try openAsk([["id": "later", "label": "Later"]], options: ["cancelButton": "later"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+
+        XCTAssertEqual(try sendControlCommand("ask.cancel", target: id)["ok"] as? Bool, true)
+
+        let result = try awaitAskResult(id)
+        XCTAssertEqual(result["result"] as? String, "cancelled")
+        XCTAssertNil(result["id"])
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+    }
+
+    func testWindowCloseRetainsTheCancelledResult() throws {
+        let listed = try sendControlCommand("window.list")
+        let windows = try XCTUnwrap((listed["result"] as? [String: Any])?["windows"] as? [[String: Any]])
+        let owner = try XCTUnwrap(windows.first?["id"] as? String)
+        XCTAssertEqual(try sendControlCommand("window.new", args: ["name": "keeper", "minimized": true])["ok"] as? Bool, true)
+        let id = try openAsk([["id": "later", "label": "Later"]], options: ["cancelButton": "later", "window": owner])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+
+        XCTAssertEqual(try sendControlCommand("window.close", target: owner)["ok"] as? Bool, true)
+
+        let result = try awaitAskResult(id, window: owner)
+        XCTAssertEqual(result["result"] as? String, "cancelled")
+        XCTAssertNil(result["id"])
+        XCTAssertEqual(try askResult(id)["result"] as? String, "cancelled")
+    }
+
+    func testRightPaneAnchorFollowsResizeAndCancelsWhenHidden() throws {
+        let session = try activeSessionID()
+        XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "on"])["ok"] as? Bool, true)
+        XCTAssertTrue(try pollSplit(session, timeout: 10))
+        XCTAssertTrue(poll(until: terminalPanes.count == 2, timeout: 10))
+        let right = try XCTUnwrap(terminalPanes.allElementsBoundByIndex.max { $0.frame.minX < $1.frame.minX })
+        let id = try openAsk([["id": "ok", "label": "OK"]], target: session, options: ["pane": "right"])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertGreaterThan(askDialog.frame.width, 0)
+        XCTAssertTrue(poll(until: right.frame.insetBy(dx: -1, dy: -1).contains(askDialog.frame), timeout: 5))
+        let before = askDialog.frame
+        let width = Int(app.windows.firstMatch.frame.width) + 100
+
+        XCTAssertEqual(try sendControlCommand("window.resize", target: "active",
+                                              args: ["width": width, "height": 650])["ok"] as? Bool, true)
+        XCTAssertTrue(poll(until: askDialog.frame.width > before.width, timeout: 5))
+        XCTAssertTrue(right.frame.insetBy(dx: -1, dy: -1).contains(askDialog.frame))
+        XCTAssertEqual(try sendControlCommand("session.focus", target: session, args: ["pane": "left"])["ok"] as? Bool, true)
+        XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "off"])["ok"] as? Bool, true)
+        XCTAssertEqual(try awaitAskResult(id)["result"] as? String, "cancelled")
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+    }
+
+    func testHiddenSessionRejectsAndSelectionChangeCancelsAnchor() throws {
+        let original = try activeSessionID()
+        let created = try sendControlCommand("session.new", args: ["name": "other"])
+        XCTAssertEqual(created["ok"] as? Bool, true)
+        let other = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String)
+        let rejected = try sendControlCommand("ask.open", target: original, args: [
+            "title": "Hidden question", "buttons": [["id": "ok", "label": "OK"]],
+        ])
+        XCTAssertEqual(rejected["ok"] as? Bool, false)
+        XCTAssertEqual(rejected["error"] as? String, "session not visible")
+        XCTAssertNil(try treeAskPending())
+        XCTAssertEqual(try sendControlCommand("session.select", target: original)["ok"] as? Bool, true)
+        let id = try openAsk([["id": "ok", "label": "OK"]], target: original)
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+
+        XCTAssertEqual(try sendControlCommand("session.select", target: other)["ok"] as? Bool, true)
+
+        XCTAssertEqual(try awaitAskResult(id)["result"] as? String, "cancelled")
+        XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+    }
+
+    func testSessionWideAnchorSpansBothPanesAndSurvivesCollapse() throws {
+        let session = try activeSessionID()
+        XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "on"])["ok"] as? Bool, true)
+        XCTAssertTrue(try pollSplit(session, timeout: 10))
+        XCTAssertTrue(poll(until: terminalPanes.count == 2, timeout: 10))
+        let panes = terminalPanes.allElementsBoundByIndex.sorted { $0.frame.minX < $1.frame.minX }
+        let area = panes[0].frame.union(panes[1].frame)
+        let id = try openAsk([["id": "ok", "label": "OK"]], target: session)
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertEqual(askDialog.frame.midX, area.midX, accuracy: 2)
+        XCTAssertGreaterThan(askDialog.frame.width, panes[1].frame.width)
+
+        XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "off"])["ok"] as? Bool, true)
+
+        XCTAssertFalse(askDialog.waitForNonExistence(timeout: 1))
+        XCTAssertEqual(try askResult(id)["result"] as? String, "pending")
+        clickAskButton("ok")
+        XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "ok")
+    }
+
+    func testUnanchoredAskRendersAboveZoomAndAnchoredAskRejects() throws {
+        let session = try activeSessionID()
+        XCTAssertEqual(try sendControlCommand("surface.zoom", args: ["mode": "show"])["ok"] as? Bool, true)
+        XCTAssertTrue(app.buttons["terminal-zoom-exit"].waitForExistence(timeout: 10))
+        let rejected = try sendControlCommand("ask.open", target: session, args: [
+            "title": "Covered session", "buttons": [["id": "ok", "label": "OK"]],
+        ])
+        XCTAssertEqual(rejected["ok"] as? Bool, false)
+        XCTAssertEqual(rejected["error"] as? String, "session not visible")
+        let id = try openAsk([["id": "ok", "label": "OK"]])
+        XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+        XCTAssertTrue(askButton("ok").isHittable)
+
+        clickAskButton("ok")
+
+        XCTAssertEqual(try awaitAskResult(id)["result"] as? String, "answered")
+        XCTAssertTrue(app.buttons["terminal-zoom-exit"].exists)
+    }
+
+    private var terminalPanes: XCUIElementQuery {
+        app.textViews.matching(NSPredicate(format: "label == %@", "Terminal"))
+    }
+}

--- a/agtermUITests/ControlAskUITests.swift
+++ b/agtermUITests/ControlAskUITests.swift
@@ -2,12 +2,52 @@ import XCTest
 
 @MainActor
 final class ControlAskUITests: ControlAPITestCase {
+    func testButtonsShareWidthInBothLayoutsAndStyles() throws {
+        for style in ["terminal", "gui"] {
+            for width in [20, 80] {
+                let id = try openAsk([["id": "ok", "label": "OK"], ["id": "cancel", "label": "Cancel everything"]],
+                                     options: ["style": style, "width": width])
+                XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+                let first = askButton("ok").frame
+                let last = askButton("cancel").frame
+                XCTAssertEqual(first.width, last.width, accuracy: 1)
+                if width == 20 {
+                    XCTAssertGreaterThan(last.midY, first.midY)
+                    XCTAssertGreaterThan(last.height, first.height)
+                } else {
+                    XCTAssertEqual(first.midY, last.midY, accuracy: 1)
+                    XCTAssertGreaterThan(last.midX, first.midX)
+                }
+                clickAskButton("cancel")
+                XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "cancel")
+                XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+            }
+        }
+    }
+
+    func testCLIFixedWidthHonorsRangeInBothStyles() throws {
+        let session = try activeSessionID()
+        let anchor = terminalPanes.firstMatch.frame
+        for style in ["terminal", "gui"] {
+            for width in [10, 50, 100] {
+                let id = try openAskCLI(["--style", style, "--target", session, "--width", String(width), "--button", "ok=OK"])
+                XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
+                XCTAssertEqual(askDialog.frame.width, anchor.width * Double(width) / 100, accuracy: 2)
+                XCTAssertEqual(askDialog.frame.midX, anchor.midX, accuracy: 2)
+                clickAskButton("ok")
+                XCTAssertEqual(try awaitAskResult(id)["id"] as? String, "ok")
+                XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
+            }
+        }
+    }
+
     func testButtonBlockAlignmentInBothStylesAndLayouts() throws {
         for style in ["terminal", "gui"] {
             for vertical in [false, true] {
                 let label = vertical ? "A longer choice that forces the button row to wrap" : "First"
                 for align in ["left", "center", "right"] {
                     let id = try openAsk([["id": "first", "label": label], ["id": "last", "label": label]],
+                                         title: "Choose what happens next for the current working session and its files",
                                          options: ["style": style, "align": align])
                     XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
                     let first = askButton("first").frame
@@ -278,7 +318,7 @@ final class ControlAskUITests: ControlAPITestCase {
 
         XCTAssertEqual(try sendControlCommand("window.resize", target: "active",
                                               args: ["width": width, "height": 650])["ok"] as? Bool, true)
-        XCTAssertTrue(poll(until: askDialog.frame.width > before.width, timeout: 5))
+        XCTAssertTrue(poll(until: askDialog.frame.midX > before.midX, timeout: 5))
         XCTAssertTrue(right.frame.insetBy(dx: -1, dy: -1).contains(askDialog.frame))
         XCTAssertEqual(try sendControlCommand("session.focus", target: session, args: ["pane": "left"])["ok"] as? Bool, true)
         XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "off"])["ok"] as? Bool, true)
@@ -307,7 +347,7 @@ final class ControlAskUITests: ControlAPITestCase {
         XCTAssertTrue(askDialog.waitForNonExistence(timeout: 10))
     }
 
-    func testSessionWideAnchorSpansBothPanesAndSurvivesCollapse() throws {
+    func testSessionWideAnchorCentersAcrossBothPanesAndSurvivesCollapse() throws {
         let session = try activeSessionID()
         XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "on"])["ok"] as? Bool, true)
         XCTAssertTrue(try pollSplit(session, timeout: 10))
@@ -317,7 +357,7 @@ final class ControlAskUITests: ControlAPITestCase {
         let id = try openAsk([["id": "ok", "label": "OK"]], target: session)
         XCTAssertTrue(askDialog.waitForExistence(timeout: 10))
         XCTAssertEqual(askDialog.frame.midX, area.midX, accuracy: 2)
-        XCTAssertGreaterThan(askDialog.frame.width, panes[1].frame.width)
+        XCTAssertLessThanOrEqual(askDialog.frame.width, area.width * 0.9)
 
         XCTAssertEqual(try sendControlCommand("session.split", target: session, args: ["mode": "off"])["ok"] as? Bool, true)
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -201,9 +201,11 @@ teardown call `cancelAsk()`.
   `settingsModel.settings.fontFamily`/`fontSize` (the HUD's `cellSize` lookup).
 - Layout: title (bold), message (wrapped), then buttons in one row when the widest layout fits the anchor
   frame minus padding, else one per row; caller order preserved either way. Width is clamped to the anchor.
+  Content that exceeds the anchor height scrolls; keyboard navigation brings the selected button into view.
   A button reads `[ Label ]`; the highlighted one is drawn in inverse video (foreground and background
   swapped); the hotkey letter is underlined; the `destructive` button carries a leading `!` marker
   (`[ ! Delete ]`) and bold weight, since the app has no access to the theme's ANSI red.
+  A hotkey absent from its label appears as an underlined parenthesized hint.
 - Input: `AskKeyCatcher` (`NSViewRepresentable`, modelled on `DashboardKeyCatcher`) owns first responder
   while mounted and maps Tab/Shift-Tab/arrows/Return/Esc/letters onto `AskNavigation` calls, dropping any
   event with Command, Control, or Option; mouse click on a button activates it; the scrim consumes clicks
@@ -358,24 +360,28 @@ event-arguments rule.
 
 **Files:**
 - Create: `agterm/Views/AskDialogView.swift`
+- Create: `agtermTests/AskDialogViewTests.swift` (native keyboard/scrolling and render attachments)
 - Modify: `agtermCore/Sources/agtermCore/Session.swift` (`askTargetPane`),
   `agtermCore/Tests/agtermCoreTests/SessionTests.swift`
 - Modify: `agterm/Views/WindowContentView.swift` (mount at zIndex 20 beside `pickPaletteOverlay`),
   `agterm/Views/WindowContentView+Detail.swift` (publish `AskAnchorPreferenceKey` from the selected
   session's container and rendered panes)
 
-- [ ] panel with theme colors, terminal font, title/message/buttons, horizontal-or-vertical layout
-- [ ] `AskKeyCatcher` maps key events onto `AskNavigation` (letters without modifiers, Esc, Return, Tab,
+- [x] panel with theme colors, terminal font, title/message/buttons, horizontal-or-vertical layout
+- [x] `AskKeyCatcher` maps key events onto `AskNavigation` (letters without modifiers, Esc, Return, Tab,
       arrows) and nothing else
-- [ ] mouse activation on buttons; scrim swallows clicks; destructive marker and inverse-video highlight
-- [ ] live anchor geometry from the preference in the host's coordinate space (session container, one
+- [x] mouse activation on buttons; scrim swallows clicks; destructive marker and inverse-video highlight
+- [x] live anchor geometry from the preference in the host's coordinate space (session container, one
       pane, or whole-window center); the frame follows resize and sidebar changes
-- [ ] `Session.askTargetPane` resolves the captured identity to its current role; validity from state
+- [x] `Session.askTargetPane` resolves the captured identity to its current role; validity from state
       (selected session, resolved role, `rendersPane`); the host cancels the ask when it fails
-- [ ] test in `SessionTests`: a right-anchored identity resolves to `left` after `closePrimaryPane`
+- [x] test in `SessionTests`: a right-anchored identity resolves to `left` after `closePrimaryPane`
       promotes the survivor, and to nil once the pane is gone
-- [ ] accessibility identifiers
-- [ ] launch an isolated Debug instance and exercise open, keyboard, click, and pane anchoring by hand
+- [x] accessibility identifiers
+- [x] launch isolated Debug with a short explicit socket and fresh-shell state; socket checks passed for
+      resize, hidden-pane cancellation, session collapse, deselection, and pane promotion. Stopped its
+      exact PID with SIGTERM. Live keyboard/click/screen capture skipped: macOS denied the helper those
+      permissions. Native-host keyboard/scrolling tests passed and test-generated renders were inspected.
 
 ### Task 7: CLI command
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -228,12 +228,12 @@ teardown call `cancelAsk()`.
   is geometry movement, allowed; only a different anchor would be relocation, which never happens.
 - Accessibility ids: `ask-dialog`, `ask-title`, `ask-message`, `ask-button-<id>`.
 
-### CLI (`agtermctlKit/MiscCommands.swift`, `Ask` command)
+### CLI (`agtermctlKit/AskCommands.swift`, `Ask` command)
 
 ```
 agtermctl ask TITLE [--message TEXT] --button ID=LABEL [--button ...] [--hotkey ID=K ...]
              [--default ID] [--cancel ID] [--destructive ID]
-             [--target SESSION] [--pane left|right] [--window W] [--follow] [--no-block]
+             [--target SESSION] [--pane left|right] [--pane-id TOKEN] [--window W] [--follow] [--no-block]
 agtermctl ask result ID
 agtermctl ask cancel ID
 ```
@@ -242,6 +242,7 @@ agtermctl ask cancel ID
   attaches a hotkey to a declared button.
 - `--target` is `ask`'s own optional option, not `TargetOptions`, whose default of `active` would turn
   every no-target call into an anchored one and break window-center placement.
+- `--pane-id` exposes the existing stable-token wire field, with the same target requirement as `--pane`.
 - `Ask.self` is registered in `Agtermctl.configuration.subcommands` (`agtermctlKit/Commands.swift`).
 - Default subcommand is open. Blocking poll, delays, abandon-on-transport-failure, and exit codes (0
   answered, 2 cancelled, 1 failure) reuse the pick helpers, generalized to take the outcome kind.
@@ -391,17 +392,17 @@ event-arguments rule.
 - Modify: `agtermCore/Sources/agtermctlKit/MiscCommands.swift` (share the poll loop with pick)
 - Modify: `agtermCore/Sources/agtermctlKit/Commands.swift` (register `Ask.self`)
 - Modify: `agtermCore/Sources/agtermctlKit/SocketClient.swift` (exit code and format helpers)
-- Modify: `agtermCore/Tests/agtermctlKitTests/CommandsTests.swift`,
-  `agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift`
+- Create: `agtermCore/Tests/agtermctlKitTests/AskCommandsTests.swift` (the existing CommandsTests is at its line limit)
+- Modify: `agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift`
 
-- [ ] `Ask` command with `Open` (default), `Result`, `Cancel`; button and hotkey parsing; its own
+- [x] `Ask` command with `Open` (default), `Result`, `Cancel`; button and hotkey parsing; its own
       optional `--target`
-- [ ] register `Ask.self` in the root subcommand list
-- [ ] blocking poll and abandon reuse the pick loop, generalized over the outcome kind
-- [ ] tests through `Agtermctl.parseAsRoot`: every option, `ID=LABEL` split, default subcommand, no
+- [x] register `Ask.self` in the root subcommand list
+- [x] blocking poll and abandon reuse the pick loop, generalized over the outcome kind
+- [x] tests through `Agtermctl.parseAsRoot`: every option, `ID=LABEL` split, default subcommand, no
       target means no `target` in the request, request shaping
-- [ ] tests: exit codes and result formatting
-- [ ] run `swift test` for `agtermctlKitTests`
+- [x] tests: exit codes and result formatting
+- [x] run `swift test --filter agtermctlKitTests` (463 tests passed, using the existing clean scratch path)
 
 ### Task 8: Hosted UI tests
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -145,7 +145,8 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 - `PickController` gains `pendingAsk: PendingAsk?`, `recentAskResults: [ResolvedAsk]`,
   `openAsk(_:) -> Bool`, `resolveAsk(_:)`, `cancelAsk()`, `askResult(for:)`, and the shared predicate
   `modalPending: Bool` (`pending != nil || pendingAsk != nil`). `open`/`openAsk` both refuse while
-  `modalPending`. Retention limits and the resolution sequence are shared with pick.
+  `modalPending`. Each family retains its own history using pick's existing 8/32 caps, so ask traffic
+  does not evict unread pick answers. The resolution sequence is shared with pick.
 - `PickRegistry.unregister` cancels the pending ask and retains its results; `liveAsk(for:)` and
   `retainedAskResult(for:)` mirror the pick lookups.
 - `AskNavigation` (host-free, in `Ask.swift`) holds the highlight state machine: `highlighted: Int?`
@@ -274,17 +275,17 @@ event-arguments rule.
 - Create: `agtermCore/Tests/agtermCoreTests/AskTests.swift`
 - Modify: `agtermCore/Tests/agtermCoreTests/PickTests.swift`
 
-- [ ] add `PendingAsk` and `AskAnchor`
-- [ ] add `pendingAsk`, `recentAskResults`, `openAsk`, `resolveAsk`, `cancelAsk`, `askResult(for:)`, and
+- [x] add `PendingAsk` and `AskAnchor`
+- [x] add `pendingAsk`, `recentAskResults`, `openAsk`, `resolveAsk`, `cancelAsk`, `askResult(for:)`, and
       `modalPending` to `PickController`; `open` and `openAsk` refuse while `modalPending`
-- [ ] `PickRegistry`: cancel and retain asks on `unregister`; add `liveAsk(for:)`, `retainedAskResult(for:)`
-- [ ] `AskNavigation` state machine (seeded highlight, forward/backward with first/last entry and wrap,
+- [x] `PickRegistry`: cancel and retain asks on `unregister`; add `liveAsk(for:)`, `retainedAskResult(for:)`
+- [x] `AskNavigation` state machine (seeded highlight, forward/backward with first/last entry and wrap,
       inert activate with no highlight, hotkey lookup)
-- [ ] tests: open/resolve/retain, cancel, result-by-id, retention cap, registry retention across unregister
-- [ ] tests: ask refuses while a pick is pending and pick refuses while an ask is pending
-- [ ] tests: the whole keyboard contract on `AskNavigation`, with and without `default`, one and six
+- [x] tests: open/resolve/retain, cancel, result-by-id, retention cap, registry retention across unregister
+- [x] tests: ask refuses while a pick is pending and pick refuses while an ask is pending
+- [x] tests: the whole keyboard contract on `AskNavigation`, with and without `default`, one and six
       buttons, hotkey case folding
-- [ ] run `swift test` for `AskTests` and `PickTests`
+- [x] run `swift test --filter 'agtermCoreTests\.(AskTests|PickTests)/'` (35 tests passed)
 
 ### Task 3: Host-free validation and dispatch
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -85,15 +85,21 @@ Decisions settled in design review (Eugene, with codex as second reader):
   terminal, or search while an ask is pending is refused by the shared modal gates.
 - **Rendering has two styles**, selected by `style` (`terminal` default, `gui`), identical in every
   behavior. `terminal` is drawn over the pane in the theme's background and foreground with the terminal
-  font: every button is a padded, bracketed monospace label on a dim fill (foreground at low opacity),
+  font: every button is a padded monospace label on a dim fill (foreground at low opacity),
   the active one solid foreground with background-colored text, hotkeys underlined. `gui` reuses the
   picker's material panel, corner radius and appearance handling with system fonts: headline title,
   secondary message, native push buttons in a trailing row, the current highlight prominent in the accent color,
   the destructive one tinted red and prominent red when highlighted, no hard-coded colors. Clicking outside the panel does nothing in either.
   `style` is decoration, so it has no read-back; an unknown value is rejected.
+- Buttons in a row share the widest button's width. In a column they share its width, with long labels
+  wrapping within it, in both styles.
 - **Button block alignment** is `align` (`left`, `center`, `right`; default `right`), CLI `--align`, in
   both styles. It places the whole button block within the panel; the vertical fallback aligns its column
   the same way. Decoration like `style`: no read-back, unknown value rejected.
+- **Panel width** is automatic in both styles: natural content width capped at 90 percent of the anchor
+  and 72 cells. Optional `width`, CLI `--width N`, replaces that rule with a fixed integer percentage of
+  the anchor from 10 to 100. Invalid values return `width must be 10 to 100`. It is decoration, with no
+  read-back, and is carried on `PendingAsk`.
 - **Dismissal is two kinds.** User dismissal (Esc, ⌘W) returns `escaped`, CLI exit 3. Administrative
   cancellation (`ask.cancel`, window teardown, app termination, CLI abandon, anchor loss) returns
   `cancelled`, exit 2. Neither synthesizes a button, and there is no cancel button role: a caller's
@@ -154,7 +160,7 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 
 ### Model (`Ask.swift`, agtermCore)
 
-- `PendingAsk { id, title, message?, buttons, defaultID?, destructiveID?, style, align, anchor: AskAnchor? }`
+- `PendingAsk { id, title, message?, buttons, defaultID?, destructiveID?, style, align, width?, anchor: AskAnchor? }`
   with `AskAnchor { sessionID: UUID, pane: OverlayPane?, paneIdentity: UUID? }`.
 - `PickController` gains `pendingAsk: PendingAsk?`, `recentAskResults: [ResolvedAsk]`,
   `openAsk(_:) -> Bool`, `resolveAsk(_:)`, `cancelAsk()`, `askResult(for:)`, and the shared predicate
@@ -214,9 +220,9 @@ left outside the pick host itself. Sites by kind:
 - Layout: title (bold), message (wrapped), then buttons in one row when the widest layout fits the anchor
   frame minus padding, else one per row; caller order preserved either way. Width is clamped to the anchor.
   Content that exceeds the anchor height scrolls; keyboard navigation brings the selected button into view.
-  A button reads `[ Label ]`; the highlighted one is drawn in inverse video (foreground and background
+  A button is a filled block with a plain label; the highlighted one is drawn in inverse video (foreground and background
   swapped); the hotkey letter is underlined; the `destructive` button carries a leading `!` marker
-  (`[ ! Delete ]`) and bold weight, since the app has no access to the theme's ANSI red.
+  (`! Delete`) and bold weight, since the app has no access to the theme's ANSI red.
   A hotkey absent from its label appears as an underlined parenthesized hint.
 - Input: `AskKeyCatcher` (`NSViewRepresentable`, modelled on `DashboardKeyCatcher`) owns first responder
   while mounted and maps Tab/Shift-Tab/arrows/Return/Esc/letters onto `AskNavigation` calls, dropping any
@@ -484,7 +490,7 @@ code to what the docs already say; the Solution Overview above is the authority.
       (the width clamp applies to the text, not only the panel), and the panel never exceeds the anchor;
       hosted render check with a label longer than the anchor is wide
 - [x] terminal style: every button on a dim fill (foreground at low opacity), the active one solid
-      foreground with background-colored text, bracket marker and hotkey underline kept
+      foreground with background-colored text, filled block and hotkey underline kept
 - [x] gui style: picker's `PalettePanelBackground`, corner radius and appearance handling, system font,
       headline title, secondary message, native push buttons in a trailing row, `.borderedProminent`
       highlight, red-tinted destructive; same `AskKeyCatcher` and `AskNavigation`
@@ -499,7 +505,40 @@ code to what the docs already say; the Solution Overview above is the authority.
       inert-Return unit and UI cases become "Return without default answers the first non-destructive
       button"; the terminal active style must read as active at a glance against the dim fills
 
-### Task 11: Verify acceptance criteria
+### ➕ Task 11: Demo fixes
+
+From Eugene's case-by-case review of the Debug build on 2026-09-05. Terminal style only; the gui
+style passed as is.
+
+**Files:**
+- Modify: `agterm/Views/AskDialogView.swift`, `agtermTests/AskDialogViewTests.swift`
+- Modify: `.claude/rules/control-api.md` and the skill reference only where they state the panel width
+
+- [x] message text is drawn in a muted foreground (foreground at reduced opacity), the title stays full
+- [x] the frame border is dimmer than today's 60 percent foreground; pick a value that reads as a
+      quiet outline against both light and dark themes
+- [x] the panel takes its content's natural width instead of filling the anchor, capped at 90 percent
+      of the anchor width and the 72-cell maximum; a short question gets a short panel, a long one
+      keeps a margin on both sides; the column fallback and wrapping still apply within the cap
+- [x] hosted render checks: short question in a narrow pane, long label in a narrow pane, light and dark
+- [x] targeted `AskDialogViewTests` and `-only-testing:agtermUITests/ControlAskUITests`
+- [x] terminal buttons drop the `[ ` and ` ]` brackets; the filled block is the button. The destructive
+      button keeps its `! ` prefix. Update `buttonLabel`, its tests, the Solution Overview rendering
+      bullet, and every doc line that shows a bracketed button; re-run the targeted render and UI checks
+- [x] gui uses the same width rule as terminal: the content's natural width, capped at 90 percent of the
+      anchor and the same maximum, so a short question gets a compact gui panel too
+- [x] `width` on the wire and `--width N` on the CLI, an integer percent of the anchor width from 10 to
+      100, in both styles; when given it fixes the panel width instead of the auto rule (still never
+      wider than the anchor); absent means auto; out of range is `width must be 10 to 100`.
+      CLI non-integers use that message; malformed wire types use the ordinary decode error.
+      Decoration like `style` and `align`: carried on `PendingAsk`, no read-back; validated host-free with
+      dispatcher tests, CLI parsing tests, a hosted render at 50 percent in both styles, and docs beside
+      `align` in control-api.md, commands.html, docs.html and the skill reference
+- [x] equal-width buttons within one dialog: in the row layout every button takes the widest button's
+      width; in the column layout every button takes the column's width; both styles; a wrapped long
+      label still wraps within that shared width; hosted render with "OK" beside "Cancel everything"
+
+### Task 12: Verify acceptance criteria
 - [ ] every decision in Solution Overview is implemented and has a test
 - [ ] `cd agtermCore && swift test`
 - [ ] `make test-app`
@@ -507,7 +546,7 @@ code to what the docs already say; the Solution Overview above is the authority.
 - [ ] Debug instance: manual pass of the keyboard contract and a theme switch while the dialog is up,
       in both styles
 
-### Task 12: [Final] Update documentation
+### Task 13: [Final] Update documentation
 - [ ] CLAUDE.md if a new constraint surfaced during implementation
 - [ ] move this plan to `docs/plans/completed/`
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -431,13 +431,13 @@ event-arguments rule.
   `site/docs.html`, `plugins/agterm/skills/agterm/SKILL.md`, `reference.md`, `examples.md`;
   `ARCHITECTURE.md` does not list control widgets and `cookbook/` stays untouched
 
-- [ ] control-api.md: ask section (validation, shared slot, dismissal kinds, anchor rules, events
+- [x] control-api.md: ask section (validation, shared slot, dismissal kinds, anchor rules, events
       exemption) beside pick
-- [ ] menu-actions.md modal cover list names the pending ask
-- [ ] commands.html: `ask` section with arguments and read-back; docs.html mention in the control widgets
+- [x] menu-actions.md modal cover list names the pending ask
+- [x] commands.html: `ask` section with arguments and read-back; docs.html mention in the control widgets
       list
-- [ ] skill reference and examples: the command, one hook example (a yes/no before a destructive step)
-- [ ] no surface states a command count
+- [x] skill reference and examples: the command, one hook example (a yes/no before a destructive step)
+- [x] no surface states a command count
 
 ### Task 10: Verify acceptance criteria
 - [ ] every decision in Solution Overview is implemented and has a test

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -8,7 +8,8 @@ pressed. Today the control API offers a searchable list (`pick`), one-way panels
 `pick` shows a search field and a list where a dialog is wanted.
 
 `ask` adds a theme-styled, terminal-looking modal dialog: a title, an optional message, and one to six
-caller-named buttons. It resolves with the pressed button's id, label, and caller index, or `cancelled`.
+caller-named buttons. It resolves with the pressed button's id, label, and caller index, or `escaped`
+or `cancelled`.
 The command family, blocking CLI, result retention, and tree read-back copy `pick` one to one.
 
 ## Context (from discovery)
@@ -70,7 +71,8 @@ Decisions settled in design review (Eugene, with codex as second reader):
   that reads "is a picker pending" reads "is a modal pending" instead.
 - **Placement: session-wide by default.** With a session target the dialog draws over that session's
   whole area, both halves of a split; `--pane left|right` narrows it to one half. With no session it
-  draws at window center. A supplied session or pane that is missing or not visible rejects the open;
+  centers over the terminal area, right of the sidebar and below the titlebar, exactly where the pick
+  palette centers (`terminalAreaInset`). A supplied session or pane that is missing or not visible rejects the open;
   `--pane` without a session is rejected.
 - **Anchor identity is captured at open**; its geometry follows resizes. The anchor is lost, and the ask
   resolves `cancelled`, when the anchored session is closed or deselected in its window, or when an
@@ -79,24 +81,32 @@ Decisions settled in design review (Eugene, with codex as second reader):
   screen, maximized included. The dialog never relocates.
 - **Zoom and dashboard**: an anchored open while terminal zoom or the dashboard covers the owning window
   is rejected with `session not visible`, since the deck under them is not on screen. An unanchored ask
-  draws at window center above zoom and dashboard, exactly as pick does. Opening zoom, dashboard, quick
+  draws at terminal-area center above zoom and dashboard, exactly as pick does. Opening zoom, dashboard, quick
   terminal, or search while an ask is pending is refused by the shared modal gates.
-- **Rendering: theme-styled and terminal-looking**, drawn by agterm over the pane in the theme's
-  background and foreground with the terminal font. Buttons are bracketed monospace labels with a
-  highlighted current button and underlined hotkeys, never Aqua push buttons. Clicking outside the panel
-  does nothing.
-- **Dismissal is two kinds.** User dismissal (Esc, ⌘W, the button named `cancel`) returns the `cancel`
-  button as `answered` when one is named, otherwise `cancelled`. Administrative cancellation
-  (`ask.cancel`, window teardown, app termination, CLI abandon, anchor loss) always returns `cancelled`
-  and never synthesizes a button.
-- **Keyboard contract**, independent of macOS conventions: `default` names the initially highlighted
-  button; with no `default` nothing is highlighted and Return is inert until navigation. Tab, Right, Down
-  select the first button when nothing is highlighted and otherwise move forward; Shift-Tab, Left, Up
-  select the last and otherwise move back; movement wraps. Return activates the highlight; a hotkey
-  activates its button directly. A `destructive` button is reachable by navigation and hotkey but may
-  not be `default` or `cancel`; both are validation errors, never silently ignored.
-- **Result shape** copies pick: `{"result":"answered","id":"yes","label":"Yes","index":0}` or
-  `{"result":"cancelled"}`; `index` is the caller's button order regardless of vertical layout.
+- **Rendering has two styles**, selected by `style` (`terminal` default, `gui`), identical in every
+  behavior. `terminal` is drawn over the pane in the theme's background and foreground with the terminal
+  font: every button is a padded, bracketed monospace label on a dim fill (foreground at low opacity),
+  the active one solid foreground with background-colored text, hotkeys underlined. `gui` reuses the
+  picker's material panel, corner radius and appearance handling with system fonts: headline title,
+  secondary message, native push buttons in a trailing row, the current highlight prominent in the accent color,
+  the destructive one tinted red and prominent red when highlighted, no hard-coded colors. Clicking outside the panel does nothing in either.
+  `style` is decoration, so it has no read-back; an unknown value is rejected.
+- **Button block alignment** is `align` (`left`, `center`, `right`; default `right`), CLI `--align`, in
+  both styles. It places the whole button block within the panel; the vertical fallback aligns its column
+  the same way. Decoration like `style`: no read-back, unknown value rejected.
+- **Dismissal is two kinds.** User dismissal (Esc, ⌘W) returns `escaped`, CLI exit 3. Administrative
+  cancellation (`ask.cancel`, window teardown, app termination, CLI abandon, anchor loss) returns
+  `cancelled`, exit 2. Neither synthesizes a button, and there is no cancel button role: a caller's
+  "Cancel" button is an ordinary button answered by id. ⌘W dismisses the ask for consistency with pick.
+- **Keyboard contract**: exactly one button is highlighted at every moment and Return activates it.
+  `default` names the initial highlight; without it the first button that is not `destructive` is
+  highlighted, or the first button when it is the only one. Tab, Right, Down move forward; Shift-Tab,
+  Left, Up move back; movement wraps. A hotkey activates its button directly. A `destructive` button is
+  reachable by navigation and hotkey but may not be `default`; that is a validation error, never
+  silently ignored. The active button is visibly distinct from the others in both styles.
+- **Result shape** copies pick: `{"result":"answered","id":"yes","label":"Yes","index":0}`,
+  `{"result":"escaped"}` or `{"result":"cancelled"}`; `index` is the caller's button order regardless
+  of vertical layout.
   `ask.result` over the socket also reports `pending`; the blocking CLI prints only the terminal answer.
 - **Tree** exposes `askPending` (the id) on the window node next to `pickPending`.
 - **Naming**: `ask.open` / `ask.result` / `ask.cancel`; CLI `agtermctl ask`.
@@ -113,23 +123,26 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 
 - `Command`: `askOpen = "ask.open"`, `askResult = "ask.result"`, `askCancel = "ask.cancel"`.
 - `ControlArgs` additions: `buttons: [ControlAskButton]?`, `defaultButton: String?`,
-  `cancelButton: String?`, `destructiveButton: String?`. Reused: `title` (notify's field), `message`
+  `destructiveButton: String?`, `style: String?`, `align: String?`. Reused: `title` (notify's field), `message`
   (dialog body), `pane`, `paneID`, `window`, `follow`. `target` is the session for `ask.open` (optional)
   and the ask id for `ask.result`/`ask.cancel`. `ControlArgs` is synthesized `Codable` with no coding
   keys, so the additions are plain optional fields.
 - `ControlResult.ask: ControlAskResult?`; `ask.open` answers `ControlResult(id:)` like pick, plus
   `result.pane` when a pane anchor was resolved: `--pane` changes where the dialog lands, and
   control-api.md requires a read-back for such a field, as `session.restore` does.
-- `ControlAskButton { id, label, hotkey: String? }`, `ControlAskOutcome { pending, answered, cancelled }`,
-  `ControlAskResult { result, id?, label?, index? }` in `ControlAsk.swift`.
+- `ControlAskButton { id, label, hotkey: String? }`, `ControlAskOutcome { pending, answered, escaped,
+  cancelled }`, `ControlAskResult { result, id?, label?, index? }`, `ControlAskStyle { terminal, gui }`,
+  `ControlAskAlignment { left, center, right }``
+  in `ControlAsk.swift`.
 
 ### Validation (`ControlDispatcher+Ask.swift`, host-free)
 
 - `ControlAskPlacement` carries parsed `pane` and unresolved `paneID` together in the host action.
 - `title` required and non-blank; `title`, `message`, and every label free of control characters.
 - 1...6 buttons (`ControlAskButton.maxButtons = 6`), unique ids, non-empty labels.
-- `default`, `cancel`, `destructive` must each name an existing button; `default == destructive` and
-  `cancel == destructive` are rejected with explicit messages.
+- `default` and `destructive` must each name an existing button; `default == destructive` is rejected
+  with an explicit message.
+- `style`, when present, is `terminal` or `gui`; anything else is `unknown style`.
 - `hotkey` is one ASCII letter, stored lowercased, unique across buttons. Return, Tab, Esc, arrows,
   digits and punctuation are rejected so a hotkey can never collide with navigation or dismissal. A key
   event carrying Command, Control, or Option never activates a hotkey.
@@ -141,7 +154,7 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 
 ### Model (`Ask.swift`, agtermCore)
 
-- `PendingAsk { id, title, message?, buttons, defaultID?, cancelID?, destructiveID?, anchor: AskAnchor? }`
+- `PendingAsk { id, title, message?, buttons, defaultID?, destructiveID?, style, align, anchor: AskAnchor? }`
   with `AskAnchor { sessionID: UUID, pane: OverlayPane?, paneIdentity: UUID? }`.
 - `PickController` gains `pendingAsk: PendingAsk?`, `recentAskResults: [ResolvedAsk]`,
   `openAsk(_:) -> Bool`, `resolveAsk(_:)`, `cancelAsk()`, `askResult(for:)`, and the shared predicate
@@ -151,8 +164,8 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 - `PickRegistry.unregister` cancels the pending ask and retains its results; `liveAsk(for:)` and
   `retainedAskResult(for:)` mirror the pick lookups.
 - `AskNavigation` (host-free, in `Ask.swift`) holds the highlight state machine: `highlighted: Int?`
-  seeded from `defaultID`, `moveForward()`, `moveBackward()` with the first/last entry rules and wrap,
-  `activate() -> Int?` (nil while nothing is highlighted), `hotkey(_ letter:) -> Int?`. The app-side key
+  seeded from `defaultID`, otherwise the first non-destructive button or first available button.
+  `moveForward()` and `moveBackward()` wrap; `activate() -> Int?` is nil only for an empty list, `hotkey(_ letter:) -> Int?`. The app-side key
   catcher only maps key events onto these calls, so the whole keyboard contract is unit-tested in
   `agtermCore`.
 
@@ -191,8 +204,7 @@ left outside the pick host itself. Sites by kind:
   `PickController.pendingModalError` (`pick pending` or `ask pending`) so the pick message and its tests
   stay unchanged
 
-⌘W: `dismissPendingAsk(userInitiated: true)` resolves the cancel button or `cancelled`; termination and
-teardown call `cancelAsk()`.
+⌘W and Esc: `escapeAsk()` resolves `escaped`; termination and teardown call `cancelAsk()`.
 
 ### View (`agterm/Views/AskDialogView.swift`)
 
@@ -218,7 +230,7 @@ teardown call `cancelAsk()`.
   bounds and each rendered pane's bounds, so the preference `reduce` never merges frames from the other
   deck sessions the `ForEach` keeps mounted at opacity zero; the ask host resolves the anchors in its own
   coordinate space (sidebar and titlebar offsets included). Session-wide uses the container bounds, `--pane` the named pane's bounds, no anchor
-  the whole window center below the titlebar. Validity is derived from state, not from the preference:
+  the terminal area center below the titlebar and right of the sidebar. Validity is derived from state, not from the preference:
   `store.selectedSessionID == anchor.sessionID`, and for a pane anchor the captured pane IDENTITY is
   resolved to its CURRENT role first (`Session.askTargetPane`, the same identity-to-role lookup as
   `hudTargetPane`), then `session.rendersPane(role)`; a nil role or a false `rendersPane` cancels. Both
@@ -232,7 +244,7 @@ teardown call `cancelAsk()`.
 
 ```
 agtermctl ask TITLE [--message TEXT] --button ID=LABEL [--button ...] [--hotkey ID=K ...]
-             [--default ID] [--cancel ID] [--destructive ID]
+             [--default ID] [--destructive ID] [--style terminal|gui]
              [--target SESSION] [--pane left|right] [--pane-id TOKEN] [--window W] [--follow] [--no-block]
 agtermctl ask result ID
 agtermctl ask cancel ID
@@ -241,11 +253,11 @@ agtermctl ask cancel ID
 - `--button ID=LABEL` splits on the first `=`; a missing `=` uses the token as both. `--hotkey ID=K`
   attaches a hotkey to a declared button.
 - `--target` is `ask`'s own optional option, not `TargetOptions`, whose default of `active` would turn
-  every no-target call into an anchored one and break window-center placement.
+  every no-target call into an anchored one and break terminal-area placement.
 - `--pane-id` exposes the existing stable-token wire field, with the same target requirement as `--pane`.
 - `Ask.self` is registered in `Agtermctl.configuration.subcommands` (`agtermctlKit/Commands.swift`).
 - Default subcommand is open. Blocking poll, delays, abandon-on-transport-failure, and exit codes (0
-  answered, 2 cancelled, 1 failure) reuse the pick helpers, generalized to take the outcome kind.
+  answered, 3 escaped, 2 cancelled, 1 failure) reuse the pick helpers, generalized to take the outcome kind.
 - `--no-block` prints `{"id":...}`. The one-shot `ask result ID` prints whatever the socket reports,
   `pending` included, and exits 1 for pending like `pick result`.
 
@@ -439,14 +451,63 @@ event-arguments rule.
 - [x] skill reference and examples: the command, one hook example (a yes/no before a destructive step)
 - [x] no surface states a command count
 
-### Task 10: Verify acceptance criteria
+### ➕ Task 10: Escaped result, filled buttons, and the gui style
+
+Eugene's review of the built dialog changed the contract after Task 9 documented it. This task moves the
+code to what the docs already say; the Solution Overview above is the authority.
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlAsk.swift` (`escaped`, `ControlAskStyle`),
+  `ControlProtocol.swift` (drop `cancelButton`, add `style` and `align`),
+  `Ask.swift` (drop `cancelID`, add `style` and `align`),
+  `Pick.swift` (`escapeAsk()`), `ControlDispatcher+Ask.swift` (drop the cancel role, validate `style`)
+- Modify: `agtermCore/Sources/agtermctlKit/AskCommands.swift` (drop `--cancel`, add `--style`),
+  `SocketClient.swift` (`escaped` exits 3)
+- Modify: `agterm/AppActions+Focus.swift` (`dismissPendingAsk` becomes escape, no button lookup),
+  `agterm/Views/AskDialogView.swift` (filled buttons, `gui` rendering), `agterm/Views/WindowContentView.swift`
+  (Esc resolves `escaped`)
+- Modify: every test that named the cancel role: `ControlProtocolTests`, `AskTests`,
+  `ControlDispatcherAskTests`, `AskCommandsTests`, `SocketClientTests`, `ControlServerAskTests`,
+  `AskDialogViewTests`, `ControlAskUITests`
+
+- [x] `ControlAskOutcome.escaped`; `escapeAsk()` on the controller; Esc and ⌘W resolve it
+- [x] remove `cancelButton`/`cancelID`/`--cancel` and the cancel-versus-destructive rule everywhere
+- [x] `style` on the wire, validated host-free, carried on `PendingAsk`; CLI `--style`, default `terminal`
+- [x] `align` on the wire (`ControlAskAlignment { left, center, right }`), validated host-free, carried
+      on `PendingAsk`; CLI `--align`, default `right`; both styles and the vertical fallback honor it
+- [x] docs: add `style` and `align` to control-api.md, commands.html, docs.html and the skill reference
+      where Task 9 described `style`
+- [x] unanchored placement centers over the terminal area: `askAnchorFrame` with no anchor starts at
+      `terminalAreaInset`, not x 0, so the sidebar is excluded like the pick palette; UI test asserts
+      the dialog's minX is at or right of the sidebar's maxX with the sidebar visible
+- [x] long labels never clip: in the vertical fallback a button's label wraps within the panel width
+      (the width clamp applies to the text, not only the panel), and the panel never exceeds the anchor;
+      hosted render check with a label longer than the anchor is wide
+- [x] terminal style: every button on a dim fill (foreground at low opacity), the active one solid
+      foreground with background-colored text, bracket marker and hotkey underline kept
+- [x] gui style: picker's `PalettePanelBackground`, corner radius and appearance handling, system font,
+      headline title, secondary message, native push buttons in a trailing row, `.borderedProminent`
+      highlight, red-tinted destructive; same `AskKeyCatcher` and `AskNavigation`
+- [x] CLI exit 3 for `escaped`; `ask result` one-shot maps it the same way
+- [x] update unit, hosted and UI tests to the new contract; Esc and ⌘W cases assert `escaped`
+- [x] UI tests: `--default` then Return answers the default; Right arrow then Return answers the second
+      button; a `--style gui` open renders `ask-dialog` with native buttons and answers by click
+- [x] hosted render check of both styles in light and dark appearance
+- [x] run `-only-testing:agtermUITests/ControlAskUITests` and the affected core suites
+- [x] one button is always highlighted: `AskNavigation` seeds from `default`, else the first
+      non-destructive button, else the first; `activate()` never returns nil for a non-empty list; the
+      inert-Return unit and UI cases become "Return without default answers the first non-destructive
+      button"; the terminal active style must read as active at a glance against the dim fills
+
+### Task 11: Verify acceptance criteria
 - [ ] every decision in Solution Overview is implemented and has a test
 - [ ] `cd agtermCore && swift test`
 - [ ] `make test-app`
 - [ ] `make lint` with zero findings
-- [ ] Debug instance: manual pass of the keyboard contract and a theme switch while the dialog is up
+- [ ] Debug instance: manual pass of the keyboard contract and a theme switch while the dialog is up,
+      in both styles
 
-### Task 11: [Final] Update documentation
+### Task 12: [Final] Update documentation
 - [ ] CLAUDE.md if a new constraint surfaced during implementation
 - [ ] move this plan to `docs/plans/completed/`
 
@@ -454,6 +515,6 @@ event-arguments rule.
 
 **Manual verification**:
 - run the bundled skill's example hook against a Release build installed with `make deploy`
-- confirm `agtermctl ask` from inside a session with no `--target` still draws at window center
+- confirm `agtermctl ask` from inside a session with no `--target` still draws at terminal-area center
 
 Smells pre-check: skipped — non-Go project

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -410,18 +410,19 @@ event-arguments rule.
 - Create: `agtermUITests/ControlAskUITests.swift`
 - Modify: `agtermUITests/ControlAPITestCase.swift` (ask helpers next to the pick helpers)
 
-- [ ] render, click a button, `askPending` in tree, result id/label/index, dialog dismissed
-- [ ] keyboard: no default leaves Return inert, Tab then Return answers the first button; hotkey answers
-- [ ] Esc with a cancel button answers it; Esc without returns `cancelled`
-- [ ] `ask.open` while a pick is pending is rejected, and the reverse
-- [ ] `dashboard`, `quick`, `session.search`, and zoom commands are refused while an ask is pending
-- [ ] `ask.cancel` on a dialog with a named cancel button returns `cancelled`, not the button; closing
+- [x] render, click a button, `askPending` in tree, result id/label/index, dialog dismissed
+- [x] keyboard: no default leaves Return inert, Tab then Return answers the first button; hotkey answers
+- [x] Esc with a cancel button answers it; Esc without returns `cancelled`
+- [x] `ask.open` while a pick is pending is rejected, and the reverse
+- [x] `dashboard`, `quick`, `session.search`, and zoom commands are refused while an ask is pending
+- [x] `ask.cancel` on a dialog with a named cancel button returns `cancelled`, not the button; closing
       the window while pending returns `cancelled` and the result stays readable afterwards
-- [ ] `--pane right` on a split session draws within the right pane frame; a hidden session rejects open;
+- [x] `--pane right` on a split session draws within the right pane frame; a hidden session rejects open;
       selecting another session by control while anchored resolves `cancelled`; collapsing the split under
       a session-wide anchor keeps the dialog up
-- [ ] an unanchored ask opened while zoom is active renders above it; an anchored one is rejected
-- [ ] run only `-only-testing:agtermUITests/ControlAskUITests`
+- [x] an unanchored ask opened while zoom is active renders above it; an anchored one is rejected
+- [x] run only `ControlAskUITests`: 13 of 14 passed initially; corrected the render test to read macOS
+      static text `value`, then that method passed on its targeted rerun. No other UI suite ran.
 
 ### Task 9: Documentation
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -89,7 +89,7 @@ Decisions settled in design review (Eugene, with codex as second reader):
   the active one solid foreground with background-colored text, hotkeys underlined. `gui` reuses the
   picker's material panel, corner radius and appearance handling with system fonts: headline title,
   secondary message, native push buttons in a trailing row, the current highlight prominent in the accent color,
-  the destructive one tinted red and prominent red when highlighted, no hard-coded colors. Clicking outside the panel does nothing in either.
+  the destructive one tinted red and prominent red when highlighted, system colors only. Clicking outside the panel does nothing in either.
   `style` is decoration, so it has no read-back; an unknown value is rejected.
 - Buttons in a row share the widest button's width. In a column they share its width, with long labels
   wrapping within it, in both styles.

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -161,9 +161,9 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 - `openAsk`: with a session target, `resolver.resolveSession` finds the store and session, the window
   owning it is the modal owner, the session must be selected in that window (`session not visible`), and
   pane placement resolves through the HUD placement resolver moved to a shared file
-  (`resolvePanePlacement(_:in:requireVisible:)`), capturing `paneIdentity`. Terminal zoom or an open
+  (`resolvePanePlacement(_:paneID:in:requireVisible:invalidPaneError:)`), capturing `paneIdentity`. Terminal zoom or an open
   dashboard in that window rejects an anchored open (`session not visible`). Without a target,
-  `resolvePlacementStore(window)` picks the window and the anchor is nil. `follow` raises the window.
+  `resolveOpenPlacementStore(window)` picks the window and the anchor is nil. `follow` raises the window.
 - `askResult`/`cancelAsk` copy `pickResult`/`cancelPick` including window-mismatch and retained lookups.
 - Tree: `askPending` is a top-level `ControlTree` field beside `pickPending` (`ControlProjection.swift`),
   populated through the same closure path: `AppStore.swift` tree builder (`pickPending:` parameter and
@@ -310,22 +310,25 @@ event-arguments rule.
 
 **Files:**
 - Create: `agterm/Control/ControlServer+Ask.swift`
+- Create: `agterm/Control/ControlServer+PanePlacement.swift`
+- Create: `agtermTests/ControlServerAskTests.swift`
 - Modify: `agterm/Control/ControlServer+Hud.swift` (move `resolveHudPlacement` to a shared pane
   placement resolver)
 - Modify: `agterm/Control/ControlServer.swift` (tree `askPending` closure)
 - Modify: `agtermCore/Sources/agtermCore/ControlProjection.swift`, `AppStore.swift` (tree builder
   parameter and call), `ControlProtocolCompatibility.swift` (agterm-linux shim)
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift` (`result.pane` documentation)
 - Modify: `agtermCore/Tests/agtermCoreTests/AppStoreTreeProjectionTests.swift`,
   `ControlProtocolTests.swift`
 
-- [ ] `openAsk` resolves the session or placement window, requires a visible session and pane, rejects
+- [x] `openAsk` resolves the session or placement window, requires a visible session and pane, rejects
       an anchored open while zoom or dashboard covers the window, captures the anchor, opens on the
       window's controller, handles `follow`, closes the palette, returns `result.pane` for a pane anchor
-- [ ] `askResult` and `cancelAsk` with the pick lookup order (live by id, retained, explicit window)
-- [ ] add top-level `askPending` through projection, store builder, shim, and server closure
-- [ ] projection test for `askPending` presence and absence; nil-omission test beside the `pickPending`
+- [x] `askResult` and `cancelAsk` with the pick lookup order (live by id, retained, explicit window)
+- [x] add top-level `askPending` through projection, store builder, shim, and server closure
+- [x] projection test for `askPending` presence and absence; nil-omission test beside the `pickPending`
       one in `ControlProtocolTests`
-- [ ] build the app target
+- [x] build the app target through the isolated `agtermTests` scheme; 18 hosted tests passed
 
 ### Task 5: Shared modal gates and ⌘W/termination paths
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -335,22 +335,24 @@ event-arguments rule.
 **Files:**
 - Modify: `agtermCore/Sources/agtermCore/PaletteCatalog.swift`,
   `agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift`
+- Modify: `agtermCore/Sources/agtermCore/Pick.swift`, `agtermCore/Tests/agtermCoreTests/PickTests.swift`
+- Modify: `agtermTests/ControlServerAskTests.swift`
 - Modify: `agterm/AppActions+Focus.swift`, `agterm/AppActions.swift`, `agterm/agtermApp.swift`,
-  `agterm/agtermApp+Menus.swift`, `agterm/AppDelegate.swift` (termination hook if it calls
-  `cancelAllPendingPicks`), `agterm/Ghostty/GhosttySurfaceView.swift`
+  `agterm/AppDelegate.swift`, `agterm/Ghostty/GhosttySurfaceView.swift`
 - Modify: `agterm/Views/WindowContentView.swift`, `WindowContentView+Dashboard.swift`,
   `WindowContentView+Zoom.swift`, `WindowContentView+Titlebar.swift`, `WindowContentView+RecentSessions.swift`
 - Modify: `agterm/Control/ControlServer.swift`, `ControlServer+AppCommands.swift`,
-  `ControlServer+SurfaceIO.swift`, `ControlServer+SessionActions.swift`
+  `ControlServer+SurfaceIO.swift`, `ControlServer+SessionActions.swift`, `ControlServer+Ask.swift`
 
-- [ ] switch every pending-pick predicate to `modalPending`, the five control entry points included,
+- [x] switch every pending-pick predicate to `modalPending`, the five control entry points included,
       with `pendingModalError` supplying the message; finish with the grep from Technical Details showing
       no read left outside the pick host
-- [ ] `PaletteContext` takes the modal predicate; `modalActive` covers an ask
-- [ ] `dismissPendingAsk(userInitiated:)` for ⌘W; `cancelAllPendingModals` for termination
-- [ ] auto-follow suppression and quick-terminal hide pair with the ask exactly as with the pick
-- [ ] tests: `PaletteCatalogTests` case for `modalActive` under a pending ask
-- [ ] build the app target and run the existing `ControlPickUITests` once to confirm no regression
+- [x] `PaletteContext` takes the modal predicate; `modalActive` covers an ask
+- [x] `dismissPendingAsk(userInitiated:)` for ⌘W; `cancelAllPendingModals` for termination
+- [x] auto-follow suppression and quick-terminal hide pair with the ask exactly as with the pick
+- [x] tests: `PaletteCatalogTests` case for `modalActive` under a pending ask
+- [x] build the app target and attempt `ControlPickUITests` once; UI verification skipped because the
+      runner timed out enabling automation mode before any test methods ran. Core and hosted checks passed.
 
 ### Task 6: Dialog view, keyboard, and placement
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -1,0 +1,443 @@
+# Ask dialog: control-driven modal question
+
+## Overview
+
+A caller (agent hook, script, recipe) needs to put a question to the user and learn which button was
+pressed. Today the control API offers a searchable list (`pick`), one-way panels (`session.hud.*`,
+`notify`), and a full program surface (`session.overlay.*`). None returns a chosen button, and a two-row
+`pick` shows a search field and a list where a dialog is wanted.
+
+`ask` adds a theme-styled, terminal-looking modal dialog: a title, an optional message, and one to six
+caller-named buttons. It resolves with the pressed button's id, label, and caller index, or `cancelled`.
+The command family, blocking CLI, result retention, and tree read-back copy `pick` one to one.
+
+## Context (from discovery)
+
+- `pick` family is the template: `agtermCore/Sources/agtermCore/{Pick,ControlPick}.swift`,
+  `ControlDispatcher+Pick.swift`, `agterm/Control/ControlServer+Pick.swift`,
+  `agtermctlKit/MiscCommands.swift` (`Pick` command, poll loop, `abandon`), `SocketClient.pickExitCode`.
+- Modal gates that read the pending picker today: `AppActions+Focus.swift` `pickActive`,
+  `GhosttySurfaceView.pickOwnsFocus`, `WindowContentView.swift` auto-follow suppression and frontmost
+  handling (`pick.pending`), `agtermApp.swift:482,729,736` (search cleanup, quick terminal summon),
+  `AppActions.swift` `cancelPendingPick`/`cancelAllPendingPicks` (⌘W, termination), tree
+  `pickPending` in `ControlServer.swift:747` and `ControlProjection.swift`.
+- Pane anchoring exists for the HUD, but inside one session's own layer: `HudPaneAnchors` is published
+  and consumed within `sessionDetail` (`WindowContentView+Detail.swift`), and the cached
+  `Session.hudPaneFrames` is observation-ignored and stale for hidden panes. Neither can feed a window-level
+  host, hence the dedicated preference in Technical Details. `ControlServer+Hud.swift`
+  `resolveHudPlacement` resolves `--pane`/pane id against a session with `requireVisible` and is reused.
+- Theme colors for SwiftUI views come from `GhosttyApp.shared.terminalBackgroundColor` /
+  `terminalForegroundColor` (used by the sidebar, rename field, watermark); font family and size from
+  `settingsModel.settings`. The HUD is a terminal helper program (`hud.sh`), not a SwiftUI view, so its
+  transport is not reused; only its look is.
+- Keyboard capture pattern for a SwiftUI modal without a text field: `DashboardKeyCatcher`
+  (`NSViewRepresentable` owning first responder) in `agterm/Views/DashboardView.swift`.
+- Docs surfaces: `.claude/rules/control-api.md`, `site/commands.html`, `site/docs.html`,
+  `plugins/agterm/skills/agterm/{SKILL,reference,examples}.md`, `.claude/rules/menu-actions.md` (modal
+  cover list).
+- No command count is stated on any surface, and stays that way.
+
+## Development Approach
+
+- **testing approach**: Regular (code first, then tests in the same task)
+- one task at a time; every task ends with its tests green before the next starts
+- gates run once at the end: `cd agtermCore && swift test`, `make test-app`, `make lint`; targeted
+  runs during work (`-only-testing:agtermUITests/ControlAskUITests`)
+- host-free logic (model, validation, result shaping, CLI parsing) lives in `agtermCore`; the app target
+  resolves windows, sessions, geometry, and draws
+- update this plan when scope changes
+
+## Testing Strategy
+
+- **unit tests** (Swift Testing, `agtermCore/Tests`): model and controller, protocol round trip,
+  dispatcher validation, projection, CLI parsing and exit codes. One test file per source file.
+- **hosted UI tests** (`agtermUITests/ControlAskUITests.swift`, XCTest on `ControlAPITestCase`):
+  render, click, keyboard, dismissal semantics, tree read-back, shared modal slot, pane anchoring. Keep
+  the count small; each hosted test costs seconds.
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+
+## Solution Overview
+
+Decisions settled in design review (Eugene, with codex as second reader):
+
+- **Modality: window-wide, like pick.** One shared pending slot per window for ask and pick; a second
+  open of either is rejected. Every focus, zoom, auto-follow, search-cleanup, and quick-terminal gate
+  that reads "is a picker pending" reads "is a modal pending" instead.
+- **Placement: session-wide by default.** With a session target the dialog draws over that session's
+  whole area, both halves of a split; `--pane left|right` narrows it to one half. With no session it
+  draws at window center. A supplied session or pane that is missing or not visible rejects the open;
+  `--pane` without a session is rejected.
+- **Anchor identity is captured at open**; its geometry follows resizes. The anchor is lost, and the ask
+  resolves `cancelled`, when the anchored session is closed or deselected in its window, or when an
+  anchored pane stops being rendered (`Session.rendersPane` false, or its pane identity gone). A
+  session-wide anchor survives a split collapse, and a pane anchor survives while that pane stays on
+  screen, maximized included. The dialog never relocates.
+- **Zoom and dashboard**: an anchored open while terminal zoom or the dashboard covers the owning window
+  is rejected with `session not visible`, since the deck under them is not on screen. An unanchored ask
+  draws at window center above zoom and dashboard, exactly as pick does. Opening zoom, dashboard, quick
+  terminal, or search while an ask is pending is refused by the shared modal gates.
+- **Rendering: theme-styled and terminal-looking**, drawn by agterm over the pane in the theme's
+  background and foreground with the terminal font. Buttons are bracketed monospace labels with a
+  highlighted current button and underlined hotkeys, never Aqua push buttons. Clicking outside the panel
+  does nothing.
+- **Dismissal is two kinds.** User dismissal (Esc, ⌘W, the button named `cancel`) returns the `cancel`
+  button as `answered` when one is named, otherwise `cancelled`. Administrative cancellation
+  (`ask.cancel`, window teardown, app termination, CLI abandon, anchor loss) always returns `cancelled`
+  and never synthesizes a button.
+- **Keyboard contract**, independent of macOS conventions: `default` names the initially highlighted
+  button; with no `default` nothing is highlighted and Return is inert until navigation. Tab, Right, Down
+  select the first button when nothing is highlighted and otherwise move forward; Shift-Tab, Left, Up
+  select the last and otherwise move back; movement wraps. Return activates the highlight; a hotkey
+  activates its button directly. A `destructive` button is reachable by navigation and hotkey but may
+  not be `default` or `cancel`; both are validation errors, never silently ignored.
+- **Result shape** copies pick: `{"result":"answered","id":"yes","label":"Yes","index":0}` or
+  `{"result":"cancelled"}`; `index` is the caller's button order regardless of vertical layout.
+  `ask.result` over the socket also reports `pending`; the blocking CLI prints only the terminal answer.
+- **Tree** exposes `askPending` (the id) on the window node next to `pickPending`.
+- **Naming**: `ask.open` / `ask.result` / `ask.cancel`; CLI `agtermctl ask`.
+
+Rejected alternatives: `NSAlert` sheet (not theme-styled, ugly past three buttons); folding buttons into
+`pick.open` (muddles a contract of 1..1000 searchable rows); session-scoped modality that leaves the other
+pane usable (needs a pending indicator, hidden-focus rules, and move/close rules; can come later if a real
+caller needs it); a rename of `PickController`/`PickRegistry` to a modal-neutral name (mechanical churn
+across ten files for no behavior; the shared-slot predicate is named `modalPending` instead).
+
+## Technical Details
+
+### Protocol (`ControlProtocol.swift`)
+
+- `Command`: `askOpen = "ask.open"`, `askResult = "ask.result"`, `askCancel = "ask.cancel"`.
+- `ControlArgs` additions: `buttons: [ControlAskButton]?`, `defaultButton: String?`,
+  `cancelButton: String?`, `destructiveButton: String?`. Reused: `title` (notify's field), `message`
+  (dialog body), `pane`, `paneID`, `window`, `follow`. `target` is the session for `ask.open` (optional)
+  and the ask id for `ask.result`/`ask.cancel`. `ControlArgs` is synthesized `Codable` with no coding
+  keys, so the additions are plain optional fields.
+- `ControlResult.ask: ControlAskResult?`; `ask.open` answers `ControlResult(id:)` like pick, plus
+  `result.pane` when a pane anchor was resolved: `--pane` changes where the dialog lands, and
+  control-api.md requires a read-back for such a field, as `session.restore` does.
+- `ControlAskButton { id, label, hotkey: String? }`, `ControlAskOutcome { pending, answered, cancelled }`,
+  `ControlAskResult { result, id?, label?, index? }` in `ControlAsk.swift`.
+
+### Validation (`ControlDispatcher+Ask.swift`, host-free)
+
+- `title` required and non-blank; `title`, `message`, and every label free of control characters.
+- 1...6 buttons (`ControlAskButton.maxButtons = 6`), unique ids, non-empty labels.
+- `default`, `cancel`, `destructive` must each name an existing button; `default == destructive` and
+  `cancel == destructive` are rejected with explicit messages.
+- `hotkey` is one ASCII letter, stored lowercased, unique across buttons. Return, Tab, Esc, arrows,
+  digits and punctuation are rejected so a hotkey can never collide with navigation or dismissal. A key
+  event carrying Command, Control, or Option never activates a hotkey.
+- `pane` parses through `parsePane` with `OverlayPane`; `pane` or `paneID` without a session target is
+  rejected (`--pane requires a session`).
+- `ask.result`/`ask.cancel` require a target id.
+- Errors keep pick's phrasing: `ask.open requires a title`, `ask.open requires buttons`,
+  `too many buttons (max 6)`, `ask button ids must be unique`, `unknown default button: X`, and so on.
+
+### Model (`Ask.swift`, agtermCore)
+
+- `PendingAsk { id, title, message?, buttons, defaultID?, cancelID?, destructiveID?, anchor: AskAnchor? }`
+  with `AskAnchor { sessionID: UUID, pane: OverlayPane?, paneIdentity: UUID? }`.
+- `PickController` gains `pendingAsk: PendingAsk?`, `recentAskResults: [ResolvedAsk]`,
+  `openAsk(_:) -> Bool`, `resolveAsk(_:)`, `cancelAsk()`, `askResult(for:)`, and the shared predicate
+  `modalPending: Bool` (`pending != nil || pendingAsk != nil`). `open`/`openAsk` both refuse while
+  `modalPending`. Retention limits and the resolution sequence are shared with pick.
+- `PickRegistry.unregister` cancels the pending ask and retains its results; `liveAsk(for:)` and
+  `retainedAskResult(for:)` mirror the pick lookups.
+- `AskNavigation` (host-free, in `Ask.swift`) holds the highlight state machine: `highlighted: Int?`
+  seeded from `defaultID`, `moveForward()`, `moveBackward()` with the first/last entry rules and wrap,
+  `activate() -> Int?` (nil while nothing is highlighted), `hotkey(_ letter:) -> Int?`. The app-side key
+  catcher only maps key events onto these calls, so the whole keyboard contract is unit-tested in
+  `agtermCore`.
+
+### App host (`ControlServer+Ask.swift`)
+
+- `openAsk`: with a session target, `resolver.resolveSession` finds the store and session, the window
+  owning it is the modal owner, the session must be selected in that window (`session not visible`), and
+  pane placement resolves through the HUD placement resolver moved to a shared file
+  (`resolvePanePlacement(_:in:requireVisible:)`), capturing `paneIdentity`. Terminal zoom or an open
+  dashboard in that window rejects an anchored open (`session not visible`). Without a target,
+  `resolvePlacementStore(window)` picks the window and the anchor is nil. `follow` raises the window.
+- `askResult`/`cancelAsk` copy `pickResult`/`cancelPick` including window-mismatch and retained lookups.
+- Tree: `askPending` is a top-level `ControlTree` field beside `pickPending` (`ControlProjection.swift`),
+  populated through the same closure path: `AppStore.swift` tree builder (`pickPending:` parameter and
+  call), the agterm-linux shim `ControlProtocolCompatibility.swift`, and the server closure in
+  `ControlServer.swift`. Nil is omitted from JSON like `pickPending`.
+
+### Modal gates
+
+Every site that reads the pending pick switches to `modalPending`. The grep
+`pick\.pending|PickRegistry\.shared|pickerActive|pickActive` over `agterm` and `agtermCore/Sources` finds
+about 48 hits in 20 files, and the task is complete only when that grep shows no `pending != nil` read
+left outside the pick host itself. Sites by kind:
+
+- host-free: `PaletteCatalog.swift` `PaletteContext.pickerActive`, the input to `modalActive`, which
+  `menu-actions.md` names as the single owner of menu enablement (rename to `modalPickerActive` or feed it
+  from `modalPending`; `PaletteCatalogTests` covers it)
+- menus and actions: `agtermApp+Menus.swift:68,330`, `AppActions.swift:48` (`uiActionsEnabled`),
+  `AppActions+Focus.pickActive`, `agtermApp.swift:482,729,736`
+- views: `GhosttySurfaceView.pickOwnsFocus`, `WindowContentView` frontmost/auto-follow handling and
+  palette-close-on-open, `WindowContentView+Dashboard.swift:110`, `+Zoom.swift:177`,
+  `+Titlebar.swift:192`, `+RecentSessions.swift` (six reads)
+- control entry points refusing `pick pending` today: `ControlServer.swift:646` (dashboard),
+  `ControlServer+AppCommands.swift:240` (quick terminal), `ControlServer+SurfaceIO.swift:404` (search),
+  `ControlServer+SessionActions.swift:699,724` (zoom); their message comes from one
+  `PickController.pendingModalError` (`pick pending` or `ask pending`) so the pick message and its tests
+  stay unchanged
+
+⌘W: `dismissPendingAsk(userInitiated: true)` resolves the cancel button or `cancelled`; termination and
+teardown call `cancelAsk()`.
+
+### View (`agterm/Views/AskDialogView.swift`)
+
+- Colors: `GhosttyApp.shared.terminalBackgroundColor` / `terminalForegroundColor` with the standard
+  fallbacks; a one-cell border in the foreground at reduced opacity; font from
+  `settingsModel.settings.fontFamily`/`fontSize` (the HUD's `cellSize` lookup).
+- Layout: title (bold), message (wrapped), then buttons in one row when the widest layout fits the anchor
+  frame minus padding, else one per row; caller order preserved either way. Width is clamped to the anchor.
+  A button reads `[ Label ]`; the highlighted one is drawn in inverse video (foreground and background
+  swapped); the hotkey letter is underlined; the `destructive` button carries a leading `!` marker
+  (`[ ! Delete ]`) and bold weight, since the app has no access to the theme's ANSI red.
+- Input: `AskKeyCatcher` (`NSViewRepresentable`, modelled on `DashboardKeyCatcher`) owns first responder
+  while mounted and maps Tab/Shift-Tab/arrows/Return/Esc/letters onto `AskNavigation` calls, dropping any
+  event with Command, Control, or Option; mouse click on a button activates it; the scrim consumes clicks
+  and does nothing.
+- Placement: mounted beside `pickPaletteOverlay` at the top of `WindowContentView`'s stack (zIndex 20),
+  not inside `windowOverlayLayer`, which is absent while zoomed. Geometry is live, not the HUD cache:
+  `Session.hudPaneFrames` is observation-ignored, merges only non-nil frames, and keeps stale frames for
+  hidden panes and deselected sessions, so it can neither drive resize nor prove visibility. Only the
+  SELECTED session's detail (`isActive`) publishes an `AskAnchorPreferenceKey` with the session container
+  bounds and each rendered pane's bounds, so the preference `reduce` never merges frames from the other
+  deck sessions the `ForEach` keeps mounted at opacity zero; the ask host resolves the anchors in its own
+  coordinate space (sidebar and titlebar offsets included). Session-wide uses the container bounds, `--pane` the named pane's bounds, no anchor
+  the whole window center below the titlebar. Validity is derived from state, not from the preference:
+  `store.selectedSessionID == anchor.sessionID`, and for a pane anchor the captured pane IDENTITY is
+  resolved to its CURRENT role first (`Session.askTargetPane`, the same identity-to-role lookup as
+  `hudTargetPane`), then `session.rendersPane(role)`; a nil role or a false `rendersPane` cancels. Both
+  geometry and validity use that resolved role, never the pane name given at open: when the primary
+  shell exits, `closePrimaryPane` promotes the right survivor and its identity to `left`, so a
+  right-anchored ask follows its pane into the left slot. Following one identity through a role change
+  is geometry movement, allowed; only a different anchor would be relocation, which never happens.
+- Accessibility ids: `ask-dialog`, `ask-title`, `ask-message`, `ask-button-<id>`.
+
+### CLI (`agtermctlKit/MiscCommands.swift`, `Ask` command)
+
+```
+agtermctl ask TITLE [--message TEXT] --button ID=LABEL [--button ...] [--hotkey ID=K ...]
+             [--default ID] [--cancel ID] [--destructive ID]
+             [--target SESSION] [--pane left|right] [--window W] [--follow] [--no-block]
+agtermctl ask result ID
+agtermctl ask cancel ID
+```
+
+- `--button ID=LABEL` splits on the first `=`; a missing `=` uses the token as both. `--hotkey ID=K`
+  attaches a hotkey to a declared button.
+- `--target` is `ask`'s own optional option, not `TargetOptions`, whose default of `active` would turn
+  every no-target call into an anchored one and break window-center placement.
+- `Ask.self` is registered in `Agtermctl.configuration.subcommands` (`agtermctlKit/Commands.swift`).
+- Default subcommand is open. Blocking poll, delays, abandon-on-transport-failure, and exit codes (0
+  answered, 2 cancelled, 1 failure) reuse the pick helpers, generalized to take the outcome kind.
+- `--no-block` prints `{"id":...}`. The one-shot `ask result ID` prints whatever the socket reports,
+  `pending` included, and exits 1 for pending like `pick result`.
+
+### Events
+
+No events: pick emits none either. Recorded here as the deliberate exemption from the
+event-arguments rule.
+
+## Implementation Steps
+
+### Task 1: Wire types and protocol round trip
+
+**Files:**
+- Create: `agtermCore/Sources/agtermCore/ControlAsk.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift` (nil fallthrough until Task 3)
+- Modify: `agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift`
+
+- [x] add `ControlAskButton`, `ControlAskOutcome`, `ControlAskResult`, `ResolvedAsk` (with sequence)
+- [x] add the three `Command` cases and the `ControlArgs`/`ControlResult` fields
+- [x] extend `ControlArgs`/`ControlResult` initializers
+- [x] round-trip tests for `ask.open` with every argument, `ask.result`, `ask.cancel`
+- [x] round-trip tests for every `ControlAskResult` shape (pending, answered, cancelled)
+- [x] run `swift test --filter ControlProtocolTests` (196 tests passed)
+
+### Task 2: Pending ask model on the shared modal slot
+
+**Files:**
+- Create: `agtermCore/Sources/agtermCore/Ask.swift`
+- Modify: `agtermCore/Sources/agtermCore/Pick.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/AskTests.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/PickTests.swift`
+
+- [ ] add `PendingAsk` and `AskAnchor`
+- [ ] add `pendingAsk`, `recentAskResults`, `openAsk`, `resolveAsk`, `cancelAsk`, `askResult(for:)`, and
+      `modalPending` to `PickController`; `open` and `openAsk` refuse while `modalPending`
+- [ ] `PickRegistry`: cancel and retain asks on `unregister`; add `liveAsk(for:)`, `retainedAskResult(for:)`
+- [ ] `AskNavigation` state machine (seeded highlight, forward/backward with first/last entry and wrap,
+      inert activate with no highlight, hotkey lookup)
+- [ ] tests: open/resolve/retain, cancel, result-by-id, retention cap, registry retention across unregister
+- [ ] tests: ask refuses while a pick is pending and pick refuses while an ask is pending
+- [ ] tests: the whole keyboard contract on `AskNavigation`, with and without `default`, one and six
+      buttons, hotkey case folding
+- [ ] run `swift test` for `AskTests` and `PickTests`
+
+### Task 3: Host-free validation and dispatch
+
+**Files:**
+- Create: `agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift` (`ControlActions` + routing)
+- Modify: `agtermCore/Tests/agtermCoreTests/MockControlActions.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift`
+
+- [ ] add `openAsk`, `askResult`, `cancelAsk` to `ControlActions`; route the three commands
+- [ ] implement every validation rule from Technical Details with pick-style messages
+- [ ] mock records the calls
+- [ ] table-driven tests: each rejection (title, buttons count, ids, labels, control chars, unknown role
+      ids, default==destructive, cancel==destructive, hotkey length and collision, pane without session,
+      invalid pane, missing result/cancel target)
+- [ ] tests: a valid open reaches the mock with the parsed `PendingAsk` fields intact
+- [ ] run `swift test` for the dispatcher suite
+
+### Task 4: App-side host and tree read-back
+
+**Files:**
+- Create: `agterm/Control/ControlServer+Ask.swift`
+- Modify: `agterm/Control/ControlServer+Hud.swift` (move `resolveHudPlacement` to a shared pane
+  placement resolver)
+- Modify: `agterm/Control/ControlServer.swift` (tree `askPending` closure)
+- Modify: `agtermCore/Sources/agtermCore/ControlProjection.swift`, `AppStore.swift` (tree builder
+  parameter and call), `ControlProtocolCompatibility.swift` (agterm-linux shim)
+- Modify: `agtermCore/Tests/agtermCoreTests/AppStoreTreeProjectionTests.swift`,
+  `ControlProtocolTests.swift`
+
+- [ ] `openAsk` resolves the session or placement window, requires a visible session and pane, rejects
+      an anchored open while zoom or dashboard covers the window, captures the anchor, opens on the
+      window's controller, handles `follow`, closes the palette, returns `result.pane` for a pane anchor
+- [ ] `askResult` and `cancelAsk` with the pick lookup order (live by id, retained, explicit window)
+- [ ] add top-level `askPending` through projection, store builder, shim, and server closure
+- [ ] projection test for `askPending` presence and absence; nil-omission test beside the `pickPending`
+      one in `ControlProtocolTests`
+- [ ] build the app target
+
+### Task 5: Shared modal gates and ⌘W/termination paths
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/PaletteCatalog.swift`,
+  `agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift`
+- Modify: `agterm/AppActions+Focus.swift`, `agterm/AppActions.swift`, `agterm/agtermApp.swift`,
+  `agterm/agtermApp+Menus.swift`, `agterm/AppDelegate.swift` (termination hook if it calls
+  `cancelAllPendingPicks`), `agterm/Ghostty/GhosttySurfaceView.swift`
+- Modify: `agterm/Views/WindowContentView.swift`, `WindowContentView+Dashboard.swift`,
+  `WindowContentView+Zoom.swift`, `WindowContentView+Titlebar.swift`, `WindowContentView+RecentSessions.swift`
+- Modify: `agterm/Control/ControlServer.swift`, `ControlServer+AppCommands.swift`,
+  `ControlServer+SurfaceIO.swift`, `ControlServer+SessionActions.swift`
+
+- [ ] switch every pending-pick predicate to `modalPending`, the five control entry points included,
+      with `pendingModalError` supplying the message; finish with the grep from Technical Details showing
+      no read left outside the pick host
+- [ ] `PaletteContext` takes the modal predicate; `modalActive` covers an ask
+- [ ] `dismissPendingAsk(userInitiated:)` for ⌘W; `cancelAllPendingModals` for termination
+- [ ] auto-follow suppression and quick-terminal hide pair with the ask exactly as with the pick
+- [ ] tests: `PaletteCatalogTests` case for `modalActive` under a pending ask
+- [ ] build the app target and run the existing `ControlPickUITests` once to confirm no regression
+
+### Task 6: Dialog view, keyboard, and placement
+
+**Files:**
+- Create: `agterm/Views/AskDialogView.swift`
+- Modify: `agtermCore/Sources/agtermCore/Session.swift` (`askTargetPane`),
+  `agtermCore/Tests/agtermCoreTests/SessionTests.swift`
+- Modify: `agterm/Views/WindowContentView.swift` (mount at zIndex 20 beside `pickPaletteOverlay`),
+  `agterm/Views/WindowContentView+Detail.swift` (publish `AskAnchorPreferenceKey` from the selected
+  session's container and rendered panes)
+
+- [ ] panel with theme colors, terminal font, title/message/buttons, horizontal-or-vertical layout
+- [ ] `AskKeyCatcher` maps key events onto `AskNavigation` (letters without modifiers, Esc, Return, Tab,
+      arrows) and nothing else
+- [ ] mouse activation on buttons; scrim swallows clicks; destructive marker and inverse-video highlight
+- [ ] live anchor geometry from the preference in the host's coordinate space (session container, one
+      pane, or whole-window center); the frame follows resize and sidebar changes
+- [ ] `Session.askTargetPane` resolves the captured identity to its current role; validity from state
+      (selected session, resolved role, `rendersPane`); the host cancels the ask when it fails
+- [ ] test in `SessionTests`: a right-anchored identity resolves to `left` after `closePrimaryPane`
+      promotes the survivor, and to nil once the pane is gone
+- [ ] accessibility identifiers
+- [ ] launch an isolated Debug instance and exercise open, keyboard, click, and pane anchoring by hand
+
+### Task 7: CLI command
+
+**Files:**
+- Create: `agtermCore/Sources/agtermctlKit/AskCommands.swift` (`MiscCommands.swift` is 741 lines and
+  the pick family alone is about 200; the package already splits per family)
+- Modify: `agtermCore/Sources/agtermctlKit/MiscCommands.swift` (share the poll loop with pick)
+- Modify: `agtermCore/Sources/agtermctlKit/Commands.swift` (register `Ask.self`)
+- Modify: `agtermCore/Sources/agtermctlKit/SocketClient.swift` (exit code and format helpers)
+- Modify: `agtermCore/Tests/agtermctlKitTests/CommandsTests.swift`,
+  `agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift`
+
+- [ ] `Ask` command with `Open` (default), `Result`, `Cancel`; button and hotkey parsing; its own
+      optional `--target`
+- [ ] register `Ask.self` in the root subcommand list
+- [ ] blocking poll and abandon reuse the pick loop, generalized over the outcome kind
+- [ ] tests through `Agtermctl.parseAsRoot`: every option, `ID=LABEL` split, default subcommand, no
+      target means no `target` in the request, request shaping
+- [ ] tests: exit codes and result formatting
+- [ ] run `swift test` for `agtermctlKitTests`
+
+### Task 8: Hosted UI tests
+
+**Files:**
+- Create: `agtermUITests/ControlAskUITests.swift`
+- Modify: `agtermUITests/ControlAPITestCase.swift` (ask helpers next to the pick helpers)
+
+- [ ] render, click a button, `askPending` in tree, result id/label/index, dialog dismissed
+- [ ] keyboard: no default leaves Return inert, Tab then Return answers the first button; hotkey answers
+- [ ] Esc with a cancel button answers it; Esc without returns `cancelled`
+- [ ] `ask.open` while a pick is pending is rejected, and the reverse
+- [ ] `dashboard`, `quick`, `session.search`, and zoom commands are refused while an ask is pending
+- [ ] `ask.cancel` on a dialog with a named cancel button returns `cancelled`, not the button; closing
+      the window while pending returns `cancelled` and the result stays readable afterwards
+- [ ] `--pane right` on a split session draws within the right pane frame; a hidden session rejects open;
+      selecting another session by control while anchored resolves `cancelled`; collapsing the split under
+      a session-wide anchor keeps the dialog up
+- [ ] an unanchored ask opened while zoom is active renders above it; an anchored one is rejected
+- [ ] run only `-only-testing:agtermUITests/ControlAskUITests`
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `.claude/rules/control-api.md`, `.claude/rules/menu-actions.md`, `site/commands.html`,
+  `site/docs.html`, `plugins/agterm/skills/agterm/SKILL.md`, `reference.md`, `examples.md`;
+  `ARCHITECTURE.md` does not list control widgets and `cookbook/` stays untouched
+
+- [ ] control-api.md: ask section (validation, shared slot, dismissal kinds, anchor rules, events
+      exemption) beside pick
+- [ ] menu-actions.md modal cover list names the pending ask
+- [ ] commands.html: `ask` section with arguments and read-back; docs.html mention in the control widgets
+      list
+- [ ] skill reference and examples: the command, one hook example (a yes/no before a destructive step)
+- [ ] no surface states a command count
+
+### Task 10: Verify acceptance criteria
+- [ ] every decision in Solution Overview is implemented and has a test
+- [ ] `cd agtermCore && swift test`
+- [ ] `make test-app`
+- [ ] `make lint` with zero findings
+- [ ] Debug instance: manual pass of the keyboard contract and a theme switch while the dialog is up
+
+### Task 11: [Final] Update documentation
+- [ ] CLAUDE.md if a new constraint surfaced during implementation
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification**:
+- run the bundled skill's example hook against a Release build installed with `make deploy`
+- confirm `agtermctl ask` from inside a session with no `--target` still draws at window center
+
+Smells pre-check: skipped — non-Go project

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -125,6 +125,7 @@ across ten files for no behavior; the shared-slot predicate is named `modalPendi
 
 ### Validation (`ControlDispatcher+Ask.swift`, host-free)
 
+- `ControlAskPlacement` carries parsed `pane` and unresolved `paneID` together in the host action.
 - `title` required and non-blank; `title`, `message`, and every label free of control characters.
 - 1...6 buttons (`ControlAskButton.maxButtons = 6`), unique ids, non-empty labels.
 - `default`, `cancel`, `destructive` must each name an existing button; `default == destructive` and
@@ -292,17 +293,18 @@ event-arguments rule.
 **Files:**
 - Create: `agtermCore/Sources/agtermCore/ControlDispatcher+Ask.swift`
 - Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift` (`ControlActions` + routing)
+- Modify: `agtermCore/Sources/agtermCore/ControlActionsDefaults.swift` (unsupported-host defaults)
 - Modify: `agtermCore/Tests/agtermCoreTests/MockControlActions.swift`
 - Create: `agtermCore/Tests/agtermCoreTests/ControlDispatcherAskTests.swift`
 
-- [ ] add `openAsk`, `askResult`, `cancelAsk` to `ControlActions`; route the three commands
-- [ ] implement every validation rule from Technical Details with pick-style messages
-- [ ] mock records the calls
-- [ ] table-driven tests: each rejection (title, buttons count, ids, labels, control chars, unknown role
+- [x] add `openAsk`, `askResult`, `cancelAsk` to `ControlActions`; route the three commands
+- [x] implement every validation rule from Technical Details with pick-style messages
+- [x] mock records the calls
+- [x] table-driven tests: each rejection (title, buttons count, ids, labels, control chars, unknown role
       ids, default==destructive, cancel==destructive, hotkey length and collision, pane without session,
       invalid pane, missing result/cancel target)
-- [ ] tests: a valid open reaches the mock with the parsed `PendingAsk` fields intact
-- [ ] run `swift test` for the dispatcher suite
+- [x] tests: a valid open reaches the mock with the parsed `PendingAsk` fields intact
+- [x] run `swift test --filter 'agtermCoreTests\.ControlDispatcher(Ask|Pick|Hud)Tests/'` (51 tests passed)
 
 ### Task 4: App-side host and tree read-back
 

--- a/docs/plans/20260905-ask-dialog.md
+++ b/docs/plans/20260905-ask-dialog.md
@@ -539,16 +539,19 @@ style passed as is.
       label still wraps within that shared width; hosted render with "OK" beside "Cancel everything"
 
 ### Task 12: Verify acceptance criteria
-- [ ] every decision in Solution Overview is implemented and has a test
-- [ ] `cd agtermCore && swift test`
-- [ ] `make test-app`
-- [ ] `make lint` with zero findings
-- [ ] Debug instance: manual pass of the keyboard contract and a theme switch while the dialog is up,
-      in both styles
+- [x] every decision in Solution Overview is implemented and has a test
+- [x] `cd agtermCore && swift test`
+- [x] `make test-app`
+- [x] `make lint` with zero findings
+- [x] Debug instance: manual pass of the keyboard contract and a theme switch while the dialog is up,
+      in both styles. Socket theme-change/pending/cancel checks passed in both styles.
+      Keyboard input and visual theme checks skipped: accessibility, screen-capture, and event-posting
+      permissions are denied. Isolated PID 60256 stopped with SIGTERM.
 
 ### Task 13: [Final] Update documentation
-- [ ] CLAUDE.md if a new constraint surfaced during implementation
-- [ ] move this plan to `docs/plans/completed/`
+- [x] CLAUDE.md if a new constraint surfaced during implementation (none; the ask contract lives in
+      control-api.md and menu-actions.md)
+- [x] move this plan to `docs/plans/completed/` (deferred to the merge: the exec run leaves the plan in place)
 
 ## Post-Completion
 

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -5,16 +5,18 @@ description: >
   running inside an agterm session and asked to control the terminal: create, rename, close, select or
   reorder sessions and workspaces; split panes; toggle the scratch terminal; run a program in an overlay
   and read its exit status; post a HUD panel or a desktop notification; show a native picker with
-  caller-supplied choices; display an image inline; type into a session, copy its selection or search its
-  scrollback; manage windows; change font size; set the theme; reload or edit the keymap and the
-  agterm-scoped ghostty config; subscribe to status, notification, lifecycle and tree-change events.
+  caller-supplied choices or a question dialog with named buttons; display an image inline; type into a
+  session, copy its selection or search its scrollback; manage windows; change font size; set the theme;
+  reload or edit the keymap and the agterm-scoped ghostty config; subscribe to status, notification,
+  lifecycle and tree-change events.
   Covers the window/workspace/session addressing model and the AGTERM_* environment a spawned shell sees,
   attaching a session running on another Mac, the cookbook recipes, the running version, and diagnosing
   problems or filing an agterm bug or feature request.
 when_to_use: >
   Trigger on: agterm, agtermctl, AGTERM_SESSION_ID, and, from inside a session, plain requests such as
-  split the pane, close the overlay, show a message over the session, show an image inline, search the
-  scrollback, attach a session from another Mac, what recipes are there, the keymap editor will not open.
+  split the pane, close the overlay, show a message over the session, show a question dialog, agtermctl ask,
+  show an image inline, search the scrollback, attach a session from another Mac, what recipes are there,
+  the keymap editor will not open.
 allowed-tools: Bash(agtermctl *)
 ---
 
@@ -100,7 +102,7 @@ sidebar is currently shown — the read side of the write-only `sidebar` command
 (`tree` or `flagged` — the read side of `sidebar mode`), `sidebarWidth` (the sidebar divider position in
 points — the read side of `sidebar width`, on `tree` only), `workspaceFilter`, `quickVisible` (whether the
 quick terminal is shown — the read side of the write-only `quick` command; app-level, so every window
-reports the same value), `zoomedSurface`, the four `dashboard*` fields, `pickPending`, and `app` (the
+reports the same value), `zoomedSurface`, the four `dashboard*` fields, `pickPending`, `askPending`, and `app` (the
 serving app's `version`, plus `commit` when the build recorded one — the same value `agtermctl version`
 returns). reference.md lists every one with its exact shape. List windows with
 `agtermctl window list --json`; each window also reports `autoFollowMs`, `sidebarVisible`, `geometry`
@@ -517,8 +519,21 @@ the field and filters on open, which re-ranks and drops that order. An empty ite
 `< /dev/null` or it blocks. The default blocks until the user chooses or cancels and prints the bare JSON
 result. `--no-block` prints the picker id instead;
 `pick result ID [--window W]` reads it later, and `pick cancel ID [--window W]` cancels it.
-Only one picker may be pending per window. It opens without raising a background target unless
+Only one pick or ask may be pending per window. It opens without raising a background target unless
 `--follow` is set. Read the live picker id from the tree's top-level `pickPending` field.
+
+**ask**: `ask TITLE --button ID=LABEL [--button ...] [--message TEXT]` opens a themed question with
+one to six buttons and blocks for a bare JSON answer. `--default ID` seeds the highlight;
+`--destructive ID` styles a button that cannot be the default.
+`--hotkey ID=LETTER` adds a letter shortcut. Without a default, use Tab/arrows before Return.
+`--style terminal|gui` defaults to `terminal`; `gui` uses the picker's material appearance and native
+buttons. Style changes only decoration, has no read-back, and rejects other values as `unknown style`.
+No `--target` centers in the window; a selected session target uses its whole area, narrowed by
+`--pane` or `--pane-id`. `--window` selects the window and `--follow` raises it.
+Exit 0 means answered, including No: inspect `.id` before acting. Esc/Command-W return `escaped`
+with exit 3; `ask.cancel`, window teardown, app termination, and anchor loss return `cancelled` with exit 2.
+`--no-block` returns an id for `ask result ID` or `ask cancel ID`; result/cancel accept `--window`.
+Tree reports `askPending`. See reference.md for validation, anchor loss, and retained results.
 
 **quick** — `quick [show|hide|toggle]` (visibility; read back from the tree's `quickVisible`; a panel YOU open
 with `quick show` stays up when agterm loses focus, unlike one the user summoned by hotkey, so a following

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -525,10 +525,12 @@ Only one pick or ask may be pending per window. It opens without raising a backg
 **ask**: `ask TITLE --button ID=LABEL [--button ...] [--message TEXT]` opens a themed question with
 one to six buttons and blocks for a bare JSON answer. `--default ID` seeds the highlight;
 `--destructive ID` styles a button that cannot be the default.
-`--hotkey ID=LETTER` adds a letter shortcut. Without a default, use Tab/arrows before Return.
+`--hotkey ID=LETTER` adds a letter shortcut. Without a default, the first non-destructive button is
+active (the first button if it is the only choice). Return always activates the highlighted button.
 `--style terminal|gui` defaults to `terminal`; `gui` uses the picker's material appearance and native
-buttons. Style changes only decoration, has no read-back, and rejects other values as `unknown style`.
-No `--target` centers in the window; a selected session target uses its whole area, narrowed by
+buttons. `--align left|center|right` aligns the button block in either style (default `right`).
+Style changes only decoration, has no read-back, and rejects other values as `unknown style`.
+No `--target` centers over the terminal area, excluding the sidebar; a selected session target uses its whole area, narrowed by
 `--pane` or `--pane-id`. `--window` selects the window and `--follow` raises it.
 Exit 0 means answered, including No: inspect `.id` before acting. Esc/Command-W return `escaped`
 with exit 3; `ask.cancel`, window teardown, app termination, and anchor loss return `cancelled` with exit 2.

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -529,6 +529,7 @@ one to six buttons and blocks for a bare JSON answer. `--default ID` seeds the h
 active (the first button if it is the only choice). Return always activates the highlighted button.
 `--style terminal|gui` defaults to `terminal`; `gui` uses the picker's material appearance and native
 buttons. `--align left|center|right` aligns the button block in either style (default `right`).
+`--width N` fixes the width to 10...100 percent of the anchor; omitted means automatic content sizing.
 Style changes only decoration, has no read-back, and rejects other values as `unknown style`.
 No `--target` centers over the terminal area, excluding the sidebar; a selected session target uses its whole area, narrowed by
 `--pane` or `--pane-id`. `--window` selects the window and `--follow` raises it.

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -929,6 +929,30 @@ agtermctl pick cancel "$pick_id" --window "$AGTERM_WINDOW_ID"
 Add `--follow` to raise a background target window when the picker opens. Without it, the picker waits in
 that window without stealing focus.
 
+## Require a yes/no answer in a cleanup hook
+
+A shell cleanup hook can require approval before removing `./build`. This example runs inside
+agterm and requires `jq`. Only an `answered` result with id `yes` reaches the removal:
+
+```bash
+#!/usr/bin/env bash
+answer=$(agtermctl ask "Remove ./build?" \
+  --message "Delete $PWD/build." \
+  --button yes=Delete --button no=Keep --default no --destructive yes \
+  --window "${AGTERM_WINDOW_ID:?run this hook inside agterm}" --follow \
+  --socket "${AGTERM_SOCKET:?run this hook inside agterm}") || exit 1
+
+printf '%s\n' "$answer" |
+  jq -e '.result == "answered" and .id == "yes"' >/dev/null || exit 1
+rm -rf -- ./build
+```
+
+Choosing Keep returns an answer with exit 0, so the id check is required. Esc and Command-W return
+`escaped` with exit 3; cancellation returns `cancelled` with exit 2. Both stop the hook.
+`ask` leaves the hook's stdin untouched. Omit `--target` to keep the question centered in its window
+even when the hook's session is not selected. The default `--style terminal` uses the terminal theme;
+add `--style gui` for the picker's material appearance and native buttons. The hook's behavior is the same.
+
 ## Say what you are doing while the user waits
 
 `session hud` posts a passive panel over a session. The session keeps focus and stays typable under it, so

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -949,7 +949,7 @@ rm -rf -- ./build
 
 Choosing Keep returns an answer with exit 0, so the id check is required. Esc and Command-W return
 `escaped` with exit 3; cancellation returns `cancelled` with exit 2. Both stop the hook.
-`ask` leaves the hook's stdin untouched. Omit `--target` to keep the question centered in its window
+`ask` leaves the hook's stdin untouched. Omit `--target` to keep the question centered over its window's terminal area
 even when the hook's session is not selected. The default `--style terminal` uses the terminal theme;
 add `--style gui` for the picker's material appearance and native buttons. The hook's behavior is the same.
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1048,14 +1048,17 @@ unique case-insensitively. Command, Control, and Option combinations do not trig
 Outside clicks leave the dialog open.
 
 `--style terminal|gui` defaults to `terminal`. Terminal style uses monospace text and the theme's
-background and foreground. Buttons have padded, bracketed labels and a dim foreground fill; the active
-button uses solid foreground fill and background-colored text. GUI style uses the picker's material,
+background and foreground. Both styles fit their content, capped at 90 percent of the anchor width and
+72 cells; labels wrap and buttons fall back to a column. Buttons have padded labels and a
+dim foreground fill; the active button uses solid foreground fill and background-colored text. GUI style uses the picker's material,
 corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
 Native push buttons sit in a row, with a prominent accent-colored highlight and a red-tinted
 destructive button that becomes prominent red when highlighted; colors follow the system appearance. Both styles share keyboard behavior, hotkeys,
 results, anchoring, and modality. Style has no read-back; an invalid value returns `unknown style`.
 `--align left|center|right` defaults to `right` and aligns the entire button block in either style,
 including its vertical fallback. It has no read-back; invalid values return `unknown align`.
+`--width N` replaces automatic sizing with a fixed integer percentage of the anchor width, 10...100,
+for either style. It has no read-back; invalid values return `width must be 10 to 100`.
 
 Omit `--target` to center over the terminal area, excluding the sidebar, or name a session to center over
 its whole area. A target must be

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1040,9 +1040,9 @@ Supply one to six buttons with unique ids and nonempty labels. A token without `
 label; otherwise only the first `=` separates them. The title must be nonblank, and title, message,
 and labels cannot contain control characters.
 
-`--default ID` names the initially highlighted button. Without it, Return is inert until Tab or an
-arrow selects one. Tab/Right/Down enter at the first button; Shift-Tab/Left/Up enter at the last;
-navigation wraps. Return chooses the highlight. Repeat `--hotkey ID=LETTER` for letter shortcuts,
+`--default ID` names the initially highlighted button. Otherwise the first non-destructive button is
+highlighted, or the first button if it is the only choice. Exactly one button is active. Tab/Right/Down
+move forward; Shift-Tab/Left/Up move back; navigation wraps. Return chooses the highlight. Repeat `--hotkey ID=LETTER` for letter shortcuts,
 unique case-insensitively. Command, Control, and Option combinations do not trigger them.
 `--destructive ID` adds the destructive marker; it cannot name the default button.
 Outside clicks leave the dialog open.
@@ -1051,11 +1051,14 @@ Outside clicks leave the dialog open.
 background and foreground. Buttons have padded, bracketed labels and a dim foreground fill; the active
 button uses solid foreground fill and background-colored text. GUI style uses the picker's material,
 corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
-Native push buttons sit in a trailing row, with a prominent accent-colored default and a red-tinted
-destructive button; colors follow the system appearance. Both styles share keyboard behavior, hotkeys,
+Native push buttons sit in a row, with a prominent accent-colored highlight and a red-tinted
+destructive button that becomes prominent red when highlighted; colors follow the system appearance. Both styles share keyboard behavior, hotkeys,
 results, anchoring, and modality. Style has no read-back; an invalid value returns `unknown style`.
+`--align left|center|right` defaults to `right` and aligns the entire button block in either style,
+including its vertical fallback. It has no read-back; invalid values return `unknown align`.
 
-Omit `--target` to center in the window, or name a session to center over its whole area. A target must be
+Omit `--target` to center over the terminal area, excluding the sidebar, or name a session to center over
+its whole area. A target must be
 selected in its owning window. `--pane left|right` narrows the anchor and requires `--target`;
 `--pane-id TOKEN` resolves a live pane token first, using `--pane` as fallback. A hidden pane or
 session is rejected, as is an anchored open under zoom or dashboard. `--window W` selects the window;

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1001,7 +1001,8 @@ keystroke replaces it rather than appending. `--allow-custom` adds a row for a n
 query and returns it as a custom result; with an empty item list that row is the only possible one, and it
 appears as soon as the query is nonblank, prefilled or typed; whitespace and newlines are trimmed first.
 A background `--window` target is not raised by default; `--follow` raises it. Only one pick or ask can be
-pending in a window, and a second open fails with `pick already pending`.
+pending in a window, and a second open fails with `pick already pending`, or `ask already pending` when a
+dialog owns the slot.
 
 The default call polls until the user answers and prints one bare JSON result:
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -248,13 +248,14 @@ as both), `dashboardHighlighted` (the highlighted cell's pane ref — the one En
 that exact pane), `dashboardFontSize` (the absolute font size in points applied to the cells, omitted when
 the mode is `untouched`), and `dashboardFontMode` (`auto` for `--auto-size`, `fixed` for `--font-size`, or
 `untouched`), plus `pickPending` (the id of the native picker currently awaiting an answer in this
-window, omitted when none is pending), and `app` (which agterm is serving this socket: `version`, plus
+window, omitted when none is pending), `askPending` (the pending question's id, also omitted when absent),
+and `app` (which agterm is serving this socket: `version`, plus
 `commit` when the build recorded one — the same value `agtermctl version` returns, so an agent already
 reading the tree gets its version floor without a second round-trip; it is not duplicated onto
 `window.list`, where a caller uses `version` instead). `idleMs` is live
 and grows while the window is idle, so it is on `tree` only, never `window.list`; `sidebarVisible` is on
 both; `sidebarMode`, `sidebarWidth`, `workspaceFilter`, `quickVisible`, `zoomedSurface`, the four
-`dashboard*` fields, and `pickPending`
+`dashboard*` fields, `pickPending`, and `askPending`
 are `tree`-only (a GUI/keyboard change would leave a cached copy stale). All of those are read-only
 projections of live GUI state. `app` is the one CONSTANT among them, and is absent from `window.list`
 for a different reason: it describes the serving app rather than a window, so repeating it on every row
@@ -999,7 +1000,7 @@ by match score and so does not preserve the supplied order; the seeded text open
 keystroke replaces it rather than appending. `--allow-custom` adds a row for a nonmatching
 query and returns it as a custom result; with an empty item list that row is the only possible one, and it
 appears as soon as the query is nonblank, prefilled or typed; whitespace and newlines are trimmed first.
-A background `--window` target is not raised by default; `--follow` raises it. Only one picker can be
+A background `--window` target is not raised by default; `--follow` raises it. Only one pick or ask can be
 pending in a window, and a second open fails with `pick already pending`.
 
 The default call polls until the user answers and prints one bare JSON result:
@@ -1028,6 +1029,61 @@ whose next poll races process shutdown may observe a transport failure instead o
 A terminal result stays readable by its own id after the next picker opens in that window, and after the
 window closes — including permanent window deletion — so a blocking caller always reads back the answer
 it waited for. Results age out oldest-first: the 8 most recent per open window, and 32 across closed ones.
+
+## ask
+
+`agtermctl ask [open] TITLE --button ID=LABEL [--button ...] [--message TEXT]` opens a themed,
+window-modal question. It takes no stdin. Only one pick or ask can be pending in a window.
+Use explicit `ask open` when the title is `open`, `result`, or `cancel`.
+
+Supply one to six buttons with unique ids and nonempty labels. A token without `=` is both id and
+label; otherwise only the first `=` separates them. The title must be nonblank, and title, message,
+and labels cannot contain control characters.
+
+`--default ID` names the initially highlighted button. Without it, Return is inert until Tab or an
+arrow selects one. Tab/Right/Down enter at the first button; Shift-Tab/Left/Up enter at the last;
+navigation wraps. Return chooses the highlight. Repeat `--hotkey ID=LETTER` for letter shortcuts,
+unique case-insensitively. Command, Control, and Option combinations do not trigger them.
+`--destructive ID` adds the destructive marker; it cannot name the default button.
+Outside clicks leave the dialog open.
+
+`--style terminal|gui` defaults to `terminal`. Terminal style uses monospace text and the theme's
+background and foreground. Buttons have padded, bracketed labels and a dim foreground fill; the active
+button uses solid foreground fill and background-colored text. GUI style uses the picker's material,
+corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
+Native push buttons sit in a trailing row, with a prominent accent-colored default and a red-tinted
+destructive button; colors follow the system appearance. Both styles share keyboard behavior, hotkeys,
+results, anchoring, and modality. Style has no read-back; an invalid value returns `unknown style`.
+
+Omit `--target` to center in the window, or name a session to center over its whole area. A target must be
+selected in its owning window. `--pane left|right` narrows the anchor and requires `--target`;
+`--pane-id TOKEN` resolves a live pane token first, using `--pane` as fallback. A hidden pane or
+session is rejected, as is an anchored open under zoom or dashboard. `--window W` selects the window;
+`--follow` raises it. Resize and pane-role changes preserve the captured identity. Closing or
+deselecting the session, or removing or hiding the anchored pane, returns `cancelled`.
+Session-wide placement and a pane that stays visible survive split collapse.
+
+The blocking call prints one bare result:
+
+```json
+{"result":"answered","id":"yes","label":"Yes","index":0}
+{"result":"escaped"}
+{"result":"cancelled"}
+```
+
+Index is the caller's button order. An answer exits 0, including a named No button, so check `id`
+before acting. Esc and Command-W return `escaped` with exit 3. `ask.cancel`, window teardown,
+app termination, and anchor loss return `cancelled` with exit 2. Failure exits 1.
+
+`--no-block` prints `{"id":"<ask-id>"}`. `agtermctl ask result ID [--window W]` prints the current
+or terminal result, including `{"result":"pending"}` with exit 1. `agtermctl ask cancel ID [--window W]`
+returns `ok` on success and cancels only a pending dialog; an already-resolved id is a successful no-op.
+Both use the exact global id, independent of the frontmost window; an explicit window must match.
+
+Tree exposes top-level `askPending` while waiting and omits it after resolution. The raw `ask.open`
+response also echoes `result.pane` for pane placement. Results retain the latest eight per open
+window and 32 across closed windows, separately from pick. Window closure cancels a pending ask;
+app shutdown can end polling with a transport failure. Ask emits no events.
 
 ## quick
 

--- a/site/commands.html
+++ b/site/commands.html
@@ -2386,7 +2386,7 @@
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
                 agtermctl ask [open] TITLE --button ID=LABEL [--button ...] [--message TEXT]
-                [--hotkey ID=LETTER ...] [--default ID] [--destructive ID] [--style terminal|gui] [--align left|center|right]
+                [--hotkey ID=LETTER ...] [--default ID] [--destructive ID] [--style terminal|gui] [--align left|center|right] [--width N]
                 [--target T] [--pane left|right] [--pane-id TOKEN] [--window W] [--follow] [--no-block]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">ask.open</div>
@@ -2397,7 +2397,7 @@
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style terminal</span> is the default:
-                monospace text, theme colors, and padded, bracketed buttons with a dim foreground fill. The active button
+                monospace text, theme colors, and padded buttons with a dim foreground fill. The active button
                 has solid foreground fill and background-colored text.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style gui</span> uses the picker's material,
                 corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
@@ -2410,6 +2410,11 @@
                 (wire argument <span style="font-family: &quot;JetBrains Mono&quot;, monospace">align</span>) defaults to right.
                 It aligns the whole button block in either style, including the vertical fallback, with no read-back.
                 Invalid values return <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown align</span>.
+                Both styles fit their content up to 90 percent of the anchor width and 72 cells.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--width N</span> (wire argument
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">width</span>) replaces that automatic sizing
+                with a fixed integer percentage of the anchor, 10 through 100. It has no read-back; invalid values return
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">width must be 10 to 100</span>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--default</span> seeds the highlight. Without it,

--- a/site/commands.html
+++ b/site/commands.html
@@ -2313,7 +2313,7 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick item label must not be empty</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick item ids must be unique</span>, or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">item text must not contain control characters</span>.
-                A second live picker returns <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick already pending</span>;
+                A second live picker returns <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick already pending</span>, or <span style="font-family: &quot;JetBrains Mono&quot;, monospace">ask already pending</span> when a dialog owns the slot;
                 an unavailable target returns the standard window-resolution error,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no open window</span>, or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no pick surface</span>.

--- a/site/commands.html
+++ b/site/commands.html
@@ -2386,7 +2386,7 @@
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
                 agtermctl ask [open] TITLE --button ID=LABEL [--button ...] [--message TEXT]
-                [--hotkey ID=LETTER ...] [--default ID] [--destructive ID] [--style terminal|gui]
+                [--hotkey ID=LETTER ...] [--default ID] [--destructive ID] [--style terminal|gui] [--align left|center|right]
                 [--target T] [--pane left|right] [--pane-id TOKEN] [--window W] [--follow] [--no-block]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">ask.open</div>
@@ -2401,20 +2401,26 @@
                 has solid foreground fill and background-colored text.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style gui</span> uses the picker's material,
                 corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
-                Native buttons sit in a trailing row; the default is prominent in the accent color and destructive is tinted red,
+                Native buttons sit in a row; the current highlight is prominent in the accent color and destructive is tinted red,
+                becoming prominent red when highlighted,
                 with no hard-coded colors. Both styles share keyboard behavior, hotkeys, results, anchoring, and modality.
                 The wire argument is <span style="font-family: &quot;JetBrains Mono&quot;, monospace">style</span>;
                 it has no read-back. Invalid values return <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown style</span>.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--align left|center|right</span>
+                (wire argument <span style="font-family: &quot;JetBrains Mono&quot;, monospace">align</span>) defaults to right.
+                It aligns the whole button block in either style, including the vertical fallback, with no read-back.
+                Invalid values return <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown align</span>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--default</span> seeds the highlight. Without it,
-                Return is inert until Tab or an arrow selects a button; navigation wraps. Return chooses the highlight.
+                the first non-destructive button is active, or the first if it is the only choice. Tab and arrows
+                move the highlight and wrap. Return chooses the active button in either style.
                 Hotkeys are single ASCII letters, unique case-insensitively.
                 A <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--destructive</span> button cannot be the default.
                 Outside clicks leave the question open.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                No <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> centers in the window.
+                No <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> centers over the terminal area, excluding the sidebar.
                 A session target must be selected and anchors to its whole area.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span> narrows placement;
                 a live <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane-id</span> takes precedence.

--- a/site/commands.html
+++ b/site/commands.html
@@ -2403,7 +2403,7 @@
                 corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
                 Native buttons sit in a row; the current highlight is prominent in the accent color and destructive is tinted red,
                 becoming prominent red when highlighted,
-                with no hard-coded colors. Both styles share keyboard behavior, hotkeys, results, anchoring, and modality.
+                with system colors only, so light and dark follow the picker. Both styles share keyboard behavior, hotkeys, results, anchoring, and modality.
                 The wire argument is <span style="font-family: &quot;JetBrains Mono&quot;, monospace">style</span>;
                 it has no read-back. Invalid values return <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown style</span>.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--align left|center|right</span>

--- a/site/commands.html
+++ b/site/commands.html
@@ -6,7 +6,7 @@
     <title>Command reference — agterm | agtermctl control API</title>
     <meta
       name="description"
-      content="Complete agtermctl reference: every agtermctl control command for agterm, including sessions, workspaces, windows, overlays, the native picker, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
+      content="Complete agtermctl reference: every agtermctl control command for agterm, including sessions, workspaces, windows, overlays, the native picker, question dialogs, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
     />
     <meta
       name="keywords"
@@ -195,6 +195,7 @@
             <a href="#surface" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">surface</a>
             <a href="#dashboard" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">dashboard</a>
             <a href="#pick" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">pick</a>
+            <a href="#ask" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">ask</a>
             <a href="#quick" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">quick</a>
             <a href="#sidebar" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">sidebar</a>
             <a href="#notify" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">notify</a>
@@ -365,9 +366,10 @@
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc; white-space: nowrap">--window &lt;id|prefix|active&gt;</span>
-              (on session, workspace, tree, font, notify, and pick commands) picks which window's tree to act on; the default is the
-              frontmost. With it set, that window must be open; without it, an id/prefix session target is matched across all open
-              windows. The <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">window.*</span> commands
+              (on session, workspace, tree, font, notify, pick, and ask commands) selects the window; the default is the
+              frontmost. Current-state operations require an open window; pick and ask result/cancel also accept a closed
+              owning window while its result is retained. Without a window selector, an id/prefix session target is matched across
+              all open windows. The <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">window.*</span> commands
               instead take the window selector as a positional argument, defaulting to
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">active</span> (frontmost). A window need
               not be open to be a <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">window.*</span>
@@ -553,6 +555,8 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quickVisible</span>, and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> (the pending native picker's id,
                 omitted when none is open),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">askPending</span> (the pending question's id,
+                omitted after resolution),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomedSurface</span>, the four
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">dashboard*</span> fields, and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">app</span> (which agterm is serving this socket —
@@ -2263,7 +2267,7 @@
               pick
             </h2>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
-              A caller-supplied fuzzy picker rendered by agterm. One picker may be pending in each window.
+              A caller-supplied fuzzy picker rendered by agterm. One pick or ask may be pending in each window.
             </p>
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
@@ -2356,6 +2360,114 @@
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <strong style="color: #bfbab0">Tree read-back:</strong> cancellation removes
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> from the target tree.
+              </p>
+            </div>
+          </section>
+
+          <!-- ASK -->
+          <section id="ask" style="scroll-margin-top: 88px; padding-top: 56px">
+            <h2
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 700;
+                font-size: 28px;
+                letter-spacing: -0.02em;
+                margin: 0 0 16px;
+                padding-bottom: 12px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+              "
+            >
+              ask
+            </h2>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              A themed question with named buttons. It is modal to its window and shares one pending slot with pick.
+            </p>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl ask [open] TITLE --button ID=LABEL [--button ...] [--message TEXT]
+                [--hotkey ID=LETTER ...] [--default ID] [--destructive ID] [--style terminal|gui]
+                [--target T] [--pane left|right] [--pane-id TOKEN] [--window W] [--follow] [--no-block]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">ask.open</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Supply a nonblank title and one to six buttons with unique ids and nonempty labels. A button token without
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">=</span> is both id and label; otherwise split at
+                the first equals sign. Title, message, and labels reject control characters. The command takes no stdin.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style terminal</span> is the default:
+                monospace text, theme colors, and padded, bracketed buttons with a dim foreground fill. The active button
+                has solid foreground fill and background-colored text.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style gui</span> uses the picker's material,
+                corner radius, and light/dark appearance, system fonts, a headline title, and a secondary-colored message.
+                Native buttons sit in a trailing row; the default is prominent in the accent color and destructive is tinted red,
+                with no hard-coded colors. Both styles share keyboard behavior, hotkeys, results, anchoring, and modality.
+                The wire argument is <span style="font-family: &quot;JetBrains Mono&quot;, monospace">style</span>;
+                it has no read-back. Invalid values return <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown style</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--default</span> seeds the highlight. Without it,
+                Return is inert until Tab or an arrow selects a button; navigation wraps. Return chooses the highlight.
+                Hotkeys are single ASCII letters, unique case-insensitively.
+                A <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--destructive</span> button cannot be the default.
+                Outside clicks leave the question open.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                No <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> centers in the window.
+                A session target must be selected and anchors to its whole area.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span> narrows placement;
+                a live <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane-id</span> takes precedence.
+                Both require a target. Hidden targets and anchored opens under zoom/dashboard are rejected.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--follow</span> raises the owning window.
+                Resize and pane-role changes preserve the anchor; losing it cancels the question.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Blocking output is
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"result":"answered","id":"yes","label":"Yes","index":0}</span>
+                or a dismissal result: Esc and Command-W return
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"result":"escaped"}</span> with exit 3;
+                cancellation returns <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"result":"cancelled"}</span> with exit 2.
+                Index follows caller order. An answer exits 0, including No; failure exits 1.
+                Check the returned id before acting.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--no-block</span> prints
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"id":"…"}</span> immediately.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <strong style="color: #bfbab0">Read-back:</strong> top-level
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">askPending</span> in tree holds the waiting id.
+                The raw protocol's open reply includes <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.pane</span>
+                for pane placement. Ask state is poll-only.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl ask result &lt;id&gt; [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">ask.result</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Read the exact global id, independent of the frontmost window. An explicit
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> must match.
+                Prints the bare result, including <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"result":"pending"}</span>
+                with exit 1. Terminal results keep the latest eight per open window and 32 across closed windows.
+                An unknown id returns <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown ask: &lt;id&gt;</span>.
+                App shutdown can interrupt polling.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl ask cancel &lt;id&gt; [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">ask.cancel</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Resolve a pending question as <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cancelled</span>. The cancel command returns
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">ok</span>; a retained terminal result is a successful no-op.
+                The exact id and optional window follow the result command's rules. Window teardown, app termination,
+                and anchor loss also return <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cancelled</span> to the waiting caller.
+                Resolution removes <span style="font-family: &quot;JetBrains Mono&quot;, monospace">askPending</span>
+                from tree.
               </p>
             </div>
           </section>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1992,14 +1992,17 @@
               The default <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style terminal</span> uses monospace text
               and theme-colored filled buttons; <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style gui</span>
               uses the picker's material appearance, system fonts, and native buttons. Both styles share placement and behavior.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--align left|center|right</span> aligns the button
+              block in either style, including a vertical column; the default is right.
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
-              Without a default, use Tab or arrows before Return. Esc and Command-W return
+              Without a default, the first non-destructive button is active, or the first if it is the only choice.
+              Tab and arrows move the highlight; Return activates it in either style. Esc and Command-W return
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">escaped</span> with exit 3.
               Cancellation through the API, window teardown, app termination, or anchor loss returns
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cancelled</span> with exit 2.
               Target a selected session to center over its whole area, optionally narrowed to a pane; omit the target for
-              window-center placement. See the <a href="/commands#ask" style="color: #6d82f3">ask reference</a> for flags,
+              placement over the terminal area, excluding the sidebar. See the <a href="/commands#ask" style="color: #6d82f3">ask reference</a> for flags,
               result polling, and cancellation.
             </p>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -751,7 +751,7 @@
               The building block is the <strong style="color: #e6e1d7">control API</strong>. Overlays are one entry in a much
               larger catalog: the same
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">agtermctl</span> creates and renames
-              sessions, splits panes, moves windows, opens the native picker, reads a session's text back, and posts
+              sessions, splits panes, moves windows, opens the native picker or a question dialog, reads a session's text back, and posts
               notifications. Every state it sets it also reads back, which is what lets a script build a whole layout rather than
               fire a single action.
             </p>
@@ -1973,6 +1973,35 @@
               agtermctl tree --json | jq -r
               <span style="color: #f2b45c">'.result.tree.pickPending // empty'</span>
             </div>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 24px 0 12px;
+              "
+            >
+              Question dialogs
+            </h3>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">agtermctl ask "Continue?" --button yes=Yes --button no=No --default no</span>
+              opens a themed dialog and blocks for a bare JSON answer. Inspect its id before acting: Yes and No both exit 0.
+              An ask is modal to its window and shares one pending slot with pick.
+              The default <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style terminal</span> uses monospace text
+              and theme-colored filled buttons; <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--style gui</span>
+              uses the picker's material appearance, system fonts, and native buttons. Both styles share placement and behavior.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              Without a default, use Tab or arrows before Return. Esc and Command-W return
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">escaped</span> with exit 3.
+              Cancellation through the API, window teardown, app termination, or anchor loss returns
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cancelled</span> with exit 2.
+              Target a selected session to center over its whole area, optionally narrowed to a pane; omit the target for
+              window-center placement. See the <a href="/commands#ask" style="color: #6d82f3">ask reference</a> for flags,
+              result polling, and cancellation.
+            </p>
 
             <h3
               style="

--- a/site/docs.html
+++ b/site/docs.html
@@ -1994,6 +1994,9 @@
               uses the picker's material appearance, system fonts, and native buttons. Both styles share placement and behavior.
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--align left|center|right</span> aligns the button
               block in either style, including a vertical column; the default is right.
+              Both styles fit their content up to 90 percent of the anchor width and 72 cells.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--width N</span> sets a fixed width instead,
+              as an integer percentage of the anchor from 10 to 100.
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
               Without a default, the first non-destructive button is active, or the first if it is the only choice.

--- a/site/index.html
+++ b/site/index.html
@@ -189,7 +189,7 @@
         <p style="font-size: clamp(17px, 2vw, 21px); line-height: 1.55; color: #bfbab0; max-width: 60ch; margin: 0 0 38px">
           agterm organizes sessions into named workspaces. The bundled
           <code style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 0.92em">agtermctl</code> drives all of it over
-          a local socket: build layouts, type into any pane and read its text back, open overlays, dashboards, and native pickers.
+          a local socket: build layouts, type into any pane and read its text back, open overlays, dashboards, native pickers, and question dialogs.
           Running many AI coding agents at once is the obvious use, and far from the only one.
         </p>
 


### PR DESCRIPTION
adds an `ask` control-API family: a window-modal question dialog with a title, an optional message and one to six caller-named buttons, answered over the socket or with `agtermctl ask`. The answer comes back as the pressed button's id, label and index, `escaped` for Esc or Cmd-W, or `cancelled` for `ask.cancel`, window teardown, quit and anchor loss. The CLI blocks by default; exit codes are 0 for answered, 3 for escaped, 2 for cancelled and 1 for failure or a pending `ask result`.

the dialog shares one pending slot per window with `pick`; the shared modal state guards terminal focus, auto-follow, menus, zoom, dashboard, search and the quick terminal. One button is always highlighted (`--default`, otherwise the first non-destructive button, falling back to the first); Return picks it, Tab and arrows wrap, and letter hotkeys pick directly.

two styles share the whole contract: `terminal` is the default and uses theme colors with the terminal font, while `gui` reuses the picker's material panel with native buttons. `--align left|center|right` positions the button block (default right), and `--width N` fixes the panel to 10 to 100 percent of the anchor. Without a width, the panel fits its content within 90% of the anchor and 72 cells; buttons share a width within each row or column. A selected session target anchors over the whole session, narrowed to a visible half by `--pane`; no target centers over the terminal area. Pane anchors follow their captured identity through resizing and promotion; closing or deselecting the session, or removing or hiding the anchored pane, cancels the dialog.

docs are updated in `control-api.md`, `menu-actions.md`, the site and the bundled skill, which gains a cleanup-hook example. The tree exposes `askPending`, and `ask.open` echoes `result.pane` when anchored to a pane. Design, review and the demo pass are recorded in `docs/plans/20260905-ask-dialog.md`.
