### PR TITLE
fix(focus): prevent a closed session from reclaiming keyboard focus

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -188,7 +188,7 @@ final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     /// Sweeps the hidden layer's retained frame on a slow cadence; exits itself on reveal or teardown.
     var hiddenJanitorTask: Task<Void, Never>?
     /// After `destroySurface()` the view is retired: never recreate a surface (a stray viewDidMoveToWindow).
-    private var isDestroyed = false
+    private(set) var isDestroyed = false
 
     /// Guards `handleProcessExit` so the close runs once. Both the `SHOW_CHILD_EXITED` action and the
     /// `close_surface_cb` can fire for one exit (ghostty documents no ordering/exclusivity between them).

--- a/agterm/Views/TerminalView.swift
+++ b/agterm/Views/TerminalView.swift
@@ -88,6 +88,9 @@ struct TerminalView: NSViewRepresentable {
     /// is first responder, so editing a sidebar rename survives a re-render. `mouseDown` covers the rest.
     private func focusIfNeeded(_ nsView: GhosttySurfaceView, coordinator: Coordinator) {
         guard let window = nsView.window else { return }
+        // a closing session's entry can update once more after the store tore its surface down, still
+        // carrying `isActive`; grabbing there leaves the keyboard on a dead pane instead of the reselected one.
+        guard !nsView.isDestroyed else { return }
         guard !nsView.askBlocksFocus else { return }
         if window.firstResponder === nsView { return }
         // don't steal focus from an active text field editor (a sidebar rename); its editor is an NSText.

--- a/agtermTests/TerminalViewTests.swift
+++ b/agtermTests/TerminalViewTests.swift
@@ -1,0 +1,47 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import agterm
+import agtermCore
+
+@MainActor
+final class TerminalViewTests: XCTestCase {
+    func testStaleActiveUpdateNeverTakesFocusForATornDownSurface() throws {
+        let fixture = try SessionAskTestFixture()
+        defer { fixture.close() }
+        let closing = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory(), command: "/bin/cat")
+        fixture.session.surface = closing
+        let neighbour = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory(), command: "/bin/cat")
+        defer { neighbour.teardown() }
+        let container = NSView(frame: CGRect(x: 0, y: 0, width: 600, height: 300))
+        neighbour.frame = CGRect(x: 0, y: 0, width: 300, height: 300)
+        container.addSubview(neighbour)
+        let host = NSHostingView(rootView: DeckEntry(session: fixture.session, surface: closing, isActive: false))
+        host.frame = CGRect(x: 300, y: 0, width: 300, height: 300)
+        container.addSubview(host)
+        fixture.window.contentView = container
+        fixture.window.orderFront(nil)
+        host.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertTrue(closing.isRealized)
+        neighbour.createSurface()
+        XCTAssertTrue(fixture.window.makeFirstResponder(neighbour))
+        XCTAssertTrue(fixture.window.firstResponder === neighbour)
+        closing.teardown()
+        host.rootView = DeckEntry(session: fixture.session, surface: closing, isActive: true)
+        host.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertTrue(fixture.window.firstResponder === neighbour)
+    }
+}
+
+private struct DeckEntry: View {
+    let session: Session
+    let surface: GhosttySurfaceView
+    let isActive: Bool
+
+    var body: some View {
+        TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: { _ in surface }, isActive: isActive)
+            .frame(width: 300, height: 300)
+    }
+}

--- a/agtermUITests/ControlAskUITests.swift
+++ b/agtermUITests/ControlAskUITests.swift
@@ -141,6 +141,24 @@ final class ControlAskUITests: ControlAPITestCase {
         XCTAssertEqual(try awaitAskResult(pane)["id"] as? String, "pane")
     }
 
+    func testAnsweredAskThenSocketCloseFocusesTheReselectedSession() throws {
+        let neighbour = try activeSessionID()
+        let before = markerDir.appendingPathComponent("neighbour-tty")
+        let neighbourTTY = try XCTUnwrap(typeUntilMarker("tty > '\(before.path)'\n", target: neighbour, file: before, select: false))
+        for style in ["terminal", "gui"] {
+            let closing = try newSession("closing-\(style)", select: true)
+            XCTAssertTrue(poll(until: (try? sessionNode(id: closing)["active"] as? Bool) == true, timeout: 10))
+            let ask = try openAsk([["id": "close", "label": "Close"]], target: closing, options: ["style": style])
+            XCTAssertTrue(askButton("close").waitForExistence(timeout: 10))
+            app.typeKey(.return, modifierFlags: [])
+            XCTAssertEqual(try awaitAskResult(ask)["id"] as? String, "close")
+            XCTAssertEqual(try sendControlCommand("session.close", target: closing)["ok"] as? Bool, true)
+            XCTAssertEqual(try sessionNode(id: neighbour)["active"] as? Bool, true)
+            let after = markerDir.appendingPathComponent("neighbour-after-\(style)")
+            XCTAssertEqual(keyboardTypeUntilMarker("tty > '\(after.path)'", file: after, attempts: 1, perAttempt: 5), neighbourTTY, style)
+        }
+    }
+
     func testSoftCloseCancelsImmediatelyAndUndoDoesNotRestoreAsk() throws {
         let first = try newSession("closing-a", select: false)
         let second = try newSession("closing-b", select: false)


### PR DESCRIPTION
after a terminal ask on the selected session is answered and that session is closed over the socket, the session agterm brings forward is selected but has no keyboard focus until the user clicks.

a stale active update let the closing session's `TerminalView` reclaim first responder after `AppStore.closeSession` had destroyed its surface. That entry's focus latch was unset: the ask catcher had refocused the pane after the answer, and a deck update that finds its own surface already focused returns without setting the latch, so the stale update grabbed the dead view.

`focusIfNeeded` now checks `isDestroyed` before requesting focus, leaving keyboard input with the reselected session.

a hosted `TerminalViewTests` case reproduces the stale update through an `NSHostingView` and fails without the guard. `ControlAskUITests` exercises the user path for both ask styles but also passes before the fix, since under XCUITest the deck updates the closing pane before the catcher releases and the latch gets set.
