### PR TITLE
feat(cookbook): add claude-account-swap

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -37,6 +37,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [annotate-claude-replies](annotate-claude-replies/) | mark up Claude's answers in revdiff and send the notes back | 0.13.0, revdiff, python3, Claude Code |
 | [annotate-pane-output](annotate-pane-output/) | mark up what the pane just printed in revdiff and send the notes back to whatever is running there | 0.13.0, revdiff, python3 |
 | [backlog-picker](backlog-picker/) | pick one of the repo's written-down deferred items and hand it to the agent in the pane | 0.20.2, python3, Claude Code |
+| [claude-account-swap](claude-account-swap/) | switch the left pane's Claude account with a conversation summary | 0.26.0, python3, jq, Claude Code, Codex CLI, Git |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [close-tab-when-done](close-tab-when-done/) | arm a tab with a chord and it closes itself when the agent stops replying | 0.22.0, jq, Claude Code |

--- a/cookbook/claude-account-swap/README.md
+++ b/cookbook/claude-account-swap/README.md
@@ -1,0 +1,186 @@
+# Switch Claude accounts
+
+Pick another Claude Code account and carry the left pane's conversation into it as a summary.
+
+## What it does
+
+The custom command opens an account picker. Selecting an account quits Claude in the left pane and
+starts a new conversation under that account's config directory. Codex writes a handoff summary
+before the old agent exits. The new agent receives it as context and is asked to wait for you.
+
+The right pane stays available while the command runs. Escape in the picker cancels the switch.
+
+## Requirements
+
+- agterm **0.26.0 or later**, which added the tree's `foregroundShell` field used before relaunching.
+  From 0.26.2, progress panels can stay over the left pane. If pane placement is unavailable or the
+  pane is hidden, the script falls back to a session-wide panel.
+- macOS, Python **3.10 or later**, `jq`, and the system `bash`, `ps`, `env`, and `cat` commands.
+- Claude Code's native executable, available as `claude`, with a separate authenticated config
+  directory for each account. Launch Claude from a shell with job control, directly or through an
+  exec wrapper as described below.
+- Codex CLI, authenticated and able to run `codex exec --ephemeral --ignore-user-config --json`
+  with `gpt-5.6-luna`. This is the default summarizing model; access to it is required unless you
+  change `CLAUDE_SWAP_MODEL`.
+- Git, used to add the current branch, commit and changed filenames to the summary when the
+  conversation's directory is a repository.
+
+## Setup
+
+1. Copy both scripts into the same directory:
+
+   ```bash
+   mkdir -p ~/.config/agterm/scripts
+   cp claude-account-swap.py pane-map-hook.sh ~/.config/agterm/scripts/
+   chmod +x ~/.config/agterm/scripts/{claude-account-swap.py,pane-map-hook.sh}
+   ```
+
+2. Sign into each account using Claude's own config directory selection. For example, run these
+   separately and complete `/login` in each:
+
+   ```bash
+   CLAUDE_CONFIG_DIR="$HOME/.claude" claude
+   CLAUDE_CONFIG_DIR="$HOME/.claude-work" claude
+   ```
+
+   Confirm the intended account with `/status` in each directory. `CLAUDE_CONFIG_DIR` selects a
+   configuration, including its settings and transcript directory; the recipe does not change
+   credentials or log you in. See Claude Code's [configuration directory reference](https://code.claude.com/docs/en/claude-directory).
+
+3. Create `~/.config/agterm/claude-accounts.json` with the directories you just configured:
+
+   ```json
+   [
+     {"label": "Personal", "config_dir": "~/.claude"},
+     {"label": "Work", "config_dir": "~/.claude-work"}
+   ]
+   ```
+
+   Add more entries for more accounts. Labels must be unique. Directories must exist and must not
+   resolve to the same location or contain one another. JSON keeps paths with spaces unambiguous;
+   `~` expands to your home directory. Shell variables such as `$HOME` are not expanded here.
+
+4. Merge these hooks into `settings.json` in **every account's config directory**. Preserve any
+   existing hooks under the same events:
+
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [{"hooks": [{"type": "command", "command": "\"$HOME/.config/agterm/scripts/pane-map-hook.sh\""}]}],
+       "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "\"$HOME/.config/agterm/scripts/pane-map-hook.sh\""}]}],
+       "PostToolUse": [{"hooks": [{"type": "command", "command": "\"$HOME/.config/agterm/scripts/pane-map-hook.sh\""}]}],
+       "Stop": [{"hooks": [{"type": "command", "command": "\"$HOME/.config/agterm/scripts/pane-map-hook.sh\""}]}]
+     }
+   }
+   ```
+
+   The [hook input](https://code.claude.com/docs/en/hooks) supplies the conversation ID and transcript
+   path. The hook records them without replacing your status line. If your status line already
+   writes `/tmp/claude/panes/SESSION.PANE`, remove that recording block: it would erase the process
+   metadata this hook adds. Readers that use only the first line remain compatible.
+
+5. Add this palette command to `~/.config/agterm/keymap.conf`:
+
+   ```text
+   command "Swap Claude Account" ~/.config/agterm/scripts/claude-account-swap.py
+   ```
+
+6. Reload the keymap:
+
+   ```bash
+   agtermctl keymap reload
+   ```
+
+7. Restart Claude directly in the left pane with the chosen `CLAUDE_CONFIG_DIR` so its new hooks run.
+
+Optional overrides are `AGTERMCTL`, `CLAUDE_BIN`, and `CODEX_BIN` for executable paths;
+`CLAUDE_SWAP_MODEL` for the summarizing model; and `PANE_MAP_DIR` for the map directory, default
+`/tmp/claude/panes`. Set `PANE_MAP_DIR` in both the hook's environment and the custom command's
+environment. Executable overrides are single paths or names, without arguments. Custom commands
+inherit the app's environment; shell startup exports alone do not configure them. An override can
+be placed before the script on the `command` line, such as `CODEX_BIN=/path/to/codex`.
+
+To add flags such as `--append-system-prompt` to every replacement, set `CLAUDE_BIN` on the custom
+command to an executable wrapper containing:
+
+```sh
+#!/bin/sh
+exec /absolute/path/to/native/claude --append-system-prompt "Your instruction." "$@"
+```
+
+Use the native binary's absolute path to avoid calling the wrapper recursively. Forward `"$@"`
+and leave `CLAUDE_CONFIG_DIR` unchanged so the selected account and handoff argument reach Claude.
+`exec` replaces the shell with Claude while preserving its process ID. The wrapper's filename
+need not be `claude`.
+
+Pass `--accounts /path/to/accounts.json` on the command line to use another account list.
+
+## Usage
+
+Let Claude finish its turn, wait ten seconds, and leave its composer empty. Open the command palette
+and choose **Swap Claude Account**, then choose the destination account. That selection confirms
+quitting the left pane's current agent. Leave the pane alone until the replacement starts.
+
+After the replacement acknowledges the context, tell it what to do next. The summary itself asks
+it to wait; it does not authorize the unfinished work.
+
+For a check that neither opens a picker nor calls a model, run
+`~/.config/agterm/scripts/claude-account-swap.py --dry-run` from the sibling pane. It checks the
+left pane's map and input gates and prints the source and available destinations.
+
+## How it works
+
+The hook walks its parent processes to find the native Claude process. It records the transcript
+path, Claude's PID and process start time, and the conversation ID in
+`$PANE_MAP_DIR/SESSION.PANE`. The first line is the transcript path; the second is JSON metadata.
+Writes replace the file atomically. Background invocations cannot publish a record.
+
+The script requires that exact process to still exist, with the same start time, and to lead its
+terminal's foreground process group. This rejects an exited Claude's leftover map, PID reuse with
+a different start time, and a backgrounded agent. A map does not expire merely because Claude has
+been idle. The transcript must be inside exactly one configured account's `projects` directory.
+There is no search for the newest conversation when the map is missing or unusable.
+
+The destination picker excludes the source account. Before quitting, the script rechecks the map,
+transcript size and modification time, foreground program, reported activity, and cursor column.
+It refuses a transcript written within ten seconds. These checks detect ordinary activity and
+changes during summarization; they cannot make reading the pane and typing `/exit` atomic.
+
+The transcript parser and digest builder are included in the script. They keep user prompts and
+assistant text, omit tool traffic, trim assistant replies to 1,500 characters, and keep the last
+120,000 characters. The last recorded working directory follows Claude into a worktree. Codex
+receives that digest and Git's working-tree state with its shell and multi-agent tools disabled.
+
+The summary is stored in a private temporary file. After `/exit` returns the pane to a foreground
+shell, the script types a quoted launch line using `env CLAUDE_CONFIG_DIR=... claude` and reads the
+packet into one launch argument. The summary is never pasted into Claude's composer. Success
+requires the replacement's hook to report a new live process and transcript under the selected
+account's directory. A retained packet's path is printed on success and included in later errors.
+
+## Limits
+
+**This quits the running Claude agent in the left pane.** A failed launch can leave that pane at
+its shell. The original transcript and the temporary summary remain on disk; delete the summary
+when you no longer need it. There is no automatic rollback or retry after typing a command.
+
+This recipe supports a native Claude executable in a local agterm pane with shell job control.
+A wrapper must replace itself with Claude using `exec`; keeping the wrapper shell alive fails
+both the foreground-program and process-group checks. Node-based installs, SSH, tmux, nested
+agents, and moving/swapping panes after Claude starts are unsupported. Those can break the
+relationship between the inherited session/pane ID and the terminal that owns the process. Restart
+Claude after a pane move.
+Do not run two instances of this custom command against the same pane at once.
+
+A foreground shell is not proof that its prompt is ready. The cursor at column 2 is also not proof
+that a Claude composer is empty if you moved the caret to the start of a draft. Status is shared
+across a session's panes, and a long tool call can leave the transcript unchanged. Confirm that the
+agent has finished and leave its pane untouched during the switch.
+
+Each switch sends conversation text and repository metadata to Codex. The handoff then crosses
+into the destination Claude account. Only switch conversations that belong in both accounts.
+Model summaries can omit or misstate context; the packet includes the original transcript path.
+
+Config directories can hold different tools, permissions and hooks. The launch does not copy the
+old account's settings or command-line flags. Authentication environment variables can override
+the account associated with a config directory. The startup check verifies the directory and
+process, not the signed-in person's identity or the model's acknowledgement of the summary.

--- a/cookbook/claude-account-swap/claude-account-swap.py
+++ b/cookbook/claude-account-swap/claude-account-swap.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+"""Switch the left pane's Claude account, carrying a summary into the new session."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, NamedTuple
+
+AGTERMCTL = os.environ.get("AGTERMCTL", "agtermctl")
+CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
+CODEX_BIN = os.environ.get("CODEX_BIN", "codex")
+MODEL = os.environ.get("CLAUDE_SWAP_MODEL", "gpt-5.6-luna")
+INPUT_COLUMN = 2
+BUSY_MTIME_SECONDS = 10
+CALL_TIMEOUT = 240
+WORKTREE_LIMIT = 4000
+MAX_DIGEST_BYTES = 120_000
+DETAIL_TRIM = 1500
+SUMMARY_PROMPT = (
+    "Condense the Claude Code session transcript below into a handoff packet for a DIFFERENT agent "
+    "that will pick the work up in the same directory with no other context. Emit markdown with "
+    "these bold section titles and nothing else: Goal, Current state, Decisions and constraints, "
+    "Files, Next steps, Open questions. Drop a section that has no content rather than padding it. "
+    "Be concrete - name the files, branches, commands and numbers the next agent needs, taking "
+    "them from the working-tree block where the transcript does not carry them - and never "
+    "state anything the transcript does not support; mark what is uncertain as unverified. Do not "
+    "use markdown headers, emoji, or an em dash. Keep it under 400 words.\n\nTRANSCRIPT\n"
+)
+
+
+class Fail(RuntimeError):
+    """An error that can be shown without a traceback."""
+
+
+class Account(NamedTuple):
+    label: str
+    config_dir: Path
+
+
+class Process(NamedTuple):
+    pid: int
+    ppid: int
+    pgid: int
+    tpgid: int
+    started: str
+    comm: str
+
+
+class Record(NamedTuple):
+    transcript: Path
+    pid: int
+    started: str
+    session_id: str
+
+
+class Entry(NamedTuple):
+    kind: str
+    text: str
+    at: str
+    cwd: str
+
+
+def plain(text: str) -> str:
+    if not text or any(ord(c) < 32 or ord(c) == 127 for c in text):
+        raise Fail("a label, path or command is empty or contains control characters")
+    return text
+
+
+def load_accounts(path: Path) -> list[Account]:
+    try:
+        rows = json.loads(path.read_text())
+        if not isinstance(rows, list) or len(rows) < 2:
+            raise ValueError("configure at least two accounts")
+        accounts = []
+        for row in rows:
+            label, directory = row["label"], row["config_dir"]
+            if not isinstance(label, str) or not isinstance(directory, str):
+                raise TypeError("label and config_dir must be strings")
+            root = Path(plain(directory)).expanduser()
+            if not root.is_absolute() or not root.is_dir():
+                raise ValueError("config_dir must name an existing absolute directory (or start with ~)")
+            account = Account(plain(label), root.resolve())
+            for existing in accounts:
+                if label == existing.label or account.config_dir == existing.config_dir \
+                        or account.config_dir in existing.config_dir.parents \
+                        or existing.config_dir in account.config_dir.parents:
+                    raise ValueError("account labels must be unique and directories must not overlap")
+            accounts.append(account)
+        return accounts
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        raise Fail(f"cannot read accounts from {path}: {exc}") from exc
+
+
+def process_info(pid: int) -> Process | None:
+    try:
+        res = subprocess.run(["ps", "-p", str(pid), "-o", "pid=,ppid=,pgid=,tpgid=,lstart=,comm="],
+                             capture_output=True, text=True, timeout=5, check=False,
+                             env={**os.environ, "LC_ALL": "C"})
+        fields = res.stdout.split(None, 9)
+        if res.returncode or len(fields) != 10:
+            return None
+        return Process(*(int(x) for x in fields[:4]), " ".join(fields[4:9]), fields[9].strip())
+    except (OSError, subprocess.SubprocessError, ValueError) as exc:
+        raise Fail(f"cannot inspect the Claude process: {exc}") from exc
+
+
+def claude_program(program: str) -> bool:
+    if Path(program).name == "claude":
+        return True
+    binary = shutil.which(CLAUDE_BIN)
+    return bool(binary and Path(program).is_absolute()
+                and Path(program).resolve() == Path(binary).resolve())
+
+
+def claude_foreground(argv: Any) -> bool:
+    return isinstance(argv, list) and bool(argv) and isinstance(argv[0], str) and claude_program(argv[0])
+
+
+def map_path(sid: str, pane: str) -> Path:
+    if not sid or any(c not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-" for c in sid) \
+            or pane not in {"left", "right"}:
+        raise Fail("invalid session or pane identity")
+    return Path(os.environ.get("PANE_MAP_DIR", "/tmp/claude/panes")) / f"{sid}.{pane}"
+
+
+def write_record(sid: str, pane: str, record: Record) -> None:
+    path = map_path(sid, pane)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {"pid": record.pid, "started": record.started, "session_id": record.session_id}
+    # The first line stays compatible with transcript readers; replacement publishes both lines together.
+    fd, name = tempfile.mkstemp(prefix=".swap-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as output:
+            output.write(str(record.transcript) + "\n" + json.dumps(metadata) + "\n")
+        os.replace(name, path)
+    finally:
+        Path(name).unlink(missing_ok=True)
+
+
+def record_hook(data: Any) -> None:
+    sid, pane = os.environ.get("AGTERM_SESSION_ID", ""), os.environ.get("AGTERM_PANE", "left")
+    if not sid or pane not in {"left", "right"} or not isinstance(data, dict):
+        return
+    transcript, session_id = data.get("transcript_path"), data.get("session_id")
+    if not isinstance(transcript, str) or not isinstance(session_id, str):
+        return
+    path = Path(plain(transcript))
+    if not path.is_absolute() or path.stem != session_id or path.suffix != ".jsonl":
+        return
+    pid = os.getppid()
+    for _ in range(12):
+        proc = process_info(pid)
+        if proc is None:
+            return
+        if claude_program(proc.comm):
+            # A nested `claude -p` must not replace the interactive parent's mapping.
+            if proc.pid == proc.pgid == proc.tpgid:
+                write_record(sid, pane, Record(path.resolve(), proc.pid, proc.started, session_id))
+            return
+        if proc.ppid <= 1 or proc.ppid == pid:
+            return
+        pid = proc.ppid
+
+
+def live_record(sid: str, accounts: list[Account]) -> tuple[Record, Account]:
+    try:
+        lines = map_path(sid, "left").read_text().splitlines()
+        metadata = json.loads(lines[1])
+        record = Record(Path(lines[0]).resolve(), int(metadata["pid"]),
+                        metadata["started"], metadata["session_id"])
+        if record.pid <= 1 or not record.started or record.transcript.stem != record.session_id \
+                or record.transcript.suffix != ".jsonl" or not record.transcript.is_file():
+            raise ValueError("invalid transcript or process identity")
+    except (OSError, IndexError, ValueError, KeyError, TypeError) as exc:
+        raise Fail(f"no usable pane map; install the hook in this account and restart Claude: {exc}") from exc
+    proc = process_info(record.pid)
+    if proc is None or proc.started != record.started or not claude_program(proc.comm) \
+            or proc.pid != proc.pgid or proc.pgid != proc.tpgid:
+        raise Fail("the pane map belongs to an exited, replaced or background Claude process")
+    matches = [a for a in accounts if a.config_dir / "projects" in record.transcript.parents]
+    if len(matches) != 1:
+        raise Fail("the mapped transcript does not belong to exactly one configured account")
+    return record, matches[0]
+
+
+class Agt:
+    def __init__(self, sid: str) -> None:
+        self.sid = sid
+        self.socket = os.environ.get("AGT_SOCKET") or os.environ.get("AGTERM_SOCKET", "")
+        self.window = os.environ.get("AGT_WINDOW_ID") or os.environ.get("AGTERM_WINDOW_ID", "")
+        if not self.window:
+            raise Fail("the window ID is missing; invoke this from an agterm custom command")
+
+    def run(self, *args: str, stdin: str = "", timeout: float | None = 30) -> subprocess.CompletedProcess[str]:
+        command = [AGTERMCTL, *args]
+        if self.socket:
+            command += ["--socket", self.socket]
+        try:
+            return subprocess.run(command, input=stdin, capture_output=True, text=True,
+                                  check=False, timeout=timeout)
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise Fail(f"agtermctl {args[0]} failed: {exc}") from exc
+
+    def node(self, sid: str) -> dict[str, Any]:
+        res = self.run("tree", "--json", "--window", self.window)
+        try:
+            node = find_session(json.loads(res.stdout)["result"]["tree"], sid)
+        except (ValueError, KeyError, TypeError) as exc:
+            raise Fail("cannot read the agterm tree") from exc
+        if res.returncode or node is None:
+            raise Fail("the session is no longer in this window")
+        return node
+
+    def cursor_column(self, sid: str) -> int | None:
+        res = self.run("surface", "cursor", "--target", f"surface:{sid}:left", "--json")
+        try:
+            return int(json.loads(res.stdout)["result"]["cursor"]["column"]) if not res.returncode else None
+        except (ValueError, KeyError, TypeError):
+            return None
+
+    def hud(self, message: str, detail: str = "", spinner: bool = True) -> None:
+        args = ["session", "hud", message, "--target", self.sid, "--detail", detail]
+        if spinner:
+            args.append("--spinner")
+        if self.run(*args, "--pane", "left").returncode:
+            self.run(*args)
+
+    def hud_close(self) -> None:
+        self.run("session", "hud", "close", "--target", self.sid)
+
+    def pick(self, accounts: list[Account], current: Account) -> Account | None:
+        choices = {str(i): account for i, account in enumerate(accounts) if account != current}
+        items = [{"id": key, "label": a.label, "subtitle": str(a.config_dir)} for key, a in choices.items()]
+        res = self.run("pick", "--prompt", f"Quit {current.label} in the left pane and switch to",
+                       "--window", self.window, stdin=json.dumps(items), timeout=None)
+        if res.returncode == 2:
+            return None
+        if res.returncode:
+            raise Fail(f"cannot open the account picker: {res.stderr.strip()}")
+        try:
+            answer = json.loads(res.stdout)
+            if answer["result"] != "picked":
+                return None
+            return choices[answer["id"]]
+        except (ValueError, KeyError, TypeError) as exc:
+            raise Fail("the account picker returned an unknown choice") from exc
+
+    def type_line(self, sid: str, text: str) -> None:
+        res = self.run("session", "type", plain(text), "--target", sid, "--pane", "left")
+        if res.returncode:
+            raise Fail("cannot type into the left pane")
+        time.sleep(0.15)
+        res = self.run("session", "type", "--stdin", "--target", sid, "--pane", "left", stdin="\n")
+        if res.returncode:
+            raise Fail("the line was typed but could not be submitted; inspect the pane before retrying")
+
+
+def check_pane(agt: Agt, sid: str, transcript: Path) -> dict[str, Any]:
+    node = agt.node(sid)
+    if not claude_foreground(node.get("foreground")):
+        raise Fail("the left pane is not running Claude directly")
+    reason = busy_reason(node, transcript, time.time())
+    if reason:
+        raise Fail(f"not switching: {reason}")
+    if agt.cursor_column(sid) != INPUT_COLUMN:
+        raise Fail("not switching: the composer holds text or its cursor cannot be read")
+    return node
+
+
+def launch_line(target: Account, cwd: str, path: Path) -> str:
+    parts = [plain(x) for x in (cwd, str(target.config_dir), CLAUDE_BIN, str(path))]
+    directory, config, binary, packet = map(shlex.quote, parts)
+    return f'cd {directory} && env CLAUDE_CONFIG_DIR={config} {binary} "$(cat {packet})"'
+
+
+def save_packet(text: str) -> Path:
+    fd, name = tempfile.mkstemp(prefix="claude-account-swap-", suffix=".md")
+    with os.fdopen(fd, "w") as output:
+        output.write(text)
+    return Path(name)
+
+
+def wait_for_shell(agt: Agt, sid: str, deadline: float) -> bool:
+    while time.monotonic() < deadline:
+        if at_shell_prompt(agt.node(sid)):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def wait_for_agent(agt: Agt, sid: str, accounts: list[Account], target: Account,
+                   previous: Record, deadline: float) -> bool:
+    while time.monotonic() < deadline:
+        try:
+            record, account = live_record(sid, accounts)
+            if account == target and (record.pid, record.started) != (previous.pid, previous.started) \
+                    and claude_foreground(agt.node(sid).get("foreground")):
+                return True
+        except Fail:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def swap(accounts: list[Account], dry_run: bool) -> int:
+    sid = os.environ.get("AGT_SESSION_ID") or os.environ.get("AGTERM_SESSION_ID", "")
+    if not sid:
+        raise Fail("not inside an agterm session")
+    agt = Agt(sid)
+    original, current = live_record(sid, accounts)
+    node = check_pane(agt, sid, original.transcript)
+    if dry_run:
+        print(f"left pane: {current.label}; transcript: {original.transcript}")
+        print("available destinations: " + ", ".join(a.label for a in accounts if a != current))
+        return 0
+    target = agt.pick(accounts, current)
+    if target is None:
+        return 0
+    packet = None
+    try:
+        agt.hud(f"switching to {target.label}", detail=f"summarizing with {MODEL}")
+        if live_record(sid, accounts)[0] != original:
+            raise Fail("the conversation moved on while the picker was open")
+        check_pane(agt, sid, original.transcript)
+        baseline = stamp(original.transcript)
+        entries = read_entries(original.transcript)
+        if stamp(original.transcript) != baseline:
+            raise Fail("the transcript changed while it was being read")
+        digest = build_digest(entries, DETAIL_TRIM, datetime.now(timezone.utc))
+        if not digest.strip():
+            raise Fail("the transcript holds no conversation to summarize")
+        cwd = transcript_cwd(entries, str(node.get("cwd") or os.getcwd()))
+        summary = summarize(digest, cwd)
+        packet = save_packet(carry_over(summary, current.label, target.label, original.transcript))
+        line = launch_line(target, cwd, packet)
+        agt.hud(f"switching to {target.label}", detail=f"quitting {current.label}")
+        if live_record(sid, accounts)[0] != original or stamp(original.transcript) != baseline:
+            raise Fail("the conversation moved on while the packet was being written")
+        check_pane(agt, sid, original.transcript)
+        agt.type_line(sid, "/exit")
+        if not wait_for_shell(agt, sid, time.monotonic() + 30):
+            raise Fail("Claude did not exit; only /exit was typed")
+        agt.hud(f"switching to {target.label}", detail="starting Claude")
+        # The HUD round trip leaves time for the foreground to change again.
+        if not at_shell_prompt(agt.node(sid)):
+            raise Fail("the left pane no longer has a foreground shell")
+        agt.type_line(sid, line)
+        if not wait_for_agent(agt, sid, accounts, target, original, time.monotonic() + 30):
+            raise Fail("the launch was typed but the new account's hook has not confirmed startup")
+        print(f"left pane switched from {current.label} to {target.label}; packet at {packet}")
+        return 0
+    except Fail as exc:
+        if packet:
+            raise Fail(f"{exc}; packet kept at {packet}") from exc
+        raise
+    finally:
+        with contextlib.suppress(Fail):
+            agt.hud_close()
+
+
+def report(message: str) -> None:
+    sid = os.environ.get("AGT_SESSION_ID") or os.environ.get("AGTERM_SESSION_ID", "")
+    if sid:
+        with contextlib.suppress(Exception):
+            agt = Agt(sid)
+            agt.hud(message, spinner=False)
+            time.sleep(6)
+            agt.hud_close()
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--accounts", type=Path,
+                        default=Path.home() / ".config/agterm/claude-accounts.json")
+    parser.add_argument("--dry-run", action="store_true", help="check the live map and list destinations; no model call")
+    parser.add_argument("--record-hook", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+    try:
+        if args.record_hook:
+            record_hook(json.load(sys.stdin))
+            return 0
+        return swap(load_accounts(args.accounts.expanduser()), args.dry_run)
+    except (Fail, OSError, ValueError) as exc:
+        if not args.record_hook:
+            report(str(exc))
+        print(str(exc), file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+
+
+def find_session(tree: Any, sid: str) -> dict[str, Any] | None:
+    if isinstance(tree, dict):
+        if tree.get('id') == sid and 'cwd' in tree:
+            return tree
+        for value in tree.values():
+            found = find_session(value, sid)
+            if found is not None:
+                return found
+    elif isinstance(tree, list):
+        for value in tree:
+            found = find_session(value, sid)
+            if found is not None:
+                return found
+    return None
+
+
+def busy_reason(node: dict[str, Any], transcript: Path | None, now: float) -> str:
+    status, pane = (node.get('status'), node.get('statusPane'))
+    if status == 'active' and pane != 'right':
+        return 'the left pane reports an agent still working'
+    if transcript is not None:
+        try:
+            if now - transcript.stat().st_mtime < BUSY_MTIME_SECONDS:
+                return 'the transcript is still being written to'
+        except OSError:
+            pass
+    return ''
+
+
+def stamp(path: Path) -> tuple[str, int, int]:
+    try:
+        info = path.stat()
+    except OSError as exc:
+        raise Fail(f'cannot read the transcript {path}: {exc}') from exc
+    return (str(path), int(info.st_mtime_ns), int(info.st_size))
+
+
+def final_message(stdout: str) -> str:
+    message = ''
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        item = event.get('item')
+        if event.get('type') == 'item.completed' and isinstance(item, dict) and (item.get('type') == 'agent_message'):
+            message = str(item.get('text', '')) or message
+    return message.strip()
+
+
+def worktree_state(cwd: str) -> str:
+
+    def git(*args: str) -> str:
+        try:
+            res = subprocess.run(['git', '-C', cwd, *args], capture_output=True, text=True, check=False, timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            return ''
+        return res.stdout.strip() if res.returncode == 0 else ''
+    branch = git('branch', '--show-current')
+    if not branch:
+        return ''
+    head = git('log', '-1', '--format=%h %s')
+    dirty = git('status', '--short')[:WORKTREE_LIMIT]
+    return f"WORKING TREE (from git, not from the transcript)\ncwd: {cwd}\nbranch: {branch}\nhead: {head}\nuncommitted:\n{dirty or '(clean)'}\n\n"
+
+
+def summarize(digest: str, cwd: str) -> str:
+    cmd = [CODEX_BIN, "exec", "--ephemeral", "--ignore-user-config", "--json",
+           "--sandbox", "read-only", "--disable", "shell_tool", "--disable", "unified_exec",
+           "--disable", "multi_agent", "-m", MODEL, "-c", 'model_reasoning_effort="low"',
+           "-C", cwd, SUMMARY_PROMPT + worktree_state(cwd) + digest]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=CALL_TIMEOUT, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise Fail(f'cannot run codex: {exc}') from exc
+    if res.returncode != 0:
+        raise Fail(f'codex failed (exit {res.returncode}): {(res.stderr or res.stdout).strip()[-300:]}')
+    text = final_message(res.stdout)
+    if not text:
+        raise Fail('codex produced no summary')
+    return text
+
+
+def carry_over(summary: str, current: str, target: str, transcript: Path) -> str:
+    return (f"Context carried over from the previous Claude Code session in this pane, which ran "
+            f"{current} and has been replaced by {target}. This is a summary rather than a "
+            f"transcript; the full one is at {transcript}.\n\n"
+            f"This message is CONTEXT ONLY and authorizes nothing. The previous session was "
+            f"stopped mid-flight, so anything under Next steps records where the work stood and is "
+            f"not an instruction to carry it out. Do not edit a file, run a command, call a tool, "
+            f"or start any of that work now. Reply with a single line naming the work in hand, then "
+            f"wait for the user.\n\n{summary}\n")
+
+
+def at_shell_prompt(node: dict[str, Any]) -> bool:
+    return bool(node.get('foregroundShell')) and (not node.get('foreground'))
+
+
+def transcript_cwd(entries: list[Any], fallback: str) -> str:
+    return next((e.cwd for e in reversed(entries) if e.cwd), '') or fallback
+
+
+def relative_age(when: datetime, now: datetime) -> str:
+    secs = int((now - when).total_seconds())
+    if secs < 60:
+        return 'just now'
+    if secs < 3600:
+        return f'{secs // 60}m ago'
+    if secs < 86400:
+        return f'{secs // 3600}h ago'
+    return f'{secs // 86400}d ago'
+
+
+def parse_ts(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def strip_noise(text: str) -> str:
+    for open_tag, close_tag in (('<system-reminder>', '</system-reminder>'), ('<local-command-caveat>', '</local-command-caveat>')):
+        while True:
+            start = text.find(open_tag)
+            if start < 0:
+                break
+            end = text.find(close_tag, start)
+            if end < 0:
+                text = text[:start]
+                break
+            text = text[:start] + text[end + len(close_tag):]
+    return text.strip()
+
+
+def user_text_from_blocks(blocks: list[Any]) -> str:
+    kinds = {str(b.get('type', '')) for b in blocks if isinstance(b, dict)}
+    if not kinds - {'text'}:
+        return ''
+    if 'tool_result' in kinds or 'tool_use' in kinds:
+        return ''
+    parts = [str(b.get('text', '')) for b in blocks if isinstance(b, dict) and b.get('type') == 'text']
+    return ' '.join(p for p in parts if p)
+
+
+def read_entries(transcript: Path) -> list[Entry]:
+    entries: list[Entry] = []
+    try:
+        lines = transcript.read_text(errors='replace').splitlines()
+    except OSError as exc:
+        raise Fail(f'cannot read transcript: {exc}') from exc
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        at, cwd = (str(row.get('timestamp', '')), str(row.get('cwd', '')))
+        message = row.get('message') or {}
+        content = message.get('content') if isinstance(message, dict) else None
+        if row.get('type') == 'user' and isinstance(content, str):
+            text = strip_noise(content)
+            if text and (not text.startswith('[Request interrupted')):
+                entries.append(Entry('user', text, at, cwd))
+        elif row.get('type') == 'user' and isinstance(content, list):
+            text = strip_noise(user_text_from_blocks(content))
+            if text and (not text.startswith('[Request interrupted')):
+                entries.append(Entry('user', text, at, cwd))
+        elif row.get('type') == 'assistant' and isinstance(content, list):
+            parts = [str(p.get('text', '')) for p in content if isinstance(p, dict) and p.get('type') == 'text']
+            text = strip_noise(' '.join(parts))
+            if text:
+                entries.append(Entry('assistant', text, at, cwd))
+        elif at or cwd:
+            entries.append(Entry('meta', '', at, cwd))
+    return entries
+
+
+def build_digest(entries: list[Entry], trim: int, now: datetime) -> str:
+    out: list[str] = []
+    for entry in entries:
+        if entry.kind == 'user':
+            when = parse_ts(entry.at)
+            tag = relative_age(when, now) if when else '?'
+            out.append(f'\n[{tag}] USER: {entry.text}\n')
+        elif entry.kind == 'assistant':
+            out.append(f'CLAUDE: {entry.text[:trim]}\n')
+    return ''.join(out)[-MAX_DIGEST_BYTES:]
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/cookbook/claude-account-swap/pane-map-hook.sh
+++ b/cookbook/claude-account-swap/pane-map-hook.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Keep the transcript path and the owning Claude process together in the pane map.
+set -o pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd) || exit 0
+jq -c '{transcript_path, session_id}' |
+    python3 "$script_dir/claude-account-swap.py" --record-hook
+# A missing mapping disables swapping; a hook failure must not block a Claude turn.
+exit 0

--- a/cookbook/claude-account-swap/test_claude_account_swap.py
+++ b/cookbook/claude-account-swap/test_claude_account_swap.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Regression checks using temporary records and a fake control transport."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+spec = importlib.util.spec_from_file_location("swap", Path(__file__).with_name("claude-account-swap.py"))
+assert spec and spec.loader
+swap = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = swap
+spec.loader.exec_module(swap)
+
+
+class Fixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        self.accounts = [swap.Account("Personal", self.root / "personal"),
+                         swap.Account("Work", self.root / "work")]
+        for account in self.accounts:
+            account.config_dir.mkdir()
+        self.transcript = self.accounts[0].config_dir / "projects" / "repo" / "conversation.jsonl"
+        self.transcript.parent.mkdir(parents=True)
+        self.write_turn("hello")
+        self.proc = swap.Process(123, 100, 123, 123, "Mon Sep 7 10:00:00 2026", "claude")
+        self.env = mock.patch.dict(os.environ, {"PANE_MAP_DIR": str(self.root / "maps"),
+                                               "AGT_SESSION_ID": "S", "AGT_WINDOW_ID": "W"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.record = swap.Record(self.transcript, 123, self.proc.started, "conversation")
+        swap.write_record("S", "left", self.record)
+
+    def write_turn(self, text: str) -> None:
+        self.transcript.write_text(json.dumps({"type": "user", "sessionId": "conversation",
+            "cwd": str(self.root), "message": {"content": text}}) + "\n")
+        old = time.time() - 60
+        os.utime(self.transcript, (old, old))
+
+    def live(self):
+        with mock.patch.object(swap, "process_info", return_value=self.proc):
+            return swap.live_record("S", self.accounts)
+
+
+class TestRecords(Fixture):
+    def test_live_record_identifies_source_root(self) -> None:
+        self.assertEqual((self.record, self.accounts[0]), self.live())
+
+    def test_missing_map_does_not_search_existing_transcript(self) -> None:
+        swap.map_path("S", "left").unlink()
+        with self.assertRaises(swap.Fail):
+            self.live()
+
+    def test_statusline_only_map_is_not_freshness_evidence(self) -> None:
+        swap.map_path("S", "left").write_text(str(self.transcript) + "\n")
+        with self.assertRaises(swap.Fail):
+            self.live()
+
+    def test_dead_reused_and_background_processes_are_rejected(self) -> None:
+        for proc in (None, self.proc._replace(started="another start"),
+                     self.proc._replace(tpgid=456), self.proc._replace(comm="vim")):
+            with self.subTest(proc=proc), mock.patch.object(swap, "process_info", return_value=proc), \
+                    self.assertRaises(swap.Fail):
+                swap.live_record("S", self.accounts)
+
+    def test_unknown_root_and_session_mismatch_are_rejected(self) -> None:
+        with self.assertRaises(swap.Fail), mock.patch.object(swap, "process_info", return_value=self.proc):
+            swap.live_record("S", self.accounts[1:])
+        swap.write_record("S", "left", self.record._replace(session_id="other"))
+        with self.assertRaises(swap.Fail):
+            self.live()
+
+    def test_hook_records_direct_manual_launch(self) -> None:
+        shell = swap.Process(124, 123, 124, 0, "now", "/bin/sh")
+        with mock.patch.object(swap.os, "getppid", return_value=124), \
+                mock.patch.object(swap, "process_info", side_effect=[shell, self.proc]), \
+                mock.patch.dict(os.environ, {"AGTERM_SESSION_ID": "manual", "AGTERM_PANE": "right"}):
+            swap.record_hook({"transcript_path": str(self.transcript), "session_id": "conversation"})
+        lines = swap.map_path("manual", "right").read_text().splitlines()
+        self.assertEqual(str(self.transcript), lines[0])
+        self.assertEqual(123, json.loads(lines[1])["pid"])
+
+    def test_background_hook_does_not_overwrite_map(self) -> None:
+        before = swap.map_path("S", "left").read_bytes()
+        with mock.patch.object(swap, "process_info", return_value=self.proc._replace(tpgid=456)), \
+                mock.patch.dict(os.environ, {"AGTERM_SESSION_ID": "S", "AGTERM_PANE": "left"}):
+            swap.record_hook({"transcript_path": str(self.transcript), "session_id": "conversation"})
+        self.assertEqual(before, swap.map_path("S", "left").read_bytes())
+
+    def test_account_config_rejects_duplicate_and_overlapping_roots(self) -> None:
+        config = self.root / "accounts.json"
+        for paths in (["personal", "personal"], ["personal", "personal/nested"]):
+            config.write_text(json.dumps([{"label": str(i), "config_dir": str(self.root / path)}
+                                          for i, path in enumerate(paths)]))
+            with self.assertRaises(swap.Fail):
+                swap.load_accounts(config)
+
+
+class FakeAgt:
+    def __init__(self, account) -> None:
+        self.account = account
+        self.typed = []
+        self.foreground = ["claude"]
+        self.column = 2
+
+    def node(self, sid):
+        return {"cwd": "/tmp", "foreground": self.foreground,
+                "foregroundShell": "zsh" if not self.foreground else None}
+
+    def cursor_column(self, sid):
+        return self.column
+
+    def pick(self, accounts, current):
+        return self.account
+
+    def hud(self, *args, **kwargs):
+        pass
+
+    def hud_close(self):
+        pass
+
+    def type_line(self, sid, text):
+        self.typed.append(text)
+        self.foreground = [] if text == "/exit" else ["claude"]
+
+
+class TestSwap(Fixture):
+    def setUp(self) -> None:
+        super().setUp()
+        self.agt = FakeAgt(self.accounts[1])
+        for patch in (mock.patch.object(swap, "Agt", return_value=self.agt),
+                      mock.patch.object(swap, "process_info", return_value=self.proc),
+                      mock.patch.object(swap, "save_packet", return_value=self.root / "packet.md")):
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def run_swap(self, summarizer=lambda digest, cwd: "summary"):
+        with mock.patch.object(swap, "summarize", side_effect=summarizer):
+            return swap.swap(self.accounts, False)
+
+    def test_cancel_does_not_summarize_or_type(self) -> None:
+        self.agt.account = None
+        with mock.patch.object(swap, "summarize") as summarize:
+            self.assertEqual(0, swap.swap(self.accounts, False))
+        summarize.assert_not_called()
+        self.assertEqual([], self.agt.typed)
+
+    def test_changed_transcript_after_summary_does_not_quit(self) -> None:
+        def summarize(digest, cwd):
+            self.write_turn("a later turn that already finished")
+            return "summary"
+        with self.assertRaisesRegex(swap.Fail, "moved on"):
+            self.run_swap(summarize)
+        self.assertEqual([], self.agt.typed)
+
+    def test_changed_map_after_summary_does_not_quit(self) -> None:
+        def summarize(digest, cwd):
+            swap.write_record("S", "left", self.record._replace(session_id="new"))
+            return "summary"
+        with self.assertRaises(swap.Fail):
+            self.run_swap(summarize)
+        self.assertEqual([], self.agt.typed)
+
+    def test_draft_or_wrong_program_does_not_quit(self) -> None:
+        for foreground, column in ((["claude"], 5), (["cat", "claude"], 2), (["vim"], 2)):
+            self.agt.foreground, self.agt.column = foreground, column
+            with self.assertRaises(swap.Fail):
+                self.run_swap()
+            self.assertEqual([], self.agt.typed)
+
+    def test_success_quits_then_launches_selected_config(self) -> None:
+        with mock.patch.object(swap, "wait_for_shell", return_value=True), \
+                mock.patch.object(swap, "wait_for_agent", return_value=True):
+            self.assertEqual(0, self.run_swap())
+        self.assertEqual("/exit", self.agt.typed[0])
+        self.assertIn("CLAUDE_CONFIG_DIR=", self.agt.typed[1])
+        self.assertIn(str(self.accounts[1].config_dir), self.agt.typed[1])
+
+    def test_failed_exit_never_launches(self) -> None:
+        with mock.patch.object(swap, "wait_for_shell", return_value=False), self.assertRaises(swap.Fail):
+            self.run_swap()
+        self.assertEqual(["/exit"], self.agt.typed)
+
+
+class TestQuoting(Fixture):
+    def test_shell_receives_literal_packet_and_config_path(self) -> None:
+        payload = self.root / "packet ' with spaces.md"
+        payload.write_text('$(touch forbidden) `touch forbidden` "quotes"\nnext line')
+        binary = self.root / "fake claude"
+        binary.write_text('#!/bin/sh\nprintf "%s\\n%s" "$CLAUDE_CONFIG_DIR" "$1"\n')
+        binary.chmod(0o700)
+        account = swap.Account("Work", self.root / "config ' $(no)")
+        with mock.patch.object(swap, "CLAUDE_BIN", str(binary)):
+            line = swap.launch_line(account, str(self.root), payload)
+        result = subprocess.run(["/bin/sh", "-c", line], capture_output=True, text=True, check=True)
+        self.assertEqual(str(account.config_dir) + "\n" + payload.read_text(), result.stdout)
+        self.assertFalse((self.root / "forbidden").exists())
+
+    def test_control_characters_cannot_reach_terminal(self) -> None:
+        with self.assertRaises(swap.Fail):
+            swap.launch_line(self.accounts[1], "/tmp/repo\nexit", self.root / "p")
+
+
+class TestStartup(Fixture):
+    def test_confirmation_needs_new_process_and_selected_account(self) -> None:
+        new = self.record._replace(pid=456, started="new start")
+        agt = FakeAgt(self.accounts[1])
+        for record, account, expected in ((self.record, self.accounts[1], False),
+                                          (new, self.accounts[0], False),
+                                          (new, self.accounts[1], True)):
+            with self.subTest(record=record, account=account), \
+                    mock.patch.object(swap, "live_record", return_value=(record, account)), \
+                    mock.patch.object(swap.time, "monotonic", side_effect=[0, 2]), \
+                    mock.patch.object(swap.time, "sleep"):
+                self.assertEqual(expected, swap.wait_for_agent(
+                    agt, "S", self.accounts, self.accounts[1], self.record, 1))
+
+    def test_missing_startup_hook_is_not_success(self) -> None:
+        with mock.patch.object(swap, "live_record", side_effect=swap.Fail("missing map")), \
+                mock.patch.object(swap.time, "monotonic", side_effect=[0, 2]), \
+                mock.patch.object(swap.time, "sleep"):
+            self.assertFalse(swap.wait_for_agent(
+                FakeAgt(self.accounts[1]), "S", self.accounts, self.accounts[1], self.record, 1))
+
+
+class TestDigest(Fixture):
+    def test_tools_are_dropped_and_worktree_cwd_survives(self) -> None:
+        rows = [
+            {"type": "user", "message": {"content": "do this"}},
+            {"type": "user", "message": {"content": [{"type": "tool_result", "content": "secret tool output"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "answer"},
+                                                          {"type": "tool_use", "input": "tool input"}]}},
+            {"type": "system", "cwd": "/tmp/café/worktree"},
+        ]
+        self.transcript.write_text("\n".join(json.dumps(row) for row in rows))
+        entries = swap.read_entries(self.transcript)
+        digest = swap.build_digest(entries, 1500, swap.datetime.now(swap.timezone.utc))
+        self.assertIn("do this", digest)
+        self.assertIn("answer", digest)
+        self.assertNotIn("tool", digest)
+        self.assertEqual("/tmp/café/worktree", swap.transcript_cwd(entries, "/tmp"))
+
+    def test_final_message_uses_last_completed_agent_message(self) -> None:
+        stream = "\n".join(json.dumps({"type": "item.completed",
+            "item": {"type": "agent_message", "text": text}}) for text in ["first", "last"])
+        self.assertEqual("last", swap.final_message(stream))
+
+    def test_packet_is_context_only_and_private(self) -> None:
+        text = swap.carry_over("summary", "Personal", "Work", self.transcript)
+        self.assertIn("CONTEXT ONLY", text)
+        self.assertIn("wait for the user", text)
+        path = swap.save_packet(text)
+        self.addCleanup(path.unlink)
+        self.assertEqual(0o600, path.stat().st_mode & 0o777)
+
+
+class TestTransport(unittest.TestCase):
+    def test_picker_excludes_source_and_has_no_user_timeout(self) -> None:
+        accounts = [swap.Account("One", Path("/one")), swap.Account("Two", Path("/two"))]
+        result = subprocess.CompletedProcess([], 0, '{"result":"picked","id":"1"}', "")
+        with mock.patch.dict(os.environ, {"AGT_WINDOW_ID": "W"}), \
+                mock.patch.object(swap.Agt, "run", return_value=result) as run:
+            self.assertEqual(accounts[1], swap.Agt("S").pick(accounts, accounts[0]))
+        self.assertEqual([{"id": "1", "label": "Two", "subtitle": "/two"}],
+                         json.loads(run.call_args.kwargs["stdin"]))
+        self.assertIsNone(run.call_args.kwargs["timeout"])
+
+    def test_ps_parser_reads_identity_without_arguments_or_environment(self) -> None:
+        result = subprocess.CompletedProcess([], 0,
+            "123 100 123 123 Mon Sep  7 10:00:00 2026 /opt/bin/claude\n", "")
+        with mock.patch.object(swap.subprocess, "run", return_value=result) as run:
+            process = swap.process_info(123)
+        self.assertEqual("Mon Sep 7 10:00:00 2026", process.started)
+        self.assertEqual("/opt/bin/claude", process.comm)
+        self.assertNotIn("args", run.call_args.args[0][-1])
+
+    def test_a_shell_must_be_observed_before_launch(self) -> None:
+        self.assertFalse(swap.at_shell_prompt({}))
+        self.assertFalse(swap.at_shell_prompt({"foreground": ["vim"]}))
+        self.assertTrue(swap.at_shell_prompt({"foregroundShell": "zsh"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A cookbook recipe that switches the left pane between two or more authenticated Claude config directories, carrying a summary of the outgoing conversation into the new account so the work continues rather than restarting.

**Why it needs no wrapper scripts**

`CLAUDE_CONFIG_DIR` is what selects an account, and it lives in the environment rather than in argv, so the account cannot be identified from the pane's foreground argv the way a launcher's name can. Rather than reading a launcher name, the recipe reads the pane map that Claude itself feeds: the transcript path recorded per pane, whose root is `<config dir>/projects`. That answers both questions at once, which transcript to summarize and which account it belongs to.

**What the freshness check does and does not prove**

The map file outlives the Claude that wrote it, so existence proves nothing. The hook records the owning process id and its start time beside the path, and a switch requires that process to still be alive, still be Claude, and still lead its terminal's foreground group. The start time defeats process id reuse; the foreground-group test separates the interactive session from a nested `claude -p`. A map whose owner has exited, been replaced, or moved to the background is refused rather than used.

What it cannot catch is a conversation that changed inside the same live process while the hook failed to record it, since the owner still passes every check. The transcript path stays on line one, so `claude-recap`'s reader works against the same file unchanged.

The personal script this is ported from falls back, when no map is available, to the newest transcript across every config root. That fallback is not carried over: with two panes on one repository, or one repository open in both accounts, it can summarize the wrong conversation, including the destination account's own. Here a missing map refuses the switch instead.

**Wrappers**

A wrapper still works if it replaces itself with `exec`, which preserves the process id and so keeps the foreground-group relationship intact. That is how flags such as `--append-system-prompt` reach every launch. The README shows the pattern; a wrapper that stays alive around Claude fails both checks and is documented as unsupported.

**The summary**

Condensing runs through `codex exec` in a read-only sandbox with the shell, unified-exec and multi-agent tools disabled, so neither Claude account spends its own quota summarizing its own handoff. The model is overridable with `CLAUDE_SWAP_MODEL`.

Requirements name agterm 0.26.0, which is when the tree began reporting `foregroundShell`. Progress panels use the paned `session.hud` from 0.26.2 and fall back to a session-wide panel below that, or when the left pane is hidden.

Limits state plainly that this quits the running agent, and cover the unsupported cases: Node-based installs, SSH, tmux, nested agents, and moving a pane after Claude starts.
