### PR TITLE
Show the remote host on a zmx-attached session

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -229,9 +229,10 @@ paths:
 - `confirmCloseSession` defaults off and is read on demand, without a mirror. Prompt only for GUI active
   close and sidebar row close; skip under XCUITest. Control `session.close` must never prompt.
 - `hiddenInterfaceElements` stores raw names and preserves unknown values while toggling known ones; empty
-  maps nil. Titlebar cases are `sidebarToggle`, `sessionName`, `windowName`, `recentSessions`, `scratch`,
-  `split`, `dashboard`, `quickTerminal`; sidebar cases are `newWorkspace`, `newSession`, `flaggedView`,
-  `focusFilter`, and row-level `workspaceAddSession`. Attention has its separate default-off setting.
+  maps nil. Titlebar cases are `sidebarToggle`, `sessionName`, `windowName`, `remoteHost`, `sessionContext`,
+  `recentSessions`, `scratch`, `split`, `dashboard`, `quickTerminal`; sidebar cases are `newWorkspace`,
+  `newSession`, `flaggedView`, `focusFilter`, and row-level `workspaceAddSession`. Attention has its
+  separate default-off setting.
 - `InterfaceElement` owns section/display name; the tab iterates `allCases`. Mutate the raw set, then push
   resolved known values to `GhosttyApp`. SwiftUI gates with `shows(_:)`; the AppKit row "+" checks the
   mirror on hover. Titlebar group dividers appear only between adjacent groups that each retain at least

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -84,12 +84,13 @@ paths:
 - In tree mode, flagged rows swap to `terminal.fill` or `rectangle.split.2x1.fill`; flagged mode retains
   unfilled base icons because every row is flagged. This same-size symbol swap avoids layout shift.
   `RowContent.flagged` limits reload to the changed row.
-- A remote row (`Session.remoteHost != nil`) takes `arrow.up.forward.bottomleading.rectangle` instead, and
+- A remote row (`Session.remoteHost != nil`) takes `cloud` instead, and
   there a heavier WEIGHT means split rather than flagged: a hidden split is state nothing else reveals,
   while the fill is tree-mode decoration the flat flagged view already passes `flagged: false` for.
-  Weight rather than `.fill` because `.fill` on a `*.rectangle` symbol fills the frame and erases the
-  arrow inside, leaving a blank box; the focused-workspace icon distinguishes itself the same way.
-  The split axis is not distinguished — no remote-looking symbol family carries both arrangements.
+  Weight rather than `.fill` because `.fill` is what every other row icon spends on FLAGGED, so a filled
+  cloud would read as a flag; the focused-workspace icon distinguishes itself the same way.
+  The split axis is not distinguished — no cloud symbol carries both arrangements. The title bar draws
+  the same `cloud` beside the host, gated by `InterfaceElement.remoteHost`.
   See [[control-api]].
 
 ## Workspace focus

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -11,7 +11,8 @@ extension WindowContentView {
     var titleLabel: TitlebarLabel {
         TitlebarLabel(store: store, library: library, windowID: windowID, toolbarMode: toolbarMode,
                       chromeText: chromeText, showsSessionName: shows(.sessionName),
-                      showsWindowName: shows(.windowName), showsContext: shows(.sessionContext))
+                      showsWindowName: shows(.windowName), showsContext: shows(.sessionContext),
+                      showsRemoteHost: shows(.remoteHost))
     }
 
     /// Feeds the OS window title to `WindowAccessor` from its own body, for the same reason as `titleLabel`.
@@ -228,12 +229,33 @@ struct TitlebarLabel: View {
     let showsSessionName: Bool
     let showsWindowName: Bool
     let showsContext: Bool
+    let showsRemoteHost: Bool
 
     var body: some View {
         let composition = composition
         VStack(alignment: .leading, spacing: 1) {
-            if !composition.title.isEmpty {
-                Text(composition.title).fontWeight(.semibold)
+            HStack(spacing: 0) {
+                if !composition.title.isEmpty {
+                    Text(composition.title).fontWeight(.semibold)
+                        .layoutPriority(1)
+                }
+                if let host = composition.host {
+                    HStack(spacing: 4) {
+                        Image(systemName: "cloud")
+                            .fixedSize()
+                            .accessibilityHidden(true)
+                        RemoteHostTextLayout {
+                            Text(verbatim: host)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    .foregroundStyle(chromeText.opacity(0.6))
+                    .padding(.leading, composition.title.isEmpty ? 0 : 6)
+                    .layoutPriority(1)
+                }
+                if !composition.tail.isEmpty {
+                    Text(composition.tail).fontWeight(.semibold)
+                }
             }
             if !composition.subtitle.isEmpty {
                 Text(composition.subtitle)
@@ -242,7 +264,8 @@ struct TitlebarLabel: View {
             }
         }
         // a caller-set context can run to 256 bytes, far past the row; tail truncation drops its end rather
-        // than letting the label push the trailing button cluster off the bar.
+        // than letting the label push the trailing button cluster off the bar. the host truncates in the
+        // MIDDLE under its own ceiling instead, so an ssh target retains both of its ends.
         .lineLimit(1)
         .truncationMode(.tail)
     }
@@ -253,9 +276,24 @@ struct TitlebarLabel: View {
                 sessionName: showsSessionName ? (store.activeSession?.displayName ?? "Agterm") : nil,
                 windowName: showsWindowName ? library.customWindowName(for: windowID) : nil,
                 context: showsContext ? store.activeSession?.context : nil,
-                detail: store.activeSession?.subtitleDetail ?? ""
+                detail: store.activeSession?.subtitleDetail ?? "",
+                remoteHost: showsRemoteHost ? store.activeSession?.remoteHost : nil
             ),
             mode: toolbarMode
         )
+    }
+}
+
+/// Caps the host without expanding short names or preventing compression beside the sidebar.
+private struct RemoteHostTextLayout: Layout {
+    static let ceiling: CGFloat = 240
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = min(proposal.width ?? Self.ceiling, Self.ceiling)
+        return subviews[0].sizeThatFits(ProposedViewSize(width: width, height: proposal.height))
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        subviews[0].place(at: bounds.origin, proposal: ProposedViewSize(width: bounds.width, height: bounds.height))
     }
 }

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -99,8 +99,8 @@ extension WorkspaceSidebar.Coordinator {
     /// A remote row takes its own glyph and keeps the split bit, not the flagged fill: a HIDDEN split is
     /// state nothing else reveals, while the fill is tree-mode decoration the flat flagged view already
     /// passes `flagged: false` for. It marks that split by WEIGHT, as the focused-workspace icon does,
-    /// because `.fill` on a `*.rectangle` symbol fills the frame and erases the arrow inside it. The axis
-    /// is not distinguished — no remote-looking symbol family carries both arrangements.
+    /// because `.fill` is what every other row icon spends on FLAGGED, so a filled cloud would read as a
+    /// flag. The axis is not distinguished — no cloud symbol carries both arrangements.
     private func iconForSession(split: Bool, axis: SplitAxis, flagged: Bool, remote: Bool) -> NSImage? {
         if remote { return split ? remoteSplitSessionIcon : remoteSessionIcon }
         switch (split, axis, flagged) {

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -779,9 +779,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         lazy var flaggedSessionIcon = Self.rowIcon("terminal.fill")
         lazy var flaggedSplitSessionIcon = Self.rowIcon("rectangle.split.2x1.fill")
         lazy var flaggedHorizontalSplitSessionIcon = Self.rowIcon("rectangle.split.1x2.fill")
-        lazy var remoteSessionIcon = Self.rowIcon("arrow.up.forward.bottomleading.rectangle")
-        lazy var remoteSplitSessionIcon = Self.rowIcon("arrow.up.forward.bottomleading.rectangle",
-                                                       weight: .bold)
+        lazy var remoteSessionIcon = Self.rowIcon("cloud")
+        lazy var remoteSplitSessionIcon = Self.rowIcon("cloud", weight: .bold)
 
         private static func rowIcon(_ symbolName: String, weight: NSFont.Weight = .regular) -> NSImage? {
             let config = NSImage.SymbolConfiguration(pointSize: 13, weight: weight)

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -29,6 +29,7 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     case sidebarToggle
     case sessionName
     case windowName
+    case remoteHost
     case sessionContext
     case recentSessions
     case scratch
@@ -59,6 +60,7 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
         case .sidebarToggle: return "Sidebar toggle"
         case .sessionName: return "Session name"
         case .windowName: return "Window name"
+        case .remoteHost: return "Remote host"
         case .sessionContext: return "Session context"
         case .recentSessions: return "Recent sessions"
         case .scratch: return "Scratch terminal"

--- a/agtermCore/Sources/agtermCore/TitlebarComposition.swift
+++ b/agtermCore/Sources/agtermCore/TitlebarComposition.swift
@@ -2,8 +2,12 @@
 /// owns only layout and truncation. Follows `InterfaceElement.titlebarGroupDividers`, hoisted for the
 /// same reason.
 public struct TitlebarComposition: Sendable, Equatable {
-    /// Line one. Empty when every part it can carry is hidden or absent.
+    /// Line one's session and window identity.
     public let title: String
+    /// The SSH target following the identity, styled and truncated separately by the view.
+    public var host: String?
+    /// Compact context, including its separator when another line-one part precedes it.
+    public var tail: String = ""
     /// Line two, empty outside `.normal` — the compact and hidden bars are one row or none.
     public let subtitle: String
 
@@ -18,13 +22,15 @@ public struct TitlebarComposition: Sendable, Equatable {
         public var context: String?
         /// `Session.subtitleDetail` — the focused pane's terminal title or its cwd.
         public var detail: String
+        public var remoteHost: String?
 
         public init(sessionName: String? = nil, windowName: String? = nil,
-                    context: String? = nil, detail: String = "") {
+                    context: String? = nil, detail: String = "", remoteHost: String? = nil) {
             self.sessionName = sessionName
             self.windowName = windowName
             self.context = context
             self.detail = detail
+            self.remoteHost = remoteHost
         }
     }
 
@@ -35,11 +41,11 @@ public struct TitlebarComposition: Sendable, Equatable {
 
     /// Lays the parts out for one toolbar mode.
     ///
-    /// Compact puts the context AFTER the identity so the view's tail truncation eats the context first:
-    /// `ToolbarMode` is independent of sidebar visibility, so a compact bar with the sidebar hidden is the
-    /// only place the session name appears at all. Normal gives the context line two, REPLACING the cwd
-    /// detail rather than sharing the row, which would truncate both. Hidden composes nothing — neither
-    /// title bar renders a label in that mode.
+    /// Compact puts the context LAST, after the identity and the host, so the view's lower layout priority
+    /// on `tail` drops the context first: `ToolbarMode` is independent of sidebar visibility, so a compact
+    /// bar with the sidebar hidden is the only place the session name appears at all. Normal gives the
+    /// context line two, REPLACING the cwd detail rather than sharing the row, which would truncate both.
+    /// Hidden composes nothing — neither title bar renders a label in that mode.
     public static func compose(_ parts: Parts, mode: ToolbarMode) -> TitlebarComposition {
         let identity: String
         switch (parts.sessionName, parts.windowName) {
@@ -52,10 +58,12 @@ public struct TitlebarComposition: Sendable, Equatable {
         case .hidden:
             return TitlebarComposition(title: "", subtitle: "")
         case .compact:
-            let segments = [identity, parts.context ?? ""].filter { !$0.isEmpty }
-            return TitlebarComposition(title: segments.joined(separator: contextSeparator), subtitle: "")
+            let context = parts.context ?? ""
+            let separator = !identity.isEmpty || parts.remoteHost != nil ? contextSeparator : ""
+            return TitlebarComposition(title: identity, host: parts.remoteHost,
+                                      tail: context.isEmpty ? "" : separator + context, subtitle: "")
         case .normal:
-            return TitlebarComposition(title: identity, subtitle: parts.context ?? parts.detail)
+            return TitlebarComposition(title: identity, host: parts.remoteHost, subtitle: parts.context ?? parts.detail)
         }
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -643,6 +643,15 @@ struct AppSettingsTests {
         #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
+    @Test func remoteHostIsADistinctTitleBarInterfaceElement() {
+        #expect(InterfaceElement.remoteHost.section == .titleBar)
+        #expect(InterfaceElement.remoteHost.displayName == "Remote host")
+        let hidden = AppSettings(hiddenInterfaceElements: ["remoteHost"])
+        #expect(hidden.isInterfaceElementHidden(.remoteHost))
+        #expect(!hidden.isInterfaceElementHidden(.sessionName))
+        #expect(!AppSettings(hiddenInterfaceElements: ["sessionName"]).isInterfaceElementHidden(.remoteHost))
+    }
+
     @Test func workspaceAddSessionIsADistinctSidebarInterfaceElement() {
         // the workspace-row hover "+", a separate toggle from the footer newSession button.
         #expect(InterfaceElement.workspaceAddSession.section == .sidebar)

--- a/agtermCore/Tests/agtermCoreTests/TitlebarCompositionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TitlebarCompositionTests.swift
@@ -3,9 +3,10 @@ import Testing
 
 struct TitlebarCompositionTests {
     private func compose(session: String? = "alpha", window: String? = nil, context: String? = nil,
-                         detail: String = "/repo", mode: ToolbarMode) -> TitlebarComposition {
+                         detail: String = "/repo", host: String? = nil, mode: ToolbarMode) -> TitlebarComposition {
         TitlebarComposition.compose(
-            TitlebarComposition.Parts(sessionName: session, windowName: window, context: context, detail: detail),
+            TitlebarComposition.Parts(sessionName: session, windowName: window, context: context, detail: detail,
+                                      remoteHost: host),
             mode: mode
         )
     }
@@ -35,13 +36,15 @@ struct TitlebarCompositionTests {
 
     @Test func compactAppendsContextAfterTheIdentitySoTruncationEatsItFirst() {
         let composed = compose(window: "main", context: "PR #517", mode: .compact)
-        #expect(composed.title == "alpha — main · PR #517")
+        #expect(composed.title == "alpha — main")
+        #expect(composed.tail == " · PR #517")
         #expect(composed.subtitle == "")
     }
 
     @Test func compactShowsContextAloneWhenEveryIdentityPartIsHidden() {
         let composed = compose(session: nil, window: nil, context: "PR #517", mode: .compact)
-        #expect(composed.title == "PR #517")
+        #expect(composed.title == "")
+        #expect(composed.tail == "PR #517")
     }
 
     @Test func hiddenComposesNothingEvenWithAContext() {
@@ -59,5 +62,38 @@ struct TitlebarCompositionTests {
         let composed = compose(session: nil, window: nil, context: "PR #517", mode: .normal)
         #expect(composed.title == "")
         #expect(composed.subtitle == "PR #517")
+    }
+
+    @Test(arguments: [ToolbarMode.normal, .compact])
+    func remoteHostStaysOnLineOneAlongsideIdentityAndContext(mode: ToolbarMode) {
+        let host = "builder@long.internal.example.com"
+        let composed = compose(window: "main", context: "PR #517", host: host, mode: mode)
+        #expect(composed.title == "alpha — main")
+        #expect(composed.host == host)
+        #expect(composed.tail == (mode == .compact ? " · PR #517" : ""))
+        #expect(composed.subtitle == (mode == .normal ? "PR #517" : ""))
+    }
+
+    @Test(arguments: [ToolbarMode.normal, .compact])
+    func remoteHostCanStandAloneWithBothNamesHidden(mode: ToolbarMode) {
+        let composed = compose(session: nil, host: "buildbox", mode: mode)
+        #expect(composed.title.isEmpty)
+        #expect(composed.host == "buildbox")
+        #expect(composed.tail.isEmpty)
+    }
+
+    @Test func compactContextKeepsItsSeparatorAfterAHostAlone() {
+        let composed = compose(session: nil, context: "PR #517", host: "buildbox", mode: .compact)
+        #expect(composed.title.isEmpty)
+        #expect(composed.host == "buildbox")
+        #expect(composed.tail == " · PR #517")
+    }
+
+    @Test func hiddenModeDropsEveryRemotePart() {
+        let composed = compose(window: "main", context: "PR #517", host: "buildbox", mode: .hidden)
+        #expect(composed.title.isEmpty)
+        #expect(composed.host == nil)
+        #expect(composed.tail.isEmpty)
+        #expect(composed.subtitle.isEmpty)
     }
 }

--- a/agtermTests/WindowContentView+TitlebarTests.swift
+++ b/agtermTests/WindowContentView+TitlebarTests.swift
@@ -62,4 +62,112 @@ final class WindowContentViewTitlebarTests: XCTestCase {
         }
         XCTAssertEqual(window.title, expected)
     }
+
+    func testRemoteTitlebarRendersAtNarrowAndWideWidths() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let workspace = try XCTUnwrap(store.currentWorkspaceID)
+        store.sidebarVisible = false
+        for mode in [ToolbarMode.normal, .compact] {
+            for width in [640.0, 1100.0] {
+                for host in ["dev", "builder@very-long-host.internal.example.com"] {
+                    let session = try XCTUnwrap(store.addSession(toWorkspace: workspace, cwd: "/repo",
+                                                                name: "build", remoteHost: host))
+                    XCTAssertTrue(store.setContext("PR #517 " + String(repeating: "context ", count: 20), forSession: session.id))
+                    let windowID = try XCTUnwrap(library.activeWindowID)
+                    library.renameWindow(windowID, to: "work")
+                    let visible = try renderTitlebar(mode: mode, width: width)
+                    let hidden = try renderTitlebar(mode: mode, width: width, hidden: [.remoteHost])
+                    let scale = Int(window.backingScaleFactor)
+                    XCTAssertEqual(visible.pixelsWide, Int(width) * scale)
+                    XCTAssertEqual(visible.pixelsHigh, (mode == .normal ? 48 : 30) * scale)
+                    XCTAssertGreaterThan(differentPixels(visible, hidden, from: 110 * scale, to: (Int(width) - 270) * scale), 20)
+                    let buttonsWidth = mode == .normal ? 250 : 225
+                    XCTAssertEqual(differentPixels(visible, hidden, from: (Int(width) - buttonsWidth) * scale,
+                                                   to: Int(width) * scale), 0)
+                    attach(visible, name: "remote-\(mode.rawValue)-\(Int(width))-\(host == "dev" ? "short" : "long")")
+                }
+            }
+        }
+    }
+
+    func testLongRemoteIdentityKeepsButtonsInPlaceWithSidebarVisible() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let workspace = try XCTUnwrap(store.currentWorkspaceID)
+        store.sidebarVisible = true
+        store.sidebarWidth = 220
+        let session = try XCTUnwrap(store.addSession(toWorkspace: workspace, cwd: "/repo",
+                                                    name: "a very long session name for the remote build",
+                                                    remoteHost: "builder@very-long-host.internal.example.com"))
+        XCTAssertTrue(store.setContext("PR #517 " + String(repeating: "context ", count: 20), forSession: session.id))
+        for mode in [ToolbarMode.normal, .compact] {
+            let visible = try renderTitlebar(mode: mode, width: 640)
+            let hidden = try renderTitlebar(mode: mode, width: 640, hidden: [.remoteHost])
+            let scale = Int(window.backingScaleFactor)
+            let buttonsWidth = mode == .normal ? 250 : 225
+            XCTAssertEqual(differentPixels(visible, hidden, from: (640 - buttonsWidth) * scale, to: 640 * scale), 0)
+            attach(visible, name: "remote-\(mode.rawValue)-640-sidebar-long-identity")
+        }
+    }
+
+    func testRemoteCloudSplitWeightRemainsVisibleAtSidebarSize() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let coordinator = WorkspaceSidebar.Coordinator(store: store, actions: AppActions(library: library))
+        let regular = try renderCloud(XCTUnwrap(coordinator.remoteSessionIcon))
+        let bold = try renderCloud(XCTUnwrap(coordinator.remoteSplitSessionIcon))
+        XCTAssertGreaterThan(differentPixels(regular, bold, from: 0, to: 16), 15)
+        attach(regular, name: "remote-cloud-sidebar-regular")
+        attach(bold, name: "remote-cloud-sidebar-bold")
+    }
+
+    private func renderTitlebar(mode: ToolbarMode, width: Double,
+                                hidden: Set<InterfaceElement> = []) throws -> NSBitmapImageRep {
+        let store = try XCTUnwrap(library.activeStore)
+        let content = WindowContentView(
+            windowID: try XCTUnwrap(library.activeWindowID), store: store, library: library,
+            makeSurface: { _ in fatalError("titlebar must not create surfaces") },
+            makeSplitSurface: { _ in fatalError("titlebar must not create surfaces") },
+            makeOverlaySurface: { _, _ in fatalError("titlebar must not create surfaces") },
+            makeScratchSurface: { _ in fatalError("titlebar must not create surfaces") },
+            captureOnExit: nil, actions: AppActions(library: library), palette: PaletteController(),
+            sessionSwitcher: SessionSwitcher(library: library, canSwitch: { false }),
+            toolbarMode: mode, chromeText: .black, attentionButtonEnabled: true, hiddenInterfaceElements: hidden
+        )
+        let view = content.customTitlebar.frame(width: width).background(.white).environment(\.colorScheme, .light)
+        let host = NSHostingView(rootView: view)
+        window.setContentSize(NSSize(width: width, height: mode == .normal ? 48 : 30))
+        window.contentView = host
+        window.orderFront(nil)
+        window.layoutIfNeeded()
+        host.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        return bitmap
+    }
+
+    private func renderCloud(_ image: NSImage) throws -> NSBitmapImageRep {
+        let view = Image(nsImage: image).frame(width: 16, height: 16).foregroundStyle(.black).background(.white)
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 1
+        let rendered = try XCTUnwrap(renderer.nsImage)
+        return try XCTUnwrap(NSBitmapImageRep(data: XCTUnwrap(rendered.tiffRepresentation)))
+    }
+
+    private func differentPixels(_ first: NSBitmapImageRep, _ second: NSBitmapImageRep,
+                                 from start: Int, to end: Int) -> Int {
+        (start..<end).reduce(0) { count, x in
+            count + (0..<first.pixelsHigh).filter { y in
+                first.colorAt(x: x, y: y) != second.colorAt(x: x, y: y)
+            }.count
+        }
+    }
+
+    private func attach(_ bitmap: NSBitmapImageRep, name: String) {
+        let image = NSImage(size: bitmap.size)
+        image.addRepresentation(bitmap)
+        let attachment = XCTAttachment(image: image)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
 }

--- a/site/docs.html
+++ b/site/docs.html
@@ -2526,6 +2526,7 @@
               only this side's connection — the far-side processes keep running, and nothing agterm does from this end can kill them.
               A remote session is never written to disk, so it does not come back after a relaunch. Its tree node carries
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">remoteHost</span>.
+              The title bar shows a cloud and the remote host, which you can hide with the Remote host toggle in Settings ▸ Interface.
             </p>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 12px 0 0">
               An attach joins as a follower, and pinned zmx has one leader per pane, so the pane arrives at the <em>other</em>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1453,8 +1453,8 @@
                   style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
                   >›</span
                 ><strong style="color: #e6e1d7">Interface</strong> — turn individual chrome controls on or off (each shown by
-                default): in the title bar the sidebar toggle, the session name, the window name, the session context, and
-                the recent-sessions, scratch, split, dashboard, and quick-terminal buttons; in the sidebar the new-workspace, new-session,
+                default): in the title bar the sidebar toggle, the session name, the window name, the remote host, the
+                session context, and the recent-sessions, scratch, split, dashboard, and quick-terminal buttons; in the sidebar the new-workspace, new-session,
                 flagged-view, and workspace-filter footer buttons plus the per-workspace add-session + revealed on hover. A
                 <strong style="color: #e6e1d7">Multiple Windows</strong> option (off by default) shows the sidebar only in
                 the frontmost window and collapses it on every other, so switching windows moves the sidebar with focus.


### PR DESCRIPTION
a zmx-attached session now shows a cloud and its ssh target after the session and window names, on line one of the title bar. Shown by default, hidden independently with **Remote host** in Settings ▸ Interface. Remote sidebar rows take the same cloud, replacing the arrow-in-rectangle glyph.

The host stays on line one in both normal and compact modes, uses its natural width up to 240 points, and truncates in the middle when space is short. On a narrow compact bar the identity and the host take priority over the session context, which can disappear.
