### PR TITLE
feat(remote): expose session host and resolve local launch directories

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -928,6 +928,16 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   lifecycle and no remote daemon ownership, so closing locally tears the surface down, ssh dies, and the
   far-side daemon survives. No command asks the remote zmx to kill anything. `Session.remoteHost` is model
   metadata, and persistence, ownership, icon and factory routing all read it.
+- A remote pane's reported cwd can be remote, so the local launches that inherit it go through
+  `Session.localWorkingDirectory`: the reported path when it exists here as a directory, else HOME.
+  Those are custom commands (execution cwd only; `AGT_SESSION_PWD` stays the reported path and
+  `AGT_SESSION_HOST` carries the destination), scratch, the overlay default, the quick terminal and a
+  split created after the attach-time split closes. The attach surface itself still starts in HOME
+  without the helper. `keymap.md` owns the token contract.
+- When another client leads at a different terminal size, local cursor and screen-text reads can
+  disagree with the application's layout; automation relying on those reads, the chat transport
+  included, is unsupported in that state. `docs/backlog/attached-pane-content-is-laid-out-for-the-leaders-grid.md`
+  carries the zmx mechanism.
 - `zmx list` carries the `endpoint` header — the zmx executable and its `ZMX_DIR` — because neither is
   guessable from another machine. It is INJECTED from `ZmxClient` through the restored runtime, never
   recomputed from the process environment, which would duplicate runtime selection and break hosted tests

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -931,9 +931,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - A remote pane's reported cwd can be remote, so the local launches that inherit it go through
   `Session.localWorkingDirectory`: the reported path when it exists here as a directory, else HOME.
   Those are custom commands (execution cwd only; `AGT_SESSION_PWD` stays the reported path and
-  `AGT_SESSION_HOST` carries the destination), scratch, the overlay default, the quick terminal and a
-  split created after the attach-time split closes. The primary SSH surface still starts in HOME
-  without the helper. `keymap.md` owns the token contract.
+  `AGT_SESSION_HOST` carries the destination), scratch, the overlay default, the quick terminal, a
+  local split (the first on an unsplit remote session, or one created after the attach-time split
+  closes), Duplicate Session and a new session under the current-directory setting. The primary SSH
+  surface still starts in HOME without the helper. `keymap.md` owns the token contract.
 - When another client leads at a different terminal size, local cursor and screen-text reads can
   disagree with the application's layout; automation relying on those reads, the chat transport
   included, is unsupported in that state. `docs/backlog/attached-pane-content-is-laid-out-for-the-leaders-grid.md`

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -932,7 +932,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   `Session.localWorkingDirectory`: the reported path when it exists here as a directory, else HOME.
   Those are custom commands (execution cwd only; `AGT_SESSION_PWD` stays the reported path and
   `AGT_SESSION_HOST` carries the destination), scratch, the overlay default, the quick terminal and a
-  split created after the attach-time split closes. The attach surface itself still starts in HOME
+  split created after the attach-time split closes. The primary SSH surface still starts in HOME
   without the helper. `keymap.md` owns the token contract.
 - When another client leads at a different terminal size, local cursor and screen-text reads can
   disagree with the application's layout; automation relying on those reads, the chat transport

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -107,6 +107,12 @@ paths:
   launchers still work. If `referencesSessionScopedContext` finds any session/workspace/selection token
   in `{...}` or `$...` form, no-op with notice; empty `{AGT_SESSION_PWD}` can turn `rm -rf .../*` into a
   root glob. Commands using only `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE` may run sessionless.
+- `{AGT_SESSION_HOST}`/`$AGT_SESSION_HOST` is the SSH destination of a `zmx attach` session, empty
+  otherwise; an `ssh` typed into a local session leaves it empty while `AGT_SESSION_PWD` still follows
+  that shell's cwd reports. `AGT_SESSION_PWD` stays the pane's reported path, remote or not; the
+  command's execution directory comes separately from `Session.localWorkingDirectory`, which returns
+  that path for a local session and, for a remote one, only when it exists here as a directory, else
+  HOME. Scratch, overlay default, quick terminal and a later split seed through the same helper.
 - `{AGT_PANE}`/`$AGT_PANE` is `left`, `right`, or `scratch`, derived from the firing surface for keybinds
   and `splitFocused` for palette runs. The scratch and both overlay kinds are the sessionless surfaces with
   a pane, resolved together in `sessionlessPane`; the quick terminal is nobody's pane and takes the plain

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -109,10 +109,12 @@ paths:
   root glob. Commands using only `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE` may run sessionless.
 - `{AGT_SESSION_HOST}`/`$AGT_SESSION_HOST` is the SSH destination of a `zmx attach` session, empty
   otherwise; an `ssh` typed into a local session leaves it empty while `AGT_SESSION_PWD` still follows
-  that shell's cwd reports. `AGT_SESSION_PWD` stays the pane's reported path, remote or not; the
+  any cwd reports that shell emits. `AGT_SESSION_PWD` stays the pane's reported path, remote or not; the
   command's execution directory comes separately from `Session.localWorkingDirectory`, which returns
   that path for a local session and, for a remote one, only when it exists here as a directory, else
-  HOME. Scratch, overlay default, quick terminal and a later split seed through the same helper.
+  HOME. Scratch, overlay default, quick terminal, a local split (the first on an unsplit remote session
+  or one after the attach-time split closes), Duplicate Session and a new session under the
+  current-directory setting seed through the same helper.
 - `{AGT_PANE}`/`$AGT_PANE` is `left`, `right`, or `scratch`, derived from the firing surface for keybinds
   and `splitFocused` for palette runs. The scratch and both overlay kinds are the sessionless surfaces with
   a pane, resolved together in `sessionlessPane`; the quick terminal is nobody's pane and takes the plain

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -129,8 +129,8 @@ final class AppActions {
     /// isn't wired. Read as the `addSession` argument, so it captures the cwd BEFORE the new session exists.
     func resolvedNewSessionCwd() -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return settingsModel?.settings.resolveNewSessionCwd(
-            currentSessionCwd: store?.activeSession?.focusedCwd, home: home) ?? home
+        let current = store?.activeSession.map { $0.localWorkingDirectory(reported: $0.focusedCwd, homeDirectory: home) }
+        return settingsModel?.settings.resolveNewSessionCwd(currentSessionCwd: current, home: home) ?? home
     }
 
     func openDirectory() {

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -224,9 +224,7 @@ final class CustomCommandRunner {
         // promoted survivor sits in the `surface` slot with both nil/false, so `.left`.
         let onSplit = session.splitFocused && session.splitSurface != nil
         let selectionSurface = (onSplit ? session.splitSurface : session.surface) as? GhosttySurfaceView
-        let context = self.context(for: session, in: store, selectionSurface: selectionSurface,
-                                   pane: onSplit ? .right : .left)
-        spawn(command, context: context)
+        spawn(command, for: session, in: store, selectionSurface: selectionSurface, pane: onSplit ? .right : .left)
     }
 
     /// Run a command fired by KEYBIND: context from the surface that had focus at key-down, so a chord from a
@@ -240,8 +238,7 @@ final class CustomCommandRunner {
         // the pane is the surface's identity, not the focus flag, so a chord reports the pane it was typed in
         // even before the flag catches up.
         let pane: CommandContext.Pane = (session.splitSurface as? GhosttySurfaceView) === focusedSurface ? .right : .left
-        let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: pane)
-        spawn(command, context: context)
+        spawn(command, for: session, in: store, selectionSurface: focusedSurface, pane: pane)
     }
 
     /// The open store holding `session` itself. Matched by object identity rather than through
@@ -262,8 +259,7 @@ final class CustomCommandRunner {
             guard let store = library.store(for: windowID) else { continue }
             for session in store.workspaces.flatMap(\.sessions) {
                 guard let pane = sessionlessPane(of: focusedSurface, in: session) else { continue }
-                let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: pane)
-                spawn(command, context: context)
+                spawn(command, for: session, in: store, selectionSurface: focusedSurface, pane: pane)
                 return
             }
         }
@@ -307,12 +303,21 @@ final class CustomCommandRunner {
             logger.notice("custom command \"\(command.name, privacy: .public)\" references session context but no session is active; ignored")
             return
         }
-        spawn(command, context: sessionlessContext())
+        spawn(command, context: sessionlessContext(), cwd: nil)
     }
 
-    /// Resolve every `{AGT_X}` token for the given session: ids + cwd from the model, names from the owning
-    /// workspace/window, the selection from `selectionSurface`, the fired-from pane from the caller
-    /// (`left`|`right`|`scratch`), the socket from the control server.
+    /// Spawn for a session pane: the context carries the pane's reported cwd raw, while the process starts
+    /// where `Session.localWorkingDirectory` says, which differs on a remote session whose path is not here.
+    private func spawn(_ command: CustomCommand, for session: Session, in store: AppStore,
+                       selectionSurface: GhosttySurfaceView?, pane: CommandContext.Pane) {
+        let context = self.context(for: session, in: store, selectionSurface: selectionSurface, pane: pane)
+        let cwd = session.localWorkingDirectory(reported: context.sessionPWD, homeDirectory: NSHomeDirectory())
+        spawn(command, context: context, cwd: cwd)
+    }
+
+    /// Resolve every `{AGT_X}` token for the given session: ids + cwd + remote host from the model, names
+    /// from the owning workspace/window, the selection from `selectionSurface`, the fired-from pane from the
+    /// caller (`left`|`right`|`scratch`), the socket from the control server.
     private func context(for session: Session, in store: AppStore, selectionSurface: GhosttySurfaceView?,
                          pane: CommandContext.Pane) -> CommandContext {
         let workspace = store.workspace(forSession: session.id)
@@ -322,6 +327,7 @@ final class CustomCommandRunner {
             sessionID: session.id.uuidString,
             sessionName: session.displayName,
             sessionPWD: session.cwd(for: pane),
+            sessionHost: TerminalText.sanitized(session.remoteHost ?? ""),
             workspaceID: workspace?.id.uuidString ?? "",
             workspaceName: workspace?.name ?? "",
             windowID: windowID?.uuidString ?? "",
@@ -342,10 +348,10 @@ final class CustomCommandRunner {
     }
 
     /// Spawn the expanded command as a detached `/bin/sh -c`, exporting `$AGT_*` over the app environment and
-    /// running in the session's cwd. `PATH` is widened first (`CommandPath`): the app's own is launchd's, and
-    /// `sh -c` runs no profile, so a bare `agtermctl` would exit 127. A spawn error or non-zero exit posts a
-    /// failure banner; no output capture, no success banner.
-    private func spawn(_ command: CustomCommand, context: CommandContext) {
+    /// running in `cwd` (nil for a sessionless launch, which inherits the app's). `PATH` is widened first
+    /// (`CommandPath`): the app's own is launchd's, and `sh -c` runs no profile, so a bare `agtermctl` would
+    /// exit 127. A spawn error or non-zero exit posts a failure banner; no output capture, no success banner.
+    private func spawn(_ command: CustomCommand, context: CommandContext, cwd: String?) {
         let line = context.expand(command.command)
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
@@ -359,8 +365,8 @@ final class CustomCommandRunner {
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
-        if !context.sessionPWD.isEmpty {
-            process.currentDirectoryURL = URL(fileURLWithPath: context.sessionPWD, isDirectory: true)
+        if let cwd, !cwd.isEmpty {
+            process.currentDirectoryURL = URL(fileURLWithPath: cwd, isDirectory: true)
         }
         let name = command.name
         process.terminationHandler = { proc in

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -16,7 +16,7 @@ private let logger = Logger(subsystem: "com.umputun.agterm", category: "GhosttyS
 final class GhosttySurfaceView: NSView, PaneRoleMutableSurface {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
 
-    private let workingDirectory: String
+    let workingDirectory: String
 
     /// The command run as the surface's process instead of the login shell, nil for the login shell; read in
     /// `createSurface`. The overlay uses it to run one program (e.g. a TUI) whose exit closes the overlay.

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -513,7 +513,9 @@ struct agtermApp: App {
     static func makeSplitSurface(for session: Session, store: AppStore, env: [String: String],
                                  services: SurfaceServices) -> GhosttySurfaceView {
         // cwd is the persisted `initialSplitCwd` (a restored split keeps its own directory), else the session's
-        // effectiveCwd. Font size matches the primary; env inherits the parent's window/workspace/session ids.
+        // effectiveCwd, both through `Session.localWorkingDirectory`: the directory is the LOCAL launch's,
+        // whether that is a shell or the attach-time ssh client. Font size matches the primary; env inherits
+        // the parent's window/workspace/session ids.
         // Creation, capture and override precedence matches the primary.
         let ghostty = GhosttyApp.shared
         let zmx = ZmxLaunch.wrapsLocally(mode: ghostty.launchRestoreMode, session: session)

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -522,7 +522,9 @@ struct agtermApp: App {
         let disposition = ZmxLaunch.disposition(requested: ghostty.requestedRestoreMode,
                                                 active: ghostty.launchRestoreMode, configuration: zmx)
         if disposition.backedByZmx { services.zmxForegroundResolver?.noteLifecycleChange() }
-        let view = GhosttySurfaceView(workingDirectory: session.initialSplitCwd ?? session.effectiveCwd,
+        let cwd = session.localWorkingDirectory(reported: session.initialSplitCwd ?? session.effectiveCwd,
+                                                homeDirectory: NSHomeDirectory())
+        let view = GhosttySurfaceView(workingDirectory: cwd,
                                       fontSize: session.fontSize.map(Float.init),
                                       env: Self.surfaceEnv(disposition: disposition, fallback: env),
                                       backedByZmx: disposition.backedByZmx)
@@ -573,8 +575,8 @@ struct agtermApp: App {
     /// and captures no exit status, since it is a message the app painted rather than a program the caller
     /// ran. Its body file is the helper's only input, deleted with the surface like the exit-code file.
     @MainActor
-    private static func makeOverlaySurface(for session: Session, store: AppStore, pane: OverlayPane?,
-                                           env: [String: String]) -> GhosttySurfaceView {
+    static func makeOverlaySurface(for session: Session, store: AppStore, pane: OverlayPane?,
+                                   env: [String: String]) -> GhosttySurfaceView {
         let sessionID = session.id
         let spec = Self.overlaySpec(for: session, pane: pane)
         // the session-wide slot's occupant decides passivity; the body file is what that occupant needs
@@ -585,7 +587,10 @@ struct agtermApp: App {
         overlayEnv[OverlayCapture.cmdEnvKey] = spec.command
         overlayEnv[OverlayCapture.codeEnvKey] = codeFile
         if let hudFile { overlayEnv[HudLayout.fileEnvKey] = hudFile }
-        let view = GhosttySurfaceView(workingDirectory: spec.cwd ?? session.effectiveCwd,
+        // an explicit `--cwd` is the caller's local choice; only the inherited default follows the remote rule.
+        let cwd = spec.cwd ?? session.localWorkingDirectory(reported: session.effectiveCwd,
+                                                             homeDirectory: NSHomeDirectory())
+        let view = GhosttySurfaceView(workingDirectory: cwd,
                                       fontSize: session.fontSize.map(Float.init), command: overlayExitWrapper,
                                       waitAfterCommand: spec.wait, autoFocus: !isHud, env: overlayEnv)
         view.overlayCodeFile = codeFile
@@ -651,13 +656,14 @@ struct agtermApp: App {
     /// RUN-ONCE. `autoFocus` grabs first responder on show (winning the SwiftUI/AppKit responder race); the
     /// shell's `exit` runs `closeScratch`, hiding + tearing down so the next show is fresh.
     @MainActor
-    private static func makeScratchSurface(for session: Session, store: AppStore, env: [String: String],
-                                           suppressAutoFocus: Bool, actions: AppActions) -> GhosttySurfaceView {
+    static func makeScratchSurface(for session: Session, store: AppStore, env: [String: String],
+                                   suppressAutoFocus: Bool, actions: AppActions) -> GhosttySurfaceView {
         // re-shows are focused via the `scratchActive` onChange (which also defers to those covers).
         // scratchCommand is run-once: read it for this spawn, then clear so a post-exit respawn is a shell.
         let command = session.scratchCommand
         session.scratchCommand = nil
-        let view = GhosttySurfaceView(workingDirectory: session.effectiveCwd,
+        let cwd = session.localWorkingDirectory(reported: session.effectiveCwd, homeDirectory: NSHomeDirectory())
+        let view = GhosttySurfaceView(workingDirectory: cwd,
                                       fontSize: session.fontSize.map(Float.init),
                                       command: command,
                                       autoFocus: !suppressAutoFocus, env: env)
@@ -713,16 +719,21 @@ struct agtermApp: App {
                                          programVersion: Self.terminalProgramVersion)
     }
 
+    /// The quick terminal's start directory: the active session's, through the remote rule, else HOME.
+    @MainActor
+    static func quickTerminalCwd(library: WindowLibrary?) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        guard let session = library?.activeStore?.activeSession else { return home }
+        return session.localWorkingDirectory(reported: session.effectiveCwd, homeDirectory: home)
+    }
+
     /// Bind the app's one quick terminal to the library. Every provider resolves through `activeStore` at
     /// call time rather than capturing a window, the panel outliving any particular one; `canShow` is what
     /// keeps it from being summoned into an app with no window left to return to.
     @MainActor
     func wireQuickTerminal(library: WindowLibrary) {
         let controller = QuickTerminalController.shared
-        controller.cwdProvider = { [weak library] in
-            library?.activeStore?.activeSession?.effectiveCwd
-                ?? FileManager.default.homeDirectoryForCurrentUser.path
-        }
+        controller.cwdProvider = { [weak library] in Self.quickTerminalCwd(library: library) }
         controller.envProvider = { [self] in quickTerminalEnv() }
         // typing counts as activity, so an idle auto-follow fire can't reshuffle the active window's
         // selection behind the panel while the user types (mirrors the overlay/scratch).

--- a/agtermCore/Sources/agtermCore/AppStore+Duplicate.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Duplicate.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension AppStore {
     /// Duplicates a session: a fresh shell in the SAME workspace, inserted directly after the source, rooted
-    /// at its focused-pane cwd (`focusedCwd` — the directory the sidebar row shows and "Reveal in Finder"
-    /// opens, so the duplicate lands where the row says it will).
+    /// at its focused-pane cwd (`focusedCwd`, the directory the sidebar row shows) passed through
+    /// `localWorkingDirectory`, since the duplicate is a local shell even when the source is a remote pane.
     ///
     /// ONLY the directory carries over: auto basename (no inherited `customName`), no split, scratch, status,
     /// flag or `initialCommand` — `New Session` seeded with the source's cwd, not a clone of its state.
@@ -11,6 +11,8 @@ extension AppStore {
     @discardableResult
     public func duplicateSession(_ id: UUID) -> Session? {
         guard let session = session(withID: id), let location = sessionLocation(ofSession: id) else { return nil }
-        return addSession(toWorkspace: location.workspace, cwd: session.focusedCwd, at: location.index + 1)
+        let cwd = session.localWorkingDirectory(reported: session.focusedCwd,
+                                                homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path)
+        return addSession(toWorkspace: location.workspace, cwd: cwd, at: location.index + 1)
     }
 }

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -37,6 +37,9 @@ public struct CommandContext: Equatable, Sendable {
     public var sessionID: String
     public var sessionName: String
     public var sessionPWD: String
+    /// The SSH destination a `zmx attach` session came from, empty for a local session. Marks only
+    /// agterm's own remote attachment: an `ssh` typed into a local session leaves it empty.
+    public var sessionHost: String
     public var workspaceID: String
     public var workspaceName: String
     public var windowID: String
@@ -53,11 +56,13 @@ public struct CommandContext: Equatable, Sendable {
     public var socket: String
 
     public init(sessionID: String = "", sessionName: String = "", sessionPWD: String = "",
-                workspaceID: String = "", workspaceName: String = "", windowID: String = "",
-                windowName: String = "", pane: Pane = .left, selection: String = "", socket: String = "") {
+                sessionHost: String = "", workspaceID: String = "", workspaceName: String = "",
+                windowID: String = "", windowName: String = "", pane: Pane = .left, selection: String = "",
+                socket: String = "") {
         self.sessionID = sessionID
         self.sessionName = sessionName
         self.sessionPWD = sessionPWD
+        self.sessionHost = sessionHost
         self.workspaceID = workspaceID
         self.workspaceName = workspaceName
         self.windowID = windowID
@@ -74,6 +79,7 @@ public struct CommandContext: Equatable, Sendable {
         [("AGT_SESSION_ID", sessionID),
          ("AGT_SESSION_NAME", sessionName),
          ("AGT_SESSION_PWD", sessionPWD),
+         ("AGT_SESSION_HOST", sessionHost),
          ("AGT_WORKSPACE_ID", workspaceID),
          ("AGT_WORKSPACE_NAME", workspaceName),
          ("AGT_WINDOW_ID", windowID),

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -550,6 +550,16 @@ public final class Session: Identifiable {
         }
     }
 
+    /// Where a LOCAL process for this session starts, given the pane path it would inherit: that path on a
+    /// local session; on a remote one, only when it exists here as a directory, else `homeDirectory`. The
+    /// reported path itself stays what `cwd(for:)` and `AGT_SESSION_PWD` carry.
+    public func localWorkingDirectory(reported path: String, homeDirectory: String) -> String {
+        guard remoteHost != nil else { return path }
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue ? path : homeDirectory
+    }
+
     /// The focused pane's surface: the split (right) while it has focus and exists, else the primary. With the
     /// split hidden the detail pane maximizes this one and focus helpers target it, so typing always reaches
     /// the visible pane.

--- a/agtermCore/Tests/agtermCoreTests/AppStoreDuplicateTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreDuplicateTests.swift
@@ -37,6 +37,26 @@ struct AppStoreDuplicateTests {
         #expect(dupe.initialCwd == "/split-pane")
     }
 
+    @Test func duplicateOfARemoteSessionIsALocalShellUnderTheLocalDirectoryRule() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-duplicate-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let source = try #require(store.addSession(toWorkspace: ws.id, cwd: home, remoteHost: "user@box"))
+
+        source.currentCwd = root.appendingPathComponent("only-on-the-remote").path
+        let fallback = try #require(store.duplicateSession(source.id))
+        #expect(fallback.initialCwd == home)
+        #expect(fallback.remoteHost == nil)
+
+        source.currentCwd = root.path
+        let twin = try #require(store.duplicateSession(source.id))
+        #expect(twin.initialCwd == root.path)
+    }
+
     @Test func duplicateSessionTracksLiveCwd() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
@@ -5,8 +5,21 @@ import Testing
 struct CustomCommandTests {
     private func sampleContext() -> CommandContext {
         CommandContext(sessionID: "sess-1", sessionName: "shell", sessionPWD: "/tmp/work",
-                       workspaceID: "ws-1", workspaceName: "main", windowID: "win-1",
-                       windowName: "work", pane: .right, selection: "hello", socket: "/tmp/agt.sock")
+                       sessionHost: "user@box", workspaceID: "ws-1", workspaceName: "main",
+                       windowID: "win-1", windowName: "work", pane: .right, selection: "hello",
+                       socket: "/tmp/agt.sock")
+    }
+
+    @Test func sessionHostFollowsThePwdTokenAndDefaultsEmpty() {
+        let ctx = sampleContext()
+        #expect(ctx.expand("ssh {AGT_SESSION_HOST}") == "ssh user@box")
+        #expect(ctx.environment()["AGT_SESSION_HOST"] == "user@box")
+        #expect(CommandContext().expand("[{AGT_SESSION_HOST}]") == "[]")
+        #expect(CommandContext().environment()["AGT_SESSION_HOST"] == "")
+        let names = CommandContext.tokenNames
+        let pwd = names.firstIndex(of: "AGT_SESSION_PWD")
+        #expect(pwd.map { names[$0 + 1] } == "AGT_SESSION_HOST")
+        #expect(CommandContext.referencesSessionScopedContext(#"ssh "$AGT_SESSION_HOST" uptime"#))
     }
 
     @Test func expandSubstitutesKnownTokens() {
@@ -54,6 +67,7 @@ struct CustomCommandTests {
         #expect(env["AGT_SESSION_ID"] == "sess-1")
         #expect(env["AGT_SESSION_NAME"] == "shell")
         #expect(env["AGT_SESSION_PWD"] == "/tmp/work")
+        #expect(env["AGT_SESSION_HOST"] == "user@box")
         #expect(env["AGT_WORKSPACE_ID"] == "ws-1")
         #expect(env["AGT_WORKSPACE_NAME"] == "main")
         #expect(env["AGT_WINDOW_ID"] == "win-1")
@@ -61,7 +75,7 @@ struct CustomCommandTests {
         #expect(env["AGT_PANE"] == "right")
         #expect(env["AGT_SELECTION"] == "hello")
         #expect(env["AGT_SOCKET"] == "/tmp/agt.sock")
-        #expect(env.count == 10)
+        #expect(env.count == 11)
     }
 
     @Test func paneDefaultsToLeft() {
@@ -98,7 +112,7 @@ struct CustomCommandTests {
             #expect(!ctx.expand("{\(key)}").contains("{"))
         }
         let expected: Set<String> = ["AGT_SESSION_ID", "AGT_SESSION_NAME", "AGT_SESSION_PWD",
-                                     "AGT_WORKSPACE_ID", "AGT_WORKSPACE_NAME", "AGT_WINDOW_ID",
+                                     "AGT_SESSION_HOST", "AGT_WORKSPACE_ID", "AGT_WORKSPACE_NAME", "AGT_WINDOW_ID",
                                      "AGT_WINDOW_NAME", "AGT_PANE", "AGT_SELECTION", "AGT_SOCKET"]
         #expect(envKeys == expected)
     }

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -354,6 +354,28 @@ struct SessionTests {
         #expect(session.cwd(for: .right) == "/repo/primary")
     }
 
+    @Test func localWorkingDirectoryKeepsAnyPathForALocalSession() {
+        let session = Session(initialCwd: "/repo")
+        #expect(session.localWorkingDirectory(reported: "/nowhere/primary", homeDirectory: "/home") == "/nowhere/primary")
+        #expect(session.localWorkingDirectory(reported: "/nowhere/split", homeDirectory: "/home") == "/nowhere/split")
+    }
+
+    @Test func localWorkingDirectoryOnARemoteSessionFallsBackToHomeUnlessThePathIsALocalDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-session-tests-\(UUID().uuidString)", isDirectory: true)
+        let directory = root.appendingPathComponent("twin", isDirectory: true)
+        let file = root.appendingPathComponent("plain.txt")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data().write(to: file)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = Session(initialCwd: "/home", remoteHost: "user@box")
+        #expect(session.localWorkingDirectory(reported: directory.path, homeDirectory: "/home") == directory.path)
+        let missing = root.appendingPathComponent("missing").path
+        #expect(session.localWorkingDirectory(reported: missing, homeDirectory: "/home") == "/home")
+        #expect(session.localWorkingDirectory(reported: file.path, homeDirectory: "/home") == "/home")
+    }
+
     @Test func agentIndicatorDefaultsToIdle() {
         let session = Session(initialCwd: "/repo")
         #expect(session.agentIndicator == AgentIndicator())

--- a/agtermTests/AppActionsTests.swift
+++ b/agtermTests/AppActionsTests.swift
@@ -1,0 +1,82 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+@MainActor
+final class AppActionsTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var settings: SettingsModel!
+    private var actions: AppActions!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-actions-tests-\(UUID().uuidString)", isDirectory: true)
+            try? FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+            library = WindowLibrary(directory: stateDir)
+            settings = SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir))
+            actions = AppActions(library: library)
+            actions.settingsModel = settings
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            actions = nil
+            settings = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    private var home: String { FileManager.default.homeDirectoryForCurrentUser.path }
+
+    private func remoteActiveSession(reportedCwd: String) throws -> Session {
+        let store = try XCTUnwrap(library.activeStore)
+        let workspace = try XCTUnwrap(store.currentWorkspaceID)
+        let session = try XCTUnwrap(store.addSession(toWorkspace: workspace, cwd: home, remoteHost: "user@box"))
+        session.currentCwd = reportedCwd
+        return session
+    }
+
+    func testNewSessionCwdFollowsTheCurrentSessionThroughTheLocalRule() throws {
+        settings.setNewSessionDirectory(AppSettings.NewSessionDirectory.currentSession.rawValue)
+        let local = try XCTUnwrap(library.activeStore?.activeSession)
+        local.currentCwd = "/nowhere/local"
+        XCTAssertEqual(actions.resolvedNewSessionCwd(), "/nowhere/local")
+
+        let remote = try remoteActiveSession(reportedCwd: stateDir.appendingPathComponent("only-on-the-remote").path)
+        XCTAssertEqual(actions.resolvedNewSessionCwd(), home)
+        remote.currentCwd = stateDir.path
+        XCTAssertEqual(actions.resolvedNewSessionCwd(), stateDir.path)
+    }
+
+    func testNewSessionCwdKeepsTheFocusedSplitPaneAndTheEmptyCwdFallback() throws {
+        settings.setNewSessionDirectory(AppSettings.NewSessionDirectory.currentSession.rawValue)
+        let local = try XCTUnwrap(library.activeStore?.activeSession)
+        local.currentCwd = "/nowhere/primary"
+        let split = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        local.splitSurface = split
+        local.splitCwd = "/nowhere/split"
+        local.hasSplit = true
+        local.isSplit = true
+        local.splitFocused = true
+        XCTAssertEqual(actions.resolvedNewSessionCwd(), "/nowhere/split")
+
+        local.splitFocused = false
+        local.currentCwd = ""
+        XCTAssertEqual(actions.resolvedNewSessionCwd(), home)
+    }
+
+    func testNewSessionCwdCustomModeIgnoresTheActiveSessionsRemoteness() throws {
+        settings.setNewSessionDirectory(AppSettings.NewSessionDirectory.custom.rawValue)
+        settings.setNewSessionCustomDirectory("/nowhere/custom")
+        _ = try remoteActiveSession(reportedCwd: stateDir.appendingPathComponent("only-on-the-remote").path)
+        XCTAssertEqual(actions.resolvedNewSessionCwd(), "/nowhere/custom")
+    }
+}

--- a/agtermTests/CustomCommandRunnerTests.swift
+++ b/agtermTests/CustomCommandRunnerTests.swift
@@ -533,7 +533,48 @@ final class CustomCommandRunnerTests: XCTestCase {
         session.isSplit = true
         session.splitFocused = true
 
-        let written = try fired(fix.runner, from: split, writing: "\"$AGT_SESSION_PWD\"")
-        XCTAssertEqual(written, rightDir.path)
+        let written = try fired(fix.runner, from: split, writing: "\"$AGT_SESSION_PWD|$AGT_SESSION_HOST|$PWD\"")
+        let fields = try XCTUnwrap(written).components(separatedBy: "|")
+        XCTAssertEqual(Array(fields.prefix(2)), [rightDir.path, ""])
+        XCTAssertEqual(URL(fileURLWithPath: fields[2]).resolvingSymlinksInPath().path,
+                       rightDir.resolvingSymlinksInPath().path)
+    }
+
+    private func firedFromRemoteSession(reportedCwd: String) throws -> [String] {
+        let fix = try fixture()
+        let owner = try XCTUnwrap(fix.store.currentWorkspaceID)
+        let session = try XCTUnwrap(fix.store.addSession(toWorkspace: owner, cwd: NSHomeDirectory(),
+                                                         remoteHost: "user@box"))
+        session.currentCwd = reportedCwd
+        let surface = GhosttySurfaceView(workingDirectory: NSHomeDirectory())
+        surface.session = session
+        session.surface = surface
+        let written = try fired(fix.runner, from: surface, writing: "\"$AGT_SESSION_PWD|$AGT_SESSION_HOST|$PWD\"")
+        var fields = try XCTUnwrap(written).components(separatedBy: "|")
+        fields[2] = URL(fileURLWithPath: fields[2]).resolvingSymlinksInPath().path
+        return fields
+    }
+
+    func testARemoteSessionWhoseReportedPathExistsLocallyRunsTheCommandThere() throws {
+        let twin = stateDir.appendingPathComponent("twin")
+        try FileManager.default.createDirectory(at: twin, withIntermediateDirectories: true)
+        let fields = try firedFromRemoteSession(reportedCwd: twin.path)
+        XCTAssertEqual(fields, [twin.path, "user@box", twin.resolvingSymlinksInPath().path])
+    }
+
+    func testARemoteSessionWhoseReportedPathIsMissingLocallyRunsTheCommandInHome() throws {
+        let missing = stateDir.appendingPathComponent("only-on-the-remote").path
+        let fields = try firedFromRemoteSession(reportedCwd: missing)
+        let home = URL(fileURLWithPath: NSHomeDirectory()).resolvingSymlinksInPath().path
+        XCTAssertEqual(fields, [missing, "user@box", home])
+    }
+
+    func testARemoteSessionWhoseReportedPathIsALocalFileRunsTheCommandInHome() throws {
+        let file = stateDir.appendingPathComponent("plain.txt")
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        try Data().write(to: file)
+        let fields = try firedFromRemoteSession(reportedCwd: file.path)
+        let home = URL(fileURLWithPath: NSHomeDirectory()).resolvingSymlinksInPath().path
+        XCTAssertEqual(fields, [file.path, "user@box", home])
     }
 }

--- a/agtermTests/SurfaceFactorySeedTests.swift
+++ b/agtermTests/SurfaceFactorySeedTests.swift
@@ -260,6 +260,97 @@ final class SurfaceFactorySeedTests: XCTestCase {
         XCTAssertFalse(registry.pacer.isPassthrough, "the armed primary still waits its turn")
     }
 
+    private func scratchSurface(for session: Session) -> GhosttySurfaceView {
+        agtermApp.makeScratchSurface(for: session, store: store, env: [:], suppressAutoFocus: true,
+                                     actions: AppActions(library: library))
+    }
+
+    private func overlaySurface(for session: Session) -> GhosttySurfaceView {
+        agtermApp.makeOverlaySurface(for: session, store: store, pane: nil, env: [:])
+    }
+
+    private func remoteSession(reportedCwd: String) -> Session {
+        let session = Session(initialCwd: NSHomeDirectory(), remoteHost: "user@box")
+        session.currentCwd = reportedCwd
+        return session
+    }
+
+    func testLocalShellFactoriesOnARemoteSessionSeedHomeWhenTheReportedPathIsMissing() {
+        let session = remoteSession(reportedCwd: stateDir.appendingPathComponent("only-on-the-remote").path)
+        XCTAssertEqual(scratchSurface(for: session).workingDirectory, NSHomeDirectory())
+        XCTAssertEqual(overlaySurface(for: session).workingDirectory, NSHomeDirectory())
+        XCTAssertEqual(splitSurface(for: session).workingDirectory, NSHomeDirectory())
+    }
+
+    func testLocalShellFactoriesOnARemoteSessionSeedTheReportedPathWhenItExistsLocally() throws {
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        let session = remoteSession(reportedCwd: stateDir.path)
+        XCTAssertEqual(scratchSurface(for: session).workingDirectory, stateDir.path)
+        XCTAssertEqual(overlaySurface(for: session).workingDirectory, stateDir.path)
+        XCTAssertEqual(splitSurface(for: session).workingDirectory, stateDir.path)
+    }
+
+    func testARestoredSplitPathOnARemoteSessionStillFollowsTheLocalRule() {
+        let session = remoteSession(reportedCwd: NSHomeDirectory())
+        session.initialSplitCwd = stateDir.appendingPathComponent("split-only-on-the-remote").path
+        XCTAssertEqual(splitSurface(for: session).workingDirectory, NSHomeDirectory())
+    }
+
+    func testAnExplicitOverlayCwdIsKeptOnARemoteSession() {
+        let session = remoteSession(reportedCwd: stateDir.appendingPathComponent("only-on-the-remote").path)
+        session.overlayCwd = "/nowhere/explicit"
+        XCTAssertEqual(overlaySurface(for: session).workingDirectory, "/nowhere/explicit")
+    }
+
+    func testLocalSessionFactoriesKeepTheirInheritedPaths() {
+        let session = Session(initialCwd: "/nowhere")
+        session.currentCwd = "/nowhere/primary"
+        session.initialSplitCwd = "/nowhere/restored-split"
+        XCTAssertEqual(scratchSurface(for: session).workingDirectory, "/nowhere/primary")
+        XCTAssertEqual(overlaySurface(for: session).workingDirectory, "/nowhere/primary")
+        XCTAssertEqual(splitSurface(for: session).workingDirectory, "/nowhere/restored-split")
+    }
+
+    func testASplitCreatedAfterClosingTheAttachTimeSplitIsALocalLoginShell() throws {
+        let workspace = store.addWorkspace(name: "remote")
+        let session = try XCTUnwrap(store.addSession(toWorkspace: workspace.id, cwd: NSHomeDirectory(),
+                                                     command: "ssh -tt box zmx attach primary",
+                                                     remoteHost: "box"))
+        session.splitInitialCommand = "ssh -tt box zmx attach split"
+        session.currentCwd = stateDir.appendingPathComponent("only-on-the-remote").path
+        session.hasSplit = true
+        session.isSplit = true
+
+        XCTAssertEqual(splitSurface(for: session).resolveLaunchSeed().command, "ssh -tt box zmx attach split")
+        XCTAssertEqual(splitSurface(for: session).resolveLaunchSeed().command, "ssh -tt box zmx attach split",
+                       "the attach seed is durable across a re-created split surface")
+
+        store.closeSplit(session.id)
+
+        let fresh = splitSurface(for: session)
+        XCTAssertNil(fresh.resolveLaunchSeed().command)
+        XCTAssertEqual(fresh.workingDirectory, NSHomeDirectory())
+    }
+
+    func testTheQuickTerminalStartsWhereTheActiveSessionsLocalRuleSays() throws {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let activeStore = try XCTUnwrap(library.activeStore)
+        let local = try XCTUnwrap(activeStore.activeSession)
+        local.currentCwd = "/nowhere/primary"
+        XCTAssertEqual(agtermApp.quickTerminalCwd(library: library), "/nowhere/primary")
+
+        let workspace = try XCTUnwrap(activeStore.currentWorkspaceID)
+        let remote = try XCTUnwrap(activeStore.addSession(toWorkspace: workspace, cwd: home, remoteHost: "box"))
+        activeStore.selectSession(remote.id)
+        remote.currentCwd = stateDir.appendingPathComponent("only-on-the-remote").path
+        XCTAssertEqual(agtermApp.quickTerminalCwd(library: library), home)
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        remote.currentCwd = stateDir.path
+        XCTAssertEqual(agtermApp.quickTerminalCwd(library: library), stateDir.path)
+
+        XCTAssertEqual(agtermApp.quickTerminalCwd(library: nil), home)
+    }
+
     func testThePolicyCarriesTheReapsRunningNames() {
         let context = agtermApp.LaunchSpawnContext()
         context.runningNames = ["agterm-alive"]

--- a/docs/backlog/attached-pane-content-is-laid-out-for-the-leaders-grid.md
+++ b/docs/backlog/attached-pane-content-is-laid-out-for-the-leaders-grid.md
@@ -1,0 +1,32 @@
+---
+worth: maybe
+added: 2026-09-10
+---
+# attached pane content is laid out for the leader's grid
+
+Pinned zmx (`fb1b6b6`) keeps one leader per pane and sizes the daemon pty to the leader alone. Once
+another Mac attaches and types, its client leads: the daemon resizes to that grid and broadcasts the
+program's redraw unchanged to every client, so this Mac's libghostty core, still at its own grid, holds
+rows laid out for the other one. Followers get no size or role message (`src/loop.zig:806-812` sends
+the empty Resize only to the new leader, `:150-153` appends Output raw, `:981-986` ignores a follower's
+own resize), `Info` and `History` carry no geometry or leader field (`src/ipc.zig:74-87`,
+`src/loop.zig:1039-1108`), and while another leader exists only classified Input takes the lead
+(`src/util.zig:688-728`), forwarded before the resize round trip completes; a vacant slot is claimed by
+Init or Resize without input. `zmx send` bypasses leadership.
+
+Consequence: when another client leads at a different terminal size, local cursor and screen-text
+reads can disagree with the application's layout. The chat transport's two gates (`surface cursor` at
+column 2 before typing, the composer's first row before the submit key) are such reads, and the pane
+itself renders oddly. A matching-size follower was not shown broken. Documented as unsupported in the
+remote-attach docs; deferred on 2026-09-10.
+
+Candidate mechanisms, none verified or started:
+
+- zmx size policy: size the pty to the smallest attached client (tmux `window-size smallest`) or
+  broadcast the leader's grid to followers, with agterm rendering the pane to that grid. Intended to
+  make local reads match the layout; the smallest-size variant alone does not establish that a larger
+  local core uses that grid. Needs a zmx change first (upstream option or a vendored patch against the
+  plain pin).
+- transport-only: the say script takes the lead with an empty bracketed paste, waits for the reflow,
+  then runs its guards. zmx forwards the paste bytes before the resize completes, so the wait is a
+  guess; nothing else improves and the other Mac's view reflows on every send.

--- a/docs/plans/completed/20260910-remote-cwd.md
+++ b/docs/plans/completed/20260910-remote-cwd.md
@@ -1,0 +1,246 @@
+# Remote panes: host token and local cwd for local shells
+
+## Overview
+
+A session opened with `agtermctl zmx attach HOST SESSION` runs `ssh -tt` to a remote `zmx attach`. Its
+pane reports the REMOTE working directory through OSC 7, and every local shell or command the app
+starts for that session inherits it as if it were local: a custom keymap command, the scratch
+terminal, the overlay default, the quick terminal, and a split opened after the attach-time split is
+closed. Nothing a command can read says which machine the path belongs to.
+
+This change adds `AGT_SESSION_HOST` to the custom-command context (the SSH destination the session was
+attached from, empty for a local session) and one rule for where a local shell on a remote pane
+starts: the pane's reported path when it exists locally as a directory, else local HOME. The pwd token
+keeps the reported path in both cases, so a command can still `ssh "$AGT_SESSION_HOST"` into it.
+
+This is context, not a safety gate. No token is inspected to decide whether a command may run, and no
+command is refused on a remote pane.
+
+## Context (from discovery)
+
+- `Session.remoteHost` (`agtermCore/Sources/agtermCore/Session.swift:129`) is the SSH destination,
+  set only by `ControlServer+Zmx.swift:173` through `store.addSession(... remoteHost:)`, never
+  persisted. The attach seeds the session cwd with local HOME (`ControlServer+Zmx.swift:168`), and
+  only the remote shell's cwd report replaces it.
+- `Session.cwd(for:)` (`Session.swift:544`) is the pane-aware cwd: the split's live `splitCwd`, then
+  `initialSplitCwd`, then `effectiveCwd` for `.right`; `effectiveCwd` otherwise.
+- `CommandContext` (`agtermCore/Sources/agtermCore/CustomCommand.swift`) holds the `AGT_*` token table;
+  `expand`, `environment()` and `tokenNames` all derive from it, and the Settings token reference lists
+  `tokenNames`.
+- `CustomCommandRunner.context(for:in:selectionSurface:pane:)` builds the context with
+  `sessionPWD: session.cwd(for: pane)`; `spawn` chdirs to `context.sessionPWD` when non-empty
+  (`agterm/Commands/CustomCommandRunner.swift:316-364`). The sessionless context has an empty pwd and no
+  chdir.
+- Consumers seeding a local shell from the primary cwd, all in `agterm/agtermApp.swift`:
+  `makeSplitSurface` (:525, `initialSplitCwd ?? effectiveCwd`), `makeOverlaySurface` (:588,
+  `spec.cwd ?? effectiveCwd`), `makeScratchSurface` (:659, `effectiveCwd`), `wireQuickTerminal`
+  (:723, `activeSession?.effectiveCwd`).
+- The attach-time split command is durable: `LaunchSeed.durableCommand` reads
+  `splitInitialCommand` without clearing it, so hide and show keeps the ssh split. `closeSplit`
+  (`AppStore+Panes.swift:194-205`) clears it with `initialSplitCwd`, so a split created afterwards, or
+  on an unsplit remote session, is a local login shell. `swapPanes` (:125) writes the primary's
+  reported cwd into `initialSplitCwd`, so that field can hold a remote path and is not a local override.
+- `GhosttySurfaceView.workingDirectory` is `private`; factory seed tests cannot read it today.
+- `agtermCore` already queries `FileManager` directly (`OpenPathResolver.swift`,
+  `DirectoryPanelDefaults.swift`) with real temp directories in tests. `DirectoryPanelDefaults` also
+  expands tilde and normalizes through URL, which this rule does not want.
+- Doc surfaces listing the tokens: `plugins/agterm/skills/agterm/reference.md:1275-1290`,
+  `site/docs.html:1700` (token grid) and `:1556` (example), `.claude/rules/keymap.md:105-112`. Remote
+  attach behavior: `reference.md:1460-1485`, `site/docs.html:2476`, `.claude/rules/control-api.md:921`.
+- Test homes: `agtermCore/Tests/agtermCoreTests/SessionTests.swift`, `CustomCommandTests.swift`;
+  `agtermTests/CustomCommandRunnerTests.swift` (`fired(_:from:writing:)` runs a real command and reads
+  its output), `agtermTests/SurfaceFactorySeedTests.swift`.
+
+## Development Approach
+
+- Tests first: each task writes the failing test, runs it targeted, then the code.
+- One writer in `/Users/umputun/dev.umputun/agterm/.claude/worktrees/remote-cwd`; Codex reads only.
+- Run each gate once at the end (Task 8); everything before is targeted:
+  `cd agtermCore && swift test --filter <Class>` and
+  `scripts/test-app.sh -only-testing:agtermTests/<Class>/<test>`.
+- Every task ends with its tests passing before the next starts.
+- Update this plan when scope changes.
+
+## Testing Strategy
+
+- Host-free unit tests in `agtermCore` for the helper and the token.
+- Hosted tests in `agtermTests` for the runner's actual `pwd` and environment, and for every factory
+  seed, since a correct helper with a missed call site is the likely failure.
+- No XCUITest: nothing here changes chrome or protocol.
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+
+## Solution Overview
+
+- **One decision point.** `Session.localWorkingDirectory(reported:homeDirectory:)` answers "where does
+  a local process for this session start". Every consumer calls it; nobody spells the remote check inline.
+- **Raw context, separate execution cwd.** `CommandContext.sessionPWD` and `cwd(for:)` are unchanged.
+  The runner resolves the local directory while it holds the `Session` and passes it to `spawn` as its
+  own argument. Scratch and the other factories never build a `CommandContext`.
+- **Host stays out of pane environments.** Exporting it on the local ssh client does not reach the
+  remote shell, and on scratch it would name the owning attachment rather than the shell's own host.
+  Local readers already have `remoteHost` on the tree node.
+- **Explicit overlay `--cwd` stays a local override**; only the inherited default changes.
+  `initialSplitCwd` is NOT an override: the remote check runs before it is read.
+- **Existence, not identity.** The rule picks an existing local directory of the same spelling. It
+  does not verify that the directory is the same repository, and detached commands display nothing,
+  so the docs describe it as "an existing local path".
+
+## Technical Details
+
+```swift
+// Session.swift, beside cwd(for:)
+/// Where a LOCAL process for this session starts, given the pane path it would inherit: that path on a
+/// local session; on a remote one, only when it exists here as a directory, else `homeDirectory`.
+public func localWorkingDirectory(reported path: String, homeDirectory: String) -> String {
+    guard remoteHost != nil else { return path }
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+    return exists && isDirectory.boolValue ? path : homeDirectory
+}
+```
+
+The helper takes the candidate path rather than a pane so each caller keeps the precedence it has
+today: the runner passes `cwd(for: pane)` (live `splitCwd` for a right-pane chord), the split factory
+passes `initialSplitCwd ?? effectiveCwd`. A pane-keyed helper would have read `splitCwd` in the split
+factory, and that field is not reliably nil there: `applyPwd` is queued on the main queue with no
+destroyed-view guard, so a report in flight when `closeSplit` runs lands after the clear. That
+inherited callback defect is out of scope here.
+
+- `CommandContext.sessionHost: String` (default `""`), token `("AGT_SESSION_HOST", sessionHost)` placed
+  after `AGT_SESSION_PWD`. `sessionScopedTokenBases` already covers the `AGT_SESSION` prefix, so a
+  command using only the host token stays inert in an emptied window like the other session tokens.
+- Runner: `context(for:)` sets `sessionHost: TerminalText.sanitized(session.remoteHost ?? "")`, where
+  `TerminalText.sanitized` is the existing control-character strip already applied to names; attach
+  validation rejects control characters anyway, so an accepted destination such as `user@alias` is
+  preserved verbatim. `spawn(_:context:cwd:)` takes the directory explicitly; the session path passes
+  `session.localWorkingDirectory(reported: session.cwd(for: pane), homeDirectory: NSHomeDirectory())`,
+  the sessionless path passes `nil` and keeps no chdir.
+- Factories, each passing the path it inherits today: scratch and quick terminal `effectiveCwd`;
+  overlay `spec.cwd ?? localWorkingDirectory(reported: effectiveCwd, ...)`; split
+  `localWorkingDirectory(reported: initialSplitCwd ?? effectiveCwd, ...)`.
+- `GhosttySurfaceView.workingDirectory` stays an immutable `let` and becomes internal (read by
+  `SurfaceFactorySeedTests`); `makeScratchSurface` and `makeOverlaySurface` become internal like
+  `makeSplitSurface`.
+- Docs state: the host token is the SSH destination or empty; the pwd token keeps the reported path,
+  which can be remote; HOME seeds it until the first cwd report; with the scratch focused it still
+  reports the primary pane; the host token marks only sessions opened by `zmx attach`, so an `ssh`
+  typed into a local session leaves it empty while the pwd token still follows that shell's reports;
+  examples quote `"$AGT_SESSION_HOST"` and `"$AGT_SESSION_PWD"` and pass no nested-quoted `cd` to a
+  remote shell (local double quotes do not escape the inner single quotes; verified exit 2).
+
+## Implementation Steps
+
+### Task 1: `Session.localWorkingDirectory`
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/Session.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/SessionTests.swift`
+
+- [x] tests: local session returns the reported path untouched, a nonexistent one included
+- [x] tests: remote session with the reported path an existing temp directory returns that path;
+      a missing path returns `homeDirectory`; an existing regular FILE at the path returns `homeDirectory`
+- [x] implement `localWorkingDirectory(reported:homeDirectory:)` beside `cwd(for:)`
+- [x] run `swift test --filter SessionTests`
+
+### Task 2: `AGT_SESSION_HOST` token
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/CustomCommand.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift`
+
+- [x] tests: `expand("{AGT_SESSION_HOST}")` and `environment()["AGT_SESSION_HOST"]` carry the value;
+      the default context expands it empty; `tokenNames` includes it right after `AGT_SESSION_PWD`
+- [x] test: `referencesSessionScopedContext` is true for a body using only `$AGT_SESSION_HOST`
+- [x] add `sessionHost` to `CommandContext` (field, init parameter, token row)
+- [x] run `swift test --filter CustomCommandTests`
+
+### Task 3: runner wiring
+
+**Files:**
+- Modify: `agterm/Commands/CustomCommandRunner.swift`
+- Modify: `agtermTests/CustomCommandRunnerTests.swift`
+
+- [x] test: a remote-marked session (`addSession(... remoteHost: "user@alias")`) whose reported
+      `currentCwd` is an existing temp directory; the fired command writes `$PWD`, `$AGT_SESSION_PWD`
+      and `$AGT_SESSION_HOST`; expect the directory, the same raw path, `user@alias`
+- [x] test: same with a nonexistent reported path; expect `$PWD` = `NSHomeDirectory()`, the raw path,
+      the host; the command starts
+- [x] test: same with a regular file at the reported path; expect `$PWD` = HOME
+- [x] extend `testAChordFiredInSplitPaneResolvesSplitPaneWorkingDirectory` to also write `$PWD` and
+      assert both equal the right directory (local session, live `splitCwd`)
+- [x] test: local session writes an empty `$AGT_SESSION_HOST`
+- [x] `context(for:)` fills `sessionHost`; `spawn` takes `cwd: String?`; session path passes
+      `localWorkingDirectory`, sessionless path passes nil
+- [x] run `scripts/test-app.sh -only-testing:agtermTests/CustomCommandRunnerTests`
+
+### Task 4: scratch, overlay and split factories
+
+**Files:**
+- Modify: `agterm/agtermApp.swift`
+- Modify: `agterm/Ghostty/GhosttySurfaceView.swift` (`workingDirectory` internal)
+- Modify: `agtermTests/SurfaceFactorySeedTests.swift`
+
+- [x] tests: for a remote session with a missing reported cwd, scratch, overlay-without-`cwd` and split
+      factories seed HOME; with an existing temp directory they seed that path
+- [x] test: overlay with an explicit `spec.cwd` keeps it on a remote session
+- [x] test: local session factories keep `effectiveCwd`, split keeps `initialSplitCwd`
+- [x] test: split lifecycle on a remote session: the attach-time split's seed is the ssh command and
+      survives hide/show; after `closeSplit`, a new split resolves a nil durable command (login shell)
+- [x] make `workingDirectory`, `makeScratchSurface`, `makeOverlaySurface` internal; call the helper at
+      the three sites
+- [x] run `scripts/test-app.sh -only-testing:agtermTests/SurfaceFactorySeedTests`
+
+### Task 5: quick terminal cwd provider
+
+**Files:**
+- Modify: `agterm/agtermApp.swift` (`wireQuickTerminal`)
+- Modify: `agtermTests/SurfaceFactorySeedTests.swift` (the file that already tests `agtermApp`'s seeds)
+
+- [x] test: `agtermApp.quickTerminalCwd(library:)` returns HOME for a remote active session with a
+      missing cwd, the reported path when it exists locally, `effectiveCwd` for a local session, and
+      HOME with no active session
+- [x] extract the provider body into that static helper (the app struct's `init` restores state, so the
+      instance method cannot be built in a test) and call `localWorkingDirectory` there
+- [x] run the targeted test
+
+### Task 6: documentation
+
+**Files:**
+- Modify: `plugins/agterm/skills/agterm/reference.md` (token list ~1275, remote attach ~1460)
+- Modify: `site/docs.html` (token grid :1700, remote section :2476)
+- Modify: `.claude/rules/keymap.md` (token rule ~105)
+- Modify: `.claude/rules/control-api.md` (remote attach entry ~921, one sentence on local cwd)
+
+- [x] add `AGT_SESSION_HOST` to every token list with the qualifications from Technical Details
+- [x] state the local cwd rule once under remote attach and cross-reference it from the token entry
+- [x] under remote attach, add: "When another client leads at a different terminal size, local cursor
+      and screen-text reads can disagree with the application's layout; automation relying on those
+      reads, including the chat transport, is unsupported in that state." Backlog item
+      `attached-pane-content-is-laid-out-for-the-leaders-grid` carries the mechanism.
+- [x] examples quote both variables and send no nested-quoted `cd` to a remote shell
+- [x] no surface states a token count
+
+### Task 7: verify acceptance criteria
+- [x] every consumer in Context calls the helper; grep `effectiveCwd` in `agterm/` for leftovers
+- [x] `cd agtermCore && swift test`
+- [x] `make test-app`
+- [x] `make lint` with zero findings
+
+### Task 8: final docs sweep
+- [x] `ARCHITECTURE.md` mentions the local-cwd decision point if it lists `Session` cwd accessors
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification** (needs a second Mac running agterm):
+- attach a remote session whose cwd exists on both machines; fire a keymap command writing `pwd`,
+  `$AGT_SESSION_PWD` and `$AGT_SESSION_HOST` to a file; open scratch and a new split after closing the
+  attach-time split; each starts in the local twin
+- `cd` the remote pane to a path absent locally; repeat; each starts in HOME, pwd token unchanged
+
+Smells pre-check: skipped — non-Go project

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -308,10 +308,12 @@ omitted when expanded).
 - `session duplicate [--target]` — create a fresh session (a plain login shell) in the target's workspace, right
   after it, rooted at the target's focused-pane cwd; selects + focuses it and returns the new id. ONLY the
   directory carries over — no custom name, command, split, scratch, status, flag, font size, or background.
-  Equivalent to `session new --cwd <source cwd> --after <source>` in one round-trip. Read it back from
-  `tree`: the new node sits directly after its source carrying the source's focused-pane cwd (equal to the
-  source node's `tree.cwd` unless the source is a split focused off its primary pane, where `tree.cwd`
-  reports the primary).
+  Equivalent to `session new --cwd <source cwd> --after <source>` in one round-trip, except that a remote
+  source's cwd goes through the local rule first (an existing local directory is kept, anything else
+  becomes home). Read it back from `tree`: the new node sits directly after its source carrying the
+  source's focused-pane cwd (equal to the source node's `tree.cwd` unless the source is a split focused
+  off its primary pane, where `tree.cwd` reports the primary, or a remote session, where it can read as
+  home).
 - `session close [--target T ...]` — close one session, or repeat `--target` to close a batch with one
   grace-period undo.
 - `session select` · `session rename <name>` · `session reveal` (select the focused pane's cwd in Finder).

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -198,8 +198,10 @@ agtermctl session new --cwd "$HOME/project" --no-select
 `session duplicate` creates a fresh session — a plain login shell — in the SAME workspace as the target,
 directly AFTER it, rooted at the target's focused-pane cwd, then selects + focuses it and prints the new
 id. ONLY the directory carries over: no custom name, `--command`, split, scratch, status, flag, font size,
-or background. It is `session new --cwd <source cwd> --after <source>` in one atomic round-trip, and the
-control half of the sidebar row's **Duplicate Session** context-menu item.
+or background. It is `session new --cwd <source cwd> --after <source>` in one atomic round-trip, except
+that a remote source's cwd goes through the local rule first (an existing local directory is kept,
+anything else becomes home), and the control half of the sidebar row's **Duplicate Session**
+context-menu item.
 
 ```bash
 agtermctl session duplicate                                    # a second shell beside the current session, same cwd
@@ -211,7 +213,8 @@ Read it back off `tree` — there is no new tree field: the duplicate's node app
 source, carrying the source's focused-pane cwd. That equals the source node's `tree.cwd` for a non-split
 session (and a split focused on its primary pane); for a split focused off its primary the source node's
 `tree.cwd` reports the primary while the duplicate carries the focused pane's directory, so compare against
-the pane you duplicated from.
+the pane you duplicated from; for a remote source the duplicate carries that cwd after the local rule, so
+it can read as home.
 
 ## Build a small layout
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1484,9 +1484,10 @@ The pane reports the far side's working directory, and the local launches that w
 their start directory by one rule: the reported path when it exists here as a directory, else local
 HOME. Those launches are a custom command (its `$AGT_SESSION_PWD` keeps the reported path and
 `$AGT_SESSION_HOST` names the destination), the scratch terminal, an overlay opened without `--cwd`,
-the quick terminal, and a split opened after the attach-time split is closed. An explicit overlay
-`--cwd` is used as given. Quote both variables; an existing local path is not checked to be the same
-repository as the remote one.
+the quick terminal, a local split (the first one on a remote session that arrived without a split, or
+one opened after the attach-time split is closed), Duplicate Session, and New Session when it is set
+to open in the current session's directory. An explicit overlay `--cwd` is used as given. Quote both
+variables; an existing local path is not checked to be the same repository as the remote one.
 
 When another client leads at a different terminal size, local cursor and screen-text reads can disagree
 with the application's layout; automation relying on those reads, including the chat transport, is

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1279,7 +1279,14 @@ so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECT
 
 - `{AGT_SESSION_NAME}` / `$AGT_SESSION_NAME` — the session's display name (the focused pane's terminal title, remote-settable via OSC).
 - `{AGT_SESSION_PWD}` / `$AGT_SESSION_PWD` — the working directory of the pane the command fired from;
-  the scratch terminal reports the main pane's, since it tracks no cwd of its own.
+  the scratch terminal reports the main pane's, since it tracks no cwd of its own. For a session opened
+  by `zmx attach` the path can be remote: the session starts with local HOME and follows subsequent cwd
+  reports. The command itself starts in that path only when it exists here as a directory, else in
+  local HOME. See Remote sessions.
+- `{AGT_SESSION_HOST}` / `$AGT_SESSION_HOST` — the SSH destination of a session opened by `zmx attach`,
+  verbatim as given (`user@alias` included); empty for a local session, an `ssh` typed into one included,
+  so branch on it: `if [ -n "$AGT_SESSION_HOST" ]; then ssh "$AGT_SESSION_HOST" uptime; fi` (a bare
+  `&&` chain exits 1 on a local session and the runner reports that as a failure).
 - `{AGT_SELECTION}` / `$AGT_SELECTION` — the current selection.
 - `{AGT_PANE}` / `$AGT_PANE` — the pane the command fired from: `left` (main), `right` (split), or
   `scratch` (the session's scratch terminal). Feed it back as `session type --pane "$AGT_PANE"` to type
@@ -1472,6 +1479,18 @@ and the exit status.
 Closing a remote session here ends only this side's connection: the far-side processes keep running and
 nothing agterm does from this end can kill them. It is never written to disk, so it does not come back
 after a relaunch whatever the restore mode is.
+
+The pane reports the far side's working directory, and the local launches that would inherit it pick
+their start directory by one rule: the reported path when it exists here as a directory, else local
+HOME. Those launches are a custom command (its `$AGT_SESSION_PWD` keeps the reported path and
+`$AGT_SESSION_HOST` names the destination), the scratch terminal, an overlay opened without `--cwd`,
+the quick terminal, and a split opened after the attach-time split is closed. An explicit overlay
+`--cwd` is used as given. Quote both variables; an existing local path is not checked to be the same
+repository as the remote one.
+
+When another client leads at a different terminal size, local cursor and screen-text reads can disagree
+with the application's layout; automation relying on those reads, including the chat transport, is
+unsupported in that state.
 
 Both commands run ssh non-interactively (`BatchMode`), so key-based auth must already work for the host —
 a password or host-key prompt is a failure, not a question. An attach joins as a follower and pinned zmx

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -399,7 +399,9 @@ buys nothing. A caller with no tree uses `version`.
   OSC 7 cwd the sidebar row shows and `session reveal` opens); selects + focuses the new session and
   returns its id. There are NO other options — the target session names both the destination workspace
   and the cwd — and `--target` defaults to `active`. It is equivalent to
-  `session new --cwd <source cwd> --after <source>` in ONE atomic round-trip.
+  `session new --cwd <source cwd> --after <source>` in ONE atomic round-trip, except that a remote
+  source's cwd goes through the local rule first (see Remote sessions): an existing local directory is
+  kept, anything else becomes home.
   ONLY the directory carries over: the duplicate is a plain login shell with the auto basename, and it
   does NOT inherit the source's custom name, `--command`, split, scratch, status, flag, font size, or
   background — it is "new session seeded with the source's cwd", not a clone of state. Errors: the usual
@@ -408,7 +410,8 @@ buys nothing. A caller with no tree uses `version`.
   directly after its source, carrying the source's focused-pane cwd. That equals the source node's
   `tree.cwd` for a non-split session (and a split focused on its primary pane); for a split focused off its
   primary the source node's `tree.cwd` reports the primary pane while the duplicate carries the focused
-  pane's directory. It is the control half of the sidebar row's **Duplicate Session** context-menu item
+  pane's directory, and for a remote source it is that cwd after the local rule, so it can read as home.
+  It is the control half of the sidebar row's **Duplicate Session** context-menu item
   (single-selection only).
 - `session close [--target T ...] [--window W]` — close one session, or repeat `--target` to close
   several sessions in the same window/store. Batch close honors the GUI grace-undo setting: one grouped

--- a/site/commands.html
+++ b/site/commands.html
@@ -981,7 +981,8 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cwd</span> (equal to the source node's
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree.cwd</span> unless the source is a split
                 focused off its primary pane, where <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree.cwd</span>
-                reports the primary).
+                reports the primary, or a remote session, whose cwd goes through the local rule first — an existing local
+                directory is kept, anything else becomes home — so the duplicate can read as home).
               </p>
             </div>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -2496,9 +2496,10 @@
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               The pane reports the far side's working directory, and the local launches that would inherit it — a custom
               command, the scratch terminal, an overlay opened without
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--cwd</span>, the quick terminal, a split
-              opened after the attach-time split is closed — starts in that path when it exists here as a directory, else in your
-              home. A custom command still sees the reported path in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--cwd</span>, the quick terminal, a local
+              split (the first on a session that arrived without one, or one opened after the attach-time split is closed),
+              Duplicate Session, and New Session when set to open in the current session's directory — start in that path when it
+              exists here as a directory, else in your home. A custom command still sees the reported path in
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_SESSION_PWD</span> and the
               destination in <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_SESSION_HOST</span>,
               empty for a local session, so it can reach the remote directory itself. When another client leads at a different

--- a/site/docs.html
+++ b/site/docs.html
@@ -1697,7 +1697,7 @@
                 color: #cbc6bc;
               "
             >
-              {AGT_SESSION_ID}&nbsp;&nbsp;&nbsp;{AGT_SESSION_NAME}&nbsp;&nbsp;&nbsp;{AGT_SESSION_PWD}<br />{AGT_WORKSPACE_ID}&nbsp;&nbsp;&nbsp;{AGT_WORKSPACE_NAME}<br />{AGT_WINDOW_ID}&nbsp;&nbsp;&nbsp;{AGT_WINDOW_NAME}<br />{AGT_PANE}&nbsp;&nbsp;&nbsp;{AGT_SELECTION}&nbsp;&nbsp;&nbsp;{AGT_SOCKET}
+              {AGT_SESSION_ID}&nbsp;&nbsp;&nbsp;{AGT_SESSION_NAME}&nbsp;&nbsp;&nbsp;{AGT_SESSION_PWD}&nbsp;&nbsp;&nbsp;{AGT_SESSION_HOST}<br />{AGT_WORKSPACE_ID}&nbsp;&nbsp;&nbsp;{AGT_WORKSPACE_NAME}<br />{AGT_WINDOW_ID}&nbsp;&nbsp;&nbsp;{AGT_WINDOW_NAME}<br />{AGT_PANE}&nbsp;&nbsp;&nbsp;{AGT_SELECTION}&nbsp;&nbsp;&nbsp;{AGT_SOCKET}
             </div>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               Tokens expand at fire time (also exported as
@@ -2492,6 +2492,18 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">~/.ssh/config</span>, which both paths read.
               Use <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--window</span> to choose an open local window without bringing it forward; otherwise the
               session opens in the frontmost window after discovery.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              The pane reports the far side's working directory, and the local launches that would inherit it — a custom
+              command, the scratch terminal, an overlay opened without
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--cwd</span>, the quick terminal, a split
+              opened after the attach-time split is closed — starts in that path when it exists here as a directory, else in your
+              home. A custom command still sees the reported path in
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_SESSION_PWD</span> and the
+              destination in <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">$AGT_SESSION_HOST</span>,
+              empty for a local session, so it can reach the remote directory itself. When another client leads at a different
+              terminal size, local cursor and screen-text reads can disagree with the application's layout; automation relying on
+              those reads is unsupported in that state.
             </p>
             <div
               style="


### PR DESCRIPTION
a session opened with `agtermctl zmx attach` runs its pane over ssh, so the pane can report a remote working directory, and these local launches inherited it as if it were local: a custom keymap command, the scratch terminal, an overlay opened without `--cwd`, the quick terminal, a local split, Duplicate Session and a new session under the current-directory setting. The custom-command context did not include the attachment host.

custom commands gain `AGT_SESSION_HOST`, the ssh destination the session was attached from, empty for a local session (an `ssh` typed into a local session leaves it empty). `AGT_SESSION_PWD` keeps the reported path, so a command can reach the remote directory itself.

for these launches from a remote-attached session, an existing local directory at the reported path is kept; otherwise the launch starts in local HOME. This supports mirrored checkout paths. Existence is the only check; the directory is not verified to be the same repository. Local sessions keep their old behavior, an explicit overlay `--cwd` is used as given, and the primary ssh surface still starts in HOME.

when another Mac attaches and types at a different terminal size, the pane's content here is laid out for that grid while the local grid stays, so cursor and screen-text reads can disagree with the application's layout. Automation that relies on those reads is documented as unsupported in that state; the mechanism and two unverified approaches are in `docs/backlog/`.
