### PR TITLE
fix: report an empty caret from selectedRange so the system Dictation starts

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView+Accessibility.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Accessibility.swift
@@ -17,11 +17,12 @@ import AppKit
 ///
 /// The surface renders its own contents on the GPU and is otherwise deliberately absent from
 /// the a11y tree (see `DashboardView` — "the Metal-backed surface is not in the a11y tree").
-/// The side effect of that absence: assistive and voice tools — VoiceOver, the system
-/// Dictation, and third-party dictation apps such as MacWhisper — probe `AXFocusedUIElement`
-/// for a focused *text field* before they engage. Finding none over the terminal, they never
-/// show their input widget or route text into it (in agterm the MacWhisper hold-to-dictate
-/// widget simply never appears, while it does in every ordinary NSTextView/webview terminal).
+/// The side effect of that absence: assistive and voice tools — VoiceOver and third-party
+/// dictation apps such as MacWhisper — probe `AXFocusedUIElement` for a focused *text field*
+/// before they engage. Finding none over the terminal, they never show their input widget or
+/// route text into it (in agterm the MacWhisper hold-to-dictate widget simply never appears,
+/// while it does in every ordinary NSTextView/webview terminal). The system Dictation is not
+/// one of them: it starts and inserts through `NSTextInputClient`, with no text read from here (#555).
 ///
 /// This extension reports the minimal shape of an editable text field: role `.textArea`,
 /// focusable, with a settable value. Tools that insert via `AXValue` land in `setAccessibilityValue`;
@@ -53,7 +54,7 @@ import AppKit
 /// design — the same flag drag/cursor use), so a split exposes TWO "Terminal" text areas. Only the
 /// first-responder pane reports `isAccessibilityFocused`, advertises its value settable, and accepts a
 /// write; the other reads as a non-settable text area. A client that anchors on `AXFocusedUIElement`
-/// (MacWhisper, Dictation) targets the right pane; a client that enumerates by role/label sees the
+/// (MacWhisper) targets the right pane; a client that enumerates by role/label sees the
 /// unfocused pane is not settable and skips it. Accepted: only one pane can be the live text destination
 /// at a time, and narrowing exposure to the focused pane would hide the other from screen readers.
 ///
@@ -205,7 +206,7 @@ extension GhosttySurfaceView {
     /// Tell AX the focused element moved, because `isAccessibilityFocused` (= `liveFocus`) just changed.
     ///
     /// The companion to `postAccessibilityExposureChange` for the FOCUS half: a client that anchors on
-    /// `AXFocusedUIElement` (MacWhisper, system Dictation) needs to hear the focus leave one pane for
+    /// `AXFocusedUIElement` (MacWhisper) needs to hear the focus leave one pane for
     /// another — a split-pane switch or a window key change moves it without any element appearing or
     /// disappearing.
     ///

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -398,7 +398,11 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
         ghostty_surface_preedit(surface, nil, 0)
     }
 
-    func selectedRange() -> NSRange { _selectedRange }
+    /// Dictation needs a valid caret outside a composition (#555), and the stored IME selection is stale
+    /// once one ends.
+    func selectedRange() -> NSRange {
+        hasMarkedText() ? _selectedRange : NSRange(location: 0, length: 0)
+    }
     func markedRange() -> NSRange { _markedRange }
     func hasMarkedText() -> Bool { _markedRange.location != NSNotFound }
 

--- a/agtermTests/GhosttySurfaceViewInputTests.swift
+++ b/agtermTests/GhosttySurfaceViewInputTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import agterm
+
+@MainActor
+final class GhosttySurfaceViewInputTests: XCTestCase {
+    private var surface: GhosttySurfaceView!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run { surface = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory()) }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run { surface = nil }
+        try await super.tearDown()
+    }
+
+    func testSelectedRangeIsAnEmptyInsertionPointWithoutAComposition() {
+        XCTAssertFalse(surface.hasMarkedText())
+        XCTAssertEqual(surface.selectedRange(), NSRange(location: 0, length: 0))
+    }
+
+    func testSelectedRangeIsTheImeSelectionWhileComposing() {
+        surface._markedRange = NSRange(location: 0, length: 5)
+        surface._selectedRange = NSRange(location: 5, length: 0)
+        XCTAssertEqual(surface.selectedRange(), NSRange(location: 5, length: 0))
+    }
+
+    func testSelectedRangeDropsTheStaleImeSelectionOnceCompositionEnds() {
+        surface._markedRange = NSRange(location: 0, length: 5)
+        surface._selectedRange = NSRange(location: 5, length: 0)
+        surface._markedRange = NSRange(location: NSNotFound, length: 0)
+        XCTAssertEqual(surface.selectedRange(), NSRange(location: 0, length: 0))
+    }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -1373,9 +1373,9 @@
               Accessibility
             </h2>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0">
-              Voice dictation tools that probe for a focused text field — the system Dictation, MacWhisper, and similar
-              assistive apps — engage over the terminal: the on-screen pane advertises itself to the accessibility system as
-              an editable text area, so a hold-to-dictate widget anchors to it and dictated text lands at the prompt. Text
+              Voice dictation tools that probe for a focused text field — MacWhisper and similar assistive apps — engage
+              over the terminal: the on-screen pane advertises itself to the accessibility system as an editable text area,
+              so a hold-to-dictate widget anchors to it and dictated text lands at the prompt. Text
               arrives at the cursor the same way typing does, and an insert carrying a newline, a tab, or any other control
               character goes in as a bracketed paste, so a program that accepts bracketed paste takes it as literal text
               instead of running the line or completing the word. That last part is the same caveat &#8984;V carries: at a raw
@@ -1388,6 +1388,10 @@
               read back, a dictation tool that re-sends its whole transcription on every revision (rather than only the new
               words) will concatenate its drafts at the prompt; tools that insert incrementally, MacWhisper among them, are
               unaffected.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
+              System Dictation inserts text through macOS text input, the same path used by the keyboard and input
+              methods.
             </p>
           </section>
 


### PR DESCRIPTION
The system Dictation shortcut did nothing with agterm frontmost. Before it starts, Dictation polls `selectedRange` and `firstRect(forCharacterRange:)` on the focused `NSTextInputClient`, and `GhosttySurfaceView` answered `{NSNotFound, 0}` from launch, so it had no insertion point to anchor on and declined.

`selectedRange()` now returns the IME's selection only while marked text exists and `{0, 0}` otherwise. The stored range is written by `setMarkedText` alone, so reading it after a composition ends also handed back a stale value. Verified on a Debug build: the mic appears, live transcription streams through `setMarkedText`, and the final phrase arrives through `insertText`. During this Debug attempt, the probe recorded no AX text callbacks; Dictation worked without changing the AX bridge. The AX header and the docs Accessibility section no longer list the system Dictation among tools that engage through it.

Three tests in `GhosttySurfaceViewInputTests` pin the empty caret, the IME selection while composing, and the stale range dropped after composition.

Fix #555
