### PR TITLE
fix: read the cursor column of a hidden split pane

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView+IO.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+IO.swift
@@ -144,17 +144,17 @@ extension GhosttySurfaceView {
         guard columnZeroX >= 0 else { return nil }
 
         let size = ghostty_surface_size(surface)
-        // both readings are pre-divided by the content scale agterm gave libghostty, which is the WINDOW's
-        // (`updateMetalLayerSize`). Never substitute a screen's for a detached view: that answers 2x for a
-        // surface last driven at 1x, an in-range wrong column.
-        guard let scale = window?.backingScaleFactor, scale > 0 else { return nil }
-        guard size.cell_width_px > 0, size.columns > 0 else { return nil }
-        let cellWidth = Double(size.cell_width_px) / Double(scale)
+        guard size.cell_width_px > 0, size.cell_height_px > 0, size.columns > 0 else { return nil }
 
         var x = 0.0, y = 0.0, w = 0.0, h = 0.0
         ghostty_surface_ime_point(surface, &x, &y, &w, &h)
         let after = ghostty_surface_size(surface)
-        guard after.cell_width_px == size.cell_width_px, after.columns == size.columns else { return nil }
+        guard after.cell_width_px == size.cell_width_px, after.cell_height_px == size.cell_height_px,
+              after.columns == size.columns else { return nil }
+        // `h` is one cell height over the content scale libghostty retains, the divisor behind `x` and `tl_px_x`
+        // too. agterm hands it equal X/Y scales, so `h` recovers the logical cell width without a window.
+        guard h > 0, h.isFinite else { return nil }
+        let cellWidth = h * Double(size.cell_width_px) / Double(size.cell_height_px)
         let column = Int(((x - columnZeroX) / cellWidth).rounded(.down))
         guard column >= 0, column < Int(size.columns) else { return nil }
         return column

--- a/agtermUITests/ControlSurfaceCursorUITests.swift
+++ b/agtermUITests/ControlSurfaceCursorUITests.swift
@@ -41,6 +41,39 @@ final class ControlSurfaceCursorUITests: ControlAPITestCase {
         XCTAssertEqual(empty["error"] as? String, "surface not available: surface:\(sessionID):scratch")
     }
 
+    // a hidden pane's view has no window, and a read that divided by the window's scale refused it
+    func testSurfaceCursorReadsAHiddenSplitPaneInBothDirections() throws {
+        let sessionID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
+                       "split on should succeed")
+        try waitForPrompt(sessionID, marker: "hidden-left-ready", pane: "left")
+        try waitForPrompt(sessionID, marker: "hidden-right-ready", pane: "right")
+
+        for (hidden, focused) in [("right", "left"), ("left", "right")] {
+            let target = "surface:\(sessionID):\(hidden)"
+            let shown = try XCTUnwrap(settledCursorColumn(target: target, timeout: 10),
+                                      "the shown \(hidden) pane should settle at its prompt")
+            XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","args":{"pane":"\#(focused)"}}"#)["ok"] as? Bool,
+                           true, "focusing the \(focused) pane should succeed")
+            XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"off"}}"#)["ok"] as? Bool, true,
+                           "split off should succeed")
+            try assertSplitHidden(sessionID, focusedRight: focused == "right")
+
+            XCTAssertTrue(pollCursorColumn(shown, target: target, timeout: 10),
+                          "the hidden \(hidden) pane should read its prompt column \(shown); got \(String(describing: cursorColumnOrNil(target: target)))")
+            let probe = "abcdefg"
+            try type(probe, into: sessionID, pane: hidden)
+            XCTAssertTrue(pollCursorColumn(shown + probe.count, target: target, timeout: 10),
+                          "the hidden \(hidden) pane's column should advance by the typed length; got \(String(describing: cursorColumnOrNil(target: target)))")
+            try assertSplitHidden(sessionID, focusedRight: focused == "right")
+
+            XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
+                           "split on should succeed")
+            XCTAssertTrue(pollCursorColumn(shown + probe.count, target: target, timeout: 10),
+                          "the reshown \(hidden) pane should agree with the column read while hidden")
+        }
+    }
+
     // zooming a NONFOCUSED pane leaves `splitFocused` alone, so resolving `active` from the store's focus
     // instead of the window's zoom controller silently read the hidden pane.
     func testSurfaceCursorActiveFollowsAnExplicitZoomOfTheNonFocusedPane() throws {
@@ -151,6 +184,13 @@ final class ControlSurfaceCursorUITests: ControlAPITestCase {
         let value = try typeUntilMarker("printf READY > '\(file.path)'\n",
                                         target: sessionID, file: file, select: false, pane: pane)
         XCTAssertEqual(value, "READY", "the \(pane ?? "left") pane's shell should be reading commands")
+    }
+
+    private func assertSplitHidden(_ sessionID: String, focusedRight: Bool) throws {
+        let node = try sessionNode(id: sessionID)
+        XCTAssertEqual(node["split"] as? Bool, false, "the split should be hidden")
+        XCTAssertEqual(node["hasSplit"] as? Bool, true, "the split pane should stay alive while hidden")
+        XCTAssertEqual(node["splitFocused"] as? Bool, focusedRight, "focus should stay on the shown pane")
     }
 
     private func type(_ text: String, into sessionID: String, pane: String?) throws {


### PR DESCRIPTION
`surface cursor` now reads a hidden split pane without revealing it. The read converted the pixel cell width with `window?.backingScaleFactor`, and a hidden pane's view has no window, so every hidden read answered `failed to read cursor position` while `session text` and `session type` reached the same pane.

The cell width now comes from `ghostty_surface_ime_point`'s height, which is the pixel cell height over the content scale libghostty retains for that surface. Multiplying it by the pixel width-to-height ratio gives the logical cell width, because agterm hands libghostty equal X/Y scales, so a detached pane reads at whatever scale it was last driven with no window involved. An unreadable state still returns nil.

The regression test hides each pane in turn with focus on the other, reads it, types into it and checks the column advanced by the typed length, and asserts before and after that the tree still reports the split hidden with focus on the shown pane.
