### PR TITLE
fix(status): start status sounds off the main actor

### DIFF
--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -16,9 +16,9 @@ final class StatusSoundPlayer {
 
     private var cache: [String: NSSound] = [:]
 
-    /// Playback runs here, never on the main actor: the first `NSSound.play()` in a process spins up
-    /// CoreAudio and held the main queue for ~0.7s (#575), which stalls keystroke delivery in every session.
-    /// Serial, so one clip's `stop()`/`play()` pair can't interleave with another's on the same instance.
+    /// Playback runs here, never on the main actor: the first `NSSound.play()` in a process is slow enough
+    /// to stall keystroke delivery in every session, measured at ~0.9s in #575 (the cause inside AppKit was
+    /// never established). Serial, so one clip's `stop()`/`play()` pair can't interleave with another's.
     private static let playQueue = DispatchQueue(label: "com.umputun.agterm.status-sound", qos: .userInitiated)
 
     /// De-bounce identical replays so a rapid run of `session.status --sound` (or repeated `blocked`

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -9,12 +9,20 @@ import agtermCore
 /// indicator and surface an `unknown sound` error; `NSSound(named:)` also resolves `~/Library/Sounds`.
 /// Resolved sounds are cached, so they are retained for the app's lifetime — skipping a reload, and dodging
 /// the AppKit gotcha where a locally-scoped `NSSound` is deallocated mid-play and the clip is cut off.
+///
+/// Resolution stays on the main actor because `session.status` must answer `unknown sound` before it mutates
+/// anything; only playback leaves it, on `playQueue`.
 @MainActor
 final class StatusSoundPlayer {
     /// Shared so every caller reuses one `NSSound` cache.
     static let shared = StatusSoundPlayer()
 
     private var cache: [String: NSSound] = [:]
+
+    /// Playback runs here, never on the main actor: the first `NSSound.play()` in a process spins up
+    /// CoreAudio and held the main queue for ~0.7s (#575), which stalls keystroke delivery in every session.
+    /// Serial, so one clip's `stop()`/`play()` pair can't interleave with another's on the same instance.
+    private static let playQueue = DispatchQueue(label: "com.umputun.agterm.status-sound", qos: .userInitiated)
 
     /// De-bounce identical replays so a rapid run of `session.status --sound` (or repeated `blocked`
     /// transitions) doesn't stutter the same clip; the Settings preview bypasses this and always sounds.
@@ -28,11 +36,11 @@ final class StatusSoundPlayer {
     /// Resolve a `session.status` sound value to its one-shot play action, or nil when a named sound can't
     /// be found. `default`/`beep` plays the system alert sound; anything else plays the named system sound.
     func action(for name: String) -> (() -> Void)? {
-        if name == "default" || name == "beep" { return { NSSound.beep() } }
-        if let cached = cache[name] { return { cached.stop(); cached.play() } }
+        if name == "default" || name == "beep" { return { Self.playQueue.async { NSSound.beep() } } }
+        if let cached = cache[name] { return Self.playAction(for: cached) }
         guard let sound = NSSound(named: NSSound.Name(name)) else { return nil }
         cache[name] = sound
-        return { sound.stop(); sound.play() }
+        return Self.playAction(for: sound)
     }
 
     /// Resolve and play `name`, suppressing a replay of the SAME sound within the throttle window so a burst
@@ -45,5 +53,11 @@ final class StatusSoundPlayer {
         guard let action = action(for: name) else { return false }
         if throttle.allow(name, at: ContinuousClock().now) { action() }
         return true
+    }
+
+    /// The one-shot play action for an already-resolved sound, hopping to `playQueue` so the caller's thread
+    /// — the main actor, for every caller here — never waits on audio startup.
+    private static func playAction(for sound: NSSound) -> () -> Void {
+        { playQueue.async { sound.stop(); sound.play() } }
     }
 }

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -9,9 +9,6 @@ import agtermCore
 /// indicator and surface an `unknown sound` error; `NSSound(named:)` also resolves `~/Library/Sounds`.
 /// Resolved sounds are cached, so they are retained for the app's lifetime — skipping a reload, and dodging
 /// the AppKit gotcha where a locally-scoped `NSSound` is deallocated mid-play and the clip is cut off.
-///
-/// Resolution stays on the main actor because `session.status` must answer `unknown sound` before it mutates
-/// anything; only playback leaves it, on `playQueue`.
 @MainActor
 final class StatusSoundPlayer {
     /// Shared so every caller reuses one `NSSound` cache.
@@ -55,8 +52,6 @@ final class StatusSoundPlayer {
         return true
     }
 
-    /// The one-shot play action for an already-resolved sound, hopping to `playQueue` so the caller's thread
-    /// — the main actor, for every caller here — never waits on audio startup.
     private static func playAction(for sound: NSSound) -> () -> Void {
         { playQueue.async { sound.stop(); sound.play() } }
     }

--- a/agtermTests/StatusSoundPlayerTests.swift
+++ b/agtermTests/StatusSoundPlayerTests.swift
@@ -26,7 +26,7 @@ final class StatusSoundPlayerTests: XCTestCase {
     }
 
     func testStartingAClipLeavesTheMainThread() throws {
-        // #575: the first NSSound.play() of a process spent ~0.7s starting CoreAudio on the main actor
+        // #575: the first NSSound.play() of a process took ~0.9s, on the main actor
         let fixture = try registerRecordingSound()
         let action = try XCTUnwrap(player.action(for: fixture.name))
 

--- a/agtermTests/StatusSoundPlayerTests.swift
+++ b/agtermTests/StatusSoundPlayerTests.swift
@@ -1,0 +1,44 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the status-sound player: which names resolve, and that starting a clip hands the
+/// main thread straight back.
+@MainActor
+final class StatusSoundPlayerTests: XCTestCase {
+    private var player: StatusSoundPlayer!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run { player = StatusSoundPlayer() }
+    }
+
+    func testUnknownSoundNameResolvesToNoAction() {
+        XCTAssertNil(player.action(for: "NoSuchSoundXYZ"), "an unresolvable name must report itself as such")
+        XCTAssertFalse(player.play("NoSuchSoundXYZ"), "play must fail so the control server can say 'unknown sound'")
+    }
+
+    func testEveryOfferedSoundNameResolves() {
+        for name in ["default", "beep"] + StatusSoundPlayer.standardNames {
+            XCTAssertNotNil(player.action(for: name), "the Settings picker offers \(name), so it must resolve")
+        }
+    }
+
+    func testPlayingASoundDoesNotHoldTheMainThread() throws {
+        // #575: the first NSSound.play() of a process spent ~0.7s starting CoreAudio on the main actor
+        let action = try XCTUnwrap(player.action(for: "Tink"))
+
+        let started = ContinuousClock().now
+        action()
+        let cold = ContinuousClock().now - started
+
+        let cachedAction = try XCTUnwrap(player.action(for: "Tink"))
+        let resumed = ContinuousClock().now
+        cachedAction()
+        let warm = ContinuousClock().now - resumed
+
+        XCTAssertLessThan(cold, .milliseconds(50), "the first play must not wait on audio startup, took \(cold)")
+        XCTAssertLessThan(warm, .milliseconds(50), "a cached sound must not wait on playback either, took \(warm)")
+    }
+}

--- a/agtermTests/StatusSoundPlayerTests.swift
+++ b/agtermTests/StatusSoundPlayerTests.swift
@@ -3,8 +3,8 @@ import XCTest
 @testable import agterm
 import agtermCore
 
-/// Hosted coverage for the status-sound player: which names resolve, and that starting a clip hands the
-/// main thread straight back.
+/// Hosted coverage for the status-sound player: which names resolve, and that a resolved clip is started
+/// off the main thread. The recording sound overrides playback, so nothing here proves it is audible.
 @MainActor
 final class StatusSoundPlayerTests: XCTestCase {
     private var player: StatusSoundPlayer!
@@ -25,20 +25,72 @@ final class StatusSoundPlayerTests: XCTestCase {
         }
     }
 
-    func testPlayingASoundDoesNotHoldTheMainThread() throws {
+    func testStartingAClipLeavesTheMainThread() throws {
         // #575: the first NSSound.play() of a process spent ~0.7s starting CoreAudio on the main actor
-        let action = try XCTUnwrap(player.action(for: "Tink"))
+        let fixture = try registerRecordingSound()
+        let action = try XCTUnwrap(player.action(for: fixture.name))
 
-        let started = ContinuousClock().now
         action()
-        let cold = ContinuousClock().now - started
 
-        let cachedAction = try XCTUnwrap(player.action(for: "Tink"))
-        let resumed = ContinuousClock().now
-        cachedAction()
-        let warm = ContinuousClock().now - resumed
+        wait(for: [fixture.sound.log.playCalled], timeout: 2)
+        let calls = fixture.sound.log.calls
+        XCTAssertEqual(calls.map(\.selector), ["stop", "play"], "a replay must stop the clip before starting it")
+        XCTAssertEqual(calls.filter(\.onMainThread), [], "neither call may run on the main thread")
+    }
 
-        XCTAssertLessThan(cold, .milliseconds(50), "the first play must not wait on audio startup, took \(cold)")
-        XCTAssertLessThan(warm, .milliseconds(50), "a cached sound must not wait on playback either, took \(warm)")
+    func testStartingACachedClipLeavesTheMainThread() throws {
+        let fixture = try registerRecordingSound()
+        _ = player.action(for: fixture.name)
+        let cached = try XCTUnwrap(player.action(for: fixture.name))
+
+        cached()
+
+        wait(for: [fixture.sound.log.playCalled], timeout: 2)
+        XCTAssertEqual(fixture.sound.log.calls.filter(\.onMainThread), [], "the cached branch must hop off the main thread too")
+    }
+
+    /// A sound that records its own playback instead of making noise, published under a name unique to the
+    /// call so `NSSound(named:)` hands the player this instance and no test inherits another's cache entry.
+    private func registerRecordingSound() throws -> (sound: RecordingSound, name: String) {
+        let url = URL(fileURLWithPath: "/System/Library/Sounds/Tink.aiff")
+        let sound = try XCTUnwrap(RecordingSound(contentsOf: url, byReference: true))
+        let name = NSSound.Name("agterm-status-sound-test-\(UUID().uuidString)")
+        XCTAssertTrue(sound.setName(name), "the fixture has to be resolvable by name")
+        return (sound, name as String)
+    }
+}
+
+private final class RecordingSound: NSSound {
+    let log = PlaybackLog()
+
+    override func stop() -> Bool {
+        log.record("stop")
+        return true
+    }
+
+    override func play() -> Bool {
+        log.record("play")
+        return true
+    }
+}
+
+private final class PlaybackLog: @unchecked Sendable {
+    struct Call: Equatable {
+        let selector: String
+        let onMainThread: Bool
+    }
+
+    let playCalled = XCTestExpectation(description: "play reached the sound")
+
+    private let lock = NSLock()
+    private var recorded: [Call] = []
+
+    var calls: [Call] {
+        lock.withLock { recorded }
+    }
+
+    func record(_ selector: String) {
+        lock.withLock { recorded.append(Call(selector: selector, onMainThread: Thread.isMainThread)) }
+        if selector == "play" { playCalled.fulfill() }
     }
 }


### PR DESCRIPTION
status sounds started playback synchronously on the main actor. `StatusSoundPlayer` is `@MainActor` and `ControlServer.setSessionStatus` called `play(name)` inline, so a slow first `NSSound.play()` blocked the same thread that delivers keystrokes. That stalls typing in every session, not just the one that set the status.

#575 measured ~881ms for the first `play()` call itself, and ~739ms for a first blocked-status transition end to end. Why the call is slow was never established, so the comments here say what was measured and stop there.

playback now hops to a private static serial `DispatchQueue`. Serial so one clip's `stop()`/`play()` pair cannot interleave with another's on the same cached `NSSound`. `NSSound` is annotated `Sendable` in the SDK, so the production side needs no unchecked wrapper.

name resolution via `NSSound(named:)` still runs on the main actor. That is a scope decision, not a limit of the design: `session.status` validates the name before it mutates the indicator, and moving that off the main thread means reworking the ordering. The reporter's probe put resolution at ~4ms for a system sound, and it is cached after the first hit. Slow custom-file resolution, the second stall he demonstrated with a WebDAV mount, is still there.

the test asserts the mechanism rather than elapsed time. A recording `NSSound` subclass published under a unique name records which thread `stop()` and `play()` ran on, covering the cached and uncached named-sound paths. Reverting the hop puts both calls back on the main thread and both tests fail, with no audio device involved and nothing audible during a run. The test fixture is `@unchecked Sendable`; production is not.

Fix #575
