### PR TITLE
fix(cookbook): accept padded status rows below the Claude composer

### DIFF
--- a/cookbook/two-agent-chat/peer-chat.py
+++ b/cookbook/two-agent-chat/peer-chat.py
@@ -48,7 +48,8 @@ CODEX_EMPTY_PROMPT = "Ask Codex to do anything"
 # therefore fails closed instead of weakening the live-prompt guard.
 CODEX_FOOTER_RE = re.compile(r"^ {2}\S.*$")
 CLAUDE_PROMPT_RE = re.compile(r"^\s*❯[\s ]*(.*?)\s*$")
-CLAUDE_FOOTER_RE = re.compile(r"^ {2}\S.*$")
+# status-line commands can add padding beyond Claude Code's two-space indent.
+CLAUDE_FOOTER_RE = re.compile(r"^ {2,}\S.*$")
 CLAUDE_EMPTY_PROMPTS = {
     "",
     "Press up to edit queued messages",

--- a/cookbook/two-agent-chat/test_peer_chat.py
+++ b/cookbook/two-agent-chat/test_peer_chat.py
@@ -106,6 +106,31 @@ class ClaudeLivePromptTextTests(unittest.TestCase):
             "Chat from Codex: review this",
         )
 
+    def test_live_composer_accepts_padded_status_rows(self) -> None:
+        rows = [
+            "   repo [branch] [Opus 5] 70% /rc\n  ⏵⏵ auto mode on (shift+tab to cycle)",
+            "  repo [branch] [Opus 5] 70% /rc\n    --%\n  ⏵⏵ auto mode on (shift+tab to cycle)",
+        ]
+
+        for status in rows:
+            with self.subTest(status=status):
+                screen = f"{RULE}\n❯ Chat from Codex: review this\n{RULE}\n{status}"
+                self.assertEqual(
+                    LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen),
+                    "Chat from Codex: review this",
+                )
+
+    def test_padded_status_row_does_not_admit_a_dialog(self) -> None:
+        trailers = [
+            "   repo [branch] [Opus 5] 70% /rc\nAllow this command?",
+            "   repo [branch] [Opus 5] 70% /rc\n    1. Yes\n    2. No",
+        ]
+
+        for trailer in trailers:
+            with self.subTest(trailer=trailer):
+                screen = f"{RULE}\n❯ previous user prompt\n{RULE}\n{trailer}"
+                self.assertIsNone(LIVE_PROMPT_TEXT(CLAUDE_PROFILE, screen))
+
     def test_queue_hints_are_known_empty_claude_placeholders(self) -> None:
         hints = [
             "Press up to edit queued messages",


### PR DESCRIPTION
since #527 `claude_live_prompt_text` requires every non-blank row under the composer rule to start with exactly two spaces. Claude Code indents its status rows by two, but the `statusLine` command's output is arbitrary, and a powerline-style line that pads its first segment renders with three. Every send to that pane then refused as an unrecognisable composer, on a status line the pre-#527 script never looked at.

`CLAUDE_FOOTER_RE` now takes two or more leading spaces. The refusals that matter survive: a dialog header sits at column 0 and still fails, and numbered choices are still rejected on the stripped row at any depth. `CODEX_FOOTER_RE` is untouched, Codex sends were never affected. Tests pin a padded first row, a padded second row (the `--%` placeholder shape from the report), and both refusals after a padded row. The two accept cases fail on the old regex.

Fix #553
