### PR TITLE
fix(tests): replace the session-host fixture's copied nc with a built client

### DIFF
--- a/agtermCore/Package.swift
+++ b/agtermCore/Package.swift
@@ -36,6 +36,10 @@ package.targets += [
     .target(name: "SessionHostTrampoline"),
     .target(name: "SessionHostRuntime", dependencies: ["SessionHostTrampoline", "AgtermResponsibility", "agtermCore"]),
     .executableTarget(name: "agterm-session-host", dependencies: ["SessionHostRuntime"]),
-    .testTarget(name: "SessionHostRuntimeTests", dependencies: ["SessionHostRuntime", "agterm-session-host"]),
+    // Not a product: the fixtures need a socket client they can copy into a test bundle, which
+    // /usr/bin/nc cannot be (see the target's own comment).
+    .executableTarget(name: "session-host-test-client"),
+    .testTarget(name: "SessionHostRuntimeTests",
+                dependencies: ["SessionHostRuntime", "agterm-session-host", "session-host-test-client"]),
 ]
 #endif

--- a/agtermCore/Sources/session-host-test-client/main.swift
+++ b/agtermCore/Sources/session-host-test-client/main.swift
@@ -1,0 +1,63 @@
+import Darwin
+import Foundation
+
+// A stand-in for `nc -U` inside the test bundle. The fixtures need a client whose executable sits
+// beside the host's, so the host's peer check resolves the same bundle identity; `/usr/bin/nc` cannot
+// serve because its arm64e slice is only executable as a platform binary, and any copy of it outside
+// the system volume is killed by AMFI (issue #577).
+
+let arguments = CommandLine.arguments
+guard arguments.count == 3, arguments[1] == "-U" else {
+    FileHandle.standardError.write(Data("usage: session-host-test-client -U SOCKET\n".utf8))
+    exit(2)
+}
+
+let connection = socket(AF_UNIX, SOCK_STREAM, 0)
+guard connection >= 0 else { exit(1) }
+var address = sockaddr_un()
+address.sun_family = sa_family_t(AF_UNIX)
+address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+let path = arguments[2].utf8CString
+guard path.count <= MemoryLayout.size(ofValue: address.sun_path) else { exit(1) }
+withUnsafeMutableBytes(of: &address.sun_path) { buffer in path.withUnsafeBytes { buffer.copyMemory(from: $0) } }
+let connected = withUnsafePointer(to: &address) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(connection, $0, socklen_t(MemoryLayout<sockaddr_un>.size)) }
+}
+guard connected == 0 else { exit(1) }
+
+// Both directions stay live at once: a stalled peer keeps stdin open forever, and the run must still
+// end when the host closes its side.
+var input = Int32(STDIN_FILENO)
+var buffer = [UInt8](repeating: 0, count: 65536)
+while true {
+    var entries = [pollfd(fd: connection, events: Int16(POLLIN), revents: 0)]
+    if input >= 0 { entries.append(pollfd(fd: input, events: Int16(POLLIN), revents: 0)) }
+    guard poll(&entries, nfds_t(entries.count), -1) >= 0 || errno == EINTR else { break }
+    if entries[0].revents != 0 {
+        let count = read(connection, &buffer, buffer.count)
+        if count <= 0 { break }
+        var written = 0
+        while written < count {
+            let step = buffer.withUnsafeBytes { write(STDOUT_FILENO, $0.baseAddress!.advanced(by: written), count - written) }
+            if step <= 0 { exit(0) }
+            written += step
+        }
+    }
+    if entries.count > 1, entries[1].revents != 0 {
+        let count = read(input, &buffer, buffer.count)
+        if count <= 0 {
+            // stdin is done; half-close so the host sees the request end, and keep reading the reply.
+            shutdown(connection, SHUT_WR)
+            input = -1
+        } else {
+            var written = 0
+            while written < count {
+                let step = buffer.withUnsafeBytes { write(connection, $0.baseAddress!.advanced(by: written), count - written) }
+                if step <= 0 { exit(1) }
+                written += step
+            }
+        }
+    }
+}
+close(connection)
+exit(0)

--- a/agtermCore/Tests/SessionHostRuntimeTests/SessionHostServerTests.swift
+++ b/agtermCore/Tests/SessionHostRuntimeTests/SessionHostServerTests.swift
@@ -438,9 +438,8 @@ struct SessionHostServerTests {
             let package = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
             try FileManager.default.copyItem(at: package.appendingPathComponent(".build/debug/agterm-session-host"), to: executable)
             try FileManager.default.copyItem(atPath: stagedZmxPath, toPath: zmx.path)
-            try FileManager.default.copyItem(atPath: "/usr/bin/nc", toPath: client.path)
+            try FileManager.default.copyItem(at: package.appendingPathComponent(".build/debug/session-host-test-client"), to: client)
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: client.path)
-            _ = try run(URL(fileURLWithPath: "/usr/bin/codesign"), arguments: ["--force", "--sign", "-", client.path])
             let info = ["CFBundleIdentifier": identity.bundleID, "CFBundleExecutable": "agterm-session-host", "CFBundlePackageType": "APPL"]
             try PropertyListSerialization.data(fromPropertyList: info, format: .xml, options: 0).write(to: bundle.appendingPathComponent("Contents/Info.plist"))
             try FileManager.default.createDirectory(at: URL(fileURLWithPath: paths.spawnLock).deletingLastPathComponent(), withIntermediateDirectories: true)


### PR DESCRIPTION
Fixes #577.

## The problem

`SessionHostServerTests.Fixture` copies `/usr/bin/nc` into its fake app bundle to get a socket client with the same bundle identity. `/usr/bin/nc` is a universal `x86_64 arm64e` binary, and its arm64e slice is only executable because it is a platform binary in the system trust cache. Any copy outside the system volume is not, so AMFI kills it on exec.

The ad-hoc re-signing is not the cause — an untouched byte copy is SIGKILLed the same way, and removing the arm64e slice is what makes it run:

```
$ cp /usr/bin/nc /tmp/plain-copy && /tmp/plain-copy -h ; echo "exit $?"
exit 137            # 128 + 9 = SIGKILL
```

Six tests failed as a result. Every `exchange()` parsed empty stdout into `[]`, so `.stop` never reached the host and `waitForExit()` threw `ETIMEDOUT` five seconds later. On a stock Apple Silicon Mac with SIP enabled, `swift test` reported 11 issues; CI does not see it, which #577 goes into.

## The change

Adds a small `session-host-test-client` executable target — a target, deliberately not a package product, so it never ships in the app. It speaks the same `-U SOCKET` form the fixture already passed, so only the copied path changes.

It polls the socket and stdin together rather than draining stdin first. `stalledPeerHitsItsDeadlineAndOnlyThatConnectionCloses` holds stdin open forever, and the client still has to end when the host closes its side.

`forgedHelloDoesNotOverrideTheActualPeerImage` keeps using the real `/usr/bin/nc` at its own path. That is the point of that test, and a binary run from the system volume is unaffected.

## Verification

On macOS 26.0.1, Apple Silicon, SIP enabled:

- `swift test --filter SessionHostServerTests` — 22 tests pass in 3.3s, where six previously failed
- `swift test` — 3146 tests in 128 suites pass
- `swiftlint --strict` — clean

Happy to take a different approach if you would rather not add a target; #577 lists the alternatives I considered.
