### PR TITLE
fix(status): resolve sound names off the main actor

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -648,6 +648,9 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   On resume it revalidates liveness: a session whose window closed or that moved stores mid-resolution is
   rejected rather than written. Pane ownership and `wasBlocked` are read at the mutation, never across it.
   A configured blocked default resolves after the write and cannot delay or reject it.
+  The accept loop still waits: `handleConnection` runs inline and parks on `runBlocking`, so a cold lookup
+  delays later commands. That is the price of answering `unknown sound` in the response, not an oversight.
+  Lookups use their own serial queue, never `playQueue`, so one slow name cannot hold up playback.
 - Validate color and shape before mutation. Shapes are circle, square, triangle, diamond, capsule, star;
   derive validation/help from `StatusShape.allCases`. Idle accepts but does not render shape.
   AppKit and SwiftUI resolve through shared color/symbol helpers.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -642,6 +642,12 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - Validate sound before mutation and target playback. `default`/`beep` beeps; named system/custom sounds
   use cached `NSSound`. Without per-call sound, entering blocked may play configured default once;
   repeated blocked does not. Explicit per-call wins via `AgentStatus.effectiveSound`.
+- Resolving an uncached name runs off the main actor, so `setSessionStatus` is async and suspends there.
+  It binds the target BEFORE that await, so a slow lookup racing a selection change cannot redirect
+  `active`, and `unknown sound` still outranks a missing target.
+  On resume it revalidates liveness: a session whose window closed or that moved stores mid-resolution is
+  rejected rather than written. Pane ownership and `wasBlocked` are read at the mutation, never across it.
+  A configured blocked default resolves after the write and cannot delay or reject it.
 - Validate color and shape before mutation. Shapes are circle, square, triangle, diamond, capsule, star;
   derive validation/help from `StatusShape.allCases`. Idle accepts but does not render shape.
   AppKit and SwiftUI resolve through shared color/symbol helpers.

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -398,34 +398,47 @@ extension ControlServer: ControlActions {
     /// While a session is blocked, a write from ANOTHER pane that is neither `blocked` nor `idle` is refused
     /// whole (`AppStore.applyControlStatus`) with a `blocked status owned by pane` error and no sound — one
     /// pane's `active`/`completed` must not erase the other's block.
-    func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse {
-        // validated before any mutation; an empty value counts as none, matching `AgentStatus.effectiveSound`.
-        if let sound = update.sound, !sound.isEmpty, StatusSoundPlayer.shared.action(for: sound) == nil {
-            let hint = StatusSoundPlayer.standardNames.joined(separator: ", ")
-            return ControlResponse(ok: false, error: "unknown sound: \(sound) (use 'default', 'beep', or one of: \(hint))")
-        }
-        return resolver.resolveSession(target, window: window) { store, id in
-            let session = store.session(withID: id)
-            // capture the status BEFORE mutating so the Settings default plays only on a real transition.
-            let wasBlocked = session?.agentIndicator.status == .blocked
-            // `--pane-id` resolves against the LIVE surfaces and overrides the stale role `--pane`, so a
-            // promoted-then-re-split pane lands on its CURRENT slot (#199); absent/unknown falls back to it.
-            let resolvedPane = update.paneID.flatMap { session?.paneRole(forToken: $0) } ?? update.pane
-            let indicator = AgentIndicator(status: update.status, blink: update.blink ?? false,
-                                           autoReset: update.autoReset ?? false,
-                                           color: update.color, shape: update.shape, statusPane: resolvedPane)
-            // a refusal returns BEFORE the sound: the write did not happen, so it must make no noise either.
-            if case .refused(let owner) = store.applyControlStatus(indicator, forSession: id) {
-                return ControlResponse(ok: false, error: "blocked status owned by pane \(owner.rawValue) " +
-                    "(write from that pane to change it)")
+    func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) async -> ControlResponse {
+        // bind active/prefix targets before suspension, but preserve unknown-sound error precedence.
+        let captured = resolver.resolveSessionTarget(target, window: window)
+        var prepared: (() -> Void)?
+        // empty per-call sounds fall through to the default, matching AgentStatus.effectiveSound.
+        if let sound = update.sound, !sound.isEmpty {
+            prepared = await statusSoundPlayer.action(for: sound)
+            guard prepared != nil else {
+                let hint = StatusSoundPlayer.standardNames.joined(separator: ", ")
+                return ControlResponse(ok: false, error: "unknown sound: \(sound) (use 'default', 'beep', or one of: \(hint))")
             }
-            // per-call sound wins on any status; the Settings default plays only on a NEW entry into `blocked`.
-            let blockedDefault = wasBlocked ? nil : self.settingsModel.settings.blockedStatusSoundName
-            if let name = update.status.effectiveSound(perCall: update.sound, blockedDefault: blockedDefault) {
-                StatusSoundPlayer.shared.play(name)
-            }
-            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
+        let store: AppStore
+        let id: UUID
+        switch captured {
+        case .failure(let response): return response
+        case .success(let resolved): (store, id) = resolved
+        }
+        guard library.windowID(for: store) != nil, let session = store.session(withID: id) else {
+            return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
+        }
+        let wasBlocked = session.agentIndicator.status == .blocked
+        // pane tokens and blocked ownership use the live state after resolution, with no further await.
+        // #199: promotion followed by another split can put a pane token in a different role.
+        let resolvedPane = update.paneID.flatMap { session.paneRole(forToken: $0) } ?? update.pane
+        let indicator = AgentIndicator(status: update.status, blink: update.blink ?? false,
+                                       autoReset: update.autoReset ?? false,
+                                       color: update.color, shape: update.shape, statusPane: resolvedPane)
+        // rejected writes must return before playback: no status change means no sound.
+        if case .refused(let owner) = store.applyControlStatus(indicator, forSession: id) {
+            return ControlResponse(ok: false, error: "blocked status owned by pane \(owner.rawValue) " +
+                "(write from that pane to change it)")
+        }
+        if let name = update.sound, let prepared {
+            statusSoundPlayer.play(name, using: prepared)
+        } else if let name = update.status.effectiveSound(perCall: nil,
+                                                         blockedDefault: wasBlocked ? nil : settingsModel.settings.blockedStatusSoundName) {
+            // a configured default is best-effort and must not delay or reject the status update.
+            Task { await statusSoundPlayer.play(name) }
+        }
+        return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
     }
 
     /// Pin (or unpin) the target pane's restore-command override — the per-pane shell line that wins over

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -21,6 +21,7 @@ final class ControlServer {
     let library: WindowLibrary
     let actions: AppActions
     let settingsModel: SettingsModel
+    let statusSoundPlayer: StatusSoundPlayer
     let launchRestoreMode: RestoreMode
     let zmxForegroundResolver: ZmxForegroundResolver?
     private let socketPath: String
@@ -151,11 +152,13 @@ final class ControlServer {
          zmxForegroundResolver: ZmxForegroundResolver? = nil, zmxClient: ZmxClient? = nil,
          liveAttributionProbe: LiveAttributionProbe = LiveAttributionProbe(),
          remoteRunner: (any RemoteCommandRunner)? = nil,
+         statusSoundPlayer: StatusSoundPlayer = .shared,
          socketPath: String? = nil) {
         self.remoteRunner = remoteRunner ?? RemoteCommandProcessRunner()
         self.library = library
         self.actions = actions
         self.settingsModel = settingsModel
+        self.statusSoundPlayer = statusSoundPlayer
         self.launchRestoreMode = launchRestoreMode
         self.zmxForegroundResolver = zmxForegroundResolver
         self.zmxClient = zmxClient

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -26,9 +26,9 @@ final class StatusSoundPlayer {
     /// never established). Serial, so one clip's `stop()`/`play()` pair can't interleave with another's.
     private static let playQueue = DispatchQueue(label: "com.umputun.agterm.status-sound", qos: .userInitiated)
 
-    /// Lookup I/O gets its own queue so a slow name never occupies `playQueue`. Serial, because parallel
-    /// lookups buy nothing here and `NSSound(named:)` reads a shared registry with no documented
-    /// concurrency guarantee.
+    /// Lookup I/O gets its own queue so a slow name never occupies `playQueue`. Serial by choice: parallel
+    /// lookups would let a slow blocked default overlap a later command's first lookup, but `NSSound(named:)`
+    /// reads a shared registry with no documented concurrency guarantee, and that is the worse bet.
     private static let resolveQueue = DispatchQueue(label: "com.umputun.agterm.status-sound.resolve", qos: .userInitiated)
 
     /// Suppress rapid repeats of the same status sound to avoid stuttering; Settings previews bypass this.

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -26,6 +26,11 @@ final class StatusSoundPlayer {
     /// never established). Serial, so one clip's `stop()`/`play()` pair can't interleave with another's.
     private static let playQueue = DispatchQueue(label: "com.umputun.agterm.status-sound", qos: .userInitiated)
 
+    /// Lookup I/O gets its own queue so a slow name never occupies `playQueue`. Serial, because parallel
+    /// lookups buy nothing here and `NSSound(named:)` reads a shared registry with no documented
+    /// concurrency guarantee.
+    private static let resolveQueue = DispatchQueue(label: "com.umputun.agterm.status-sound.resolve", qos: .userInitiated)
+
     /// Suppress rapid repeats of the same status sound to avoid stuttering; Settings previews bypass this.
     private var throttle = SoundThrottle(window: .milliseconds(200))
 
@@ -36,12 +41,12 @@ final class StatusSoundPlayer {
 
     /// Resolve a `session.status` sound value to its one-shot play action, or nil when a named sound can't
     /// be found. `default`/`beep` plays the system alert sound; anything else plays the named system sound.
-    /// Cache misses resolve on the playback queue; cache hits never wait for that queue.
+    /// Cache misses use the resolution queue; cache hits return without queueing.
     func action(for name: String) async -> (() -> Void)? {
         if name == "default" || name == "beep" { return { Self.playQueue.async { NSSound.beep() } } }
         if let cached = cache[name] { return Self.playAction(for: cached) }
         let resolved = await withCheckedContinuation { continuation in
-            Self.playQueue.async { [resolve] in
+            Self.resolveQueue.async { [resolve] in
                 continuation.resume(returning: resolve(name))
             }
         }
@@ -67,7 +72,7 @@ final class StatusSoundPlayer {
 
     /// Preview only while its selection still applies, bypassing status throttling.
     func preview(_ name: String, ifCurrent: () -> Bool) async {
-        guard let action = await action(for: name), !Task.isCancelled, ifCurrent() else { return }
+        guard let action = await action(for: name), ifCurrent() else { return }
         action()
     }
 

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -15,14 +15,18 @@ final class StatusSoundPlayer {
     static let shared = StatusSoundPlayer()
 
     private var cache: [String: NSSound] = [:]
+    private let resolve: @Sendable (String) -> NSSound?
+
+    init(resolve: @escaping @Sendable (String) -> NSSound? = { NSSound(named: NSSound.Name($0)) }) {
+        self.resolve = resolve
+    }
 
     /// Playback runs here, never on the main actor: the first `NSSound.play()` in a process is slow enough
     /// to stall keystroke delivery in every session, measured at ~0.9s in #575 (the cause inside AppKit was
     /// never established). Serial, so one clip's `stop()`/`play()` pair can't interleave with another's.
     private static let playQueue = DispatchQueue(label: "com.umputun.agterm.status-sound", qos: .userInitiated)
 
-    /// De-bounce identical replays so a rapid run of `session.status --sound` (or repeated `blocked`
-    /// transitions) doesn't stutter the same clip; the Settings preview bypasses this and always sounds.
+    /// Suppress rapid repeats of the same status sound to avoid stuttering; Settings previews bypass this.
     private var throttle = SoundThrottle(window: .milliseconds(200))
 
     /// The standard macOS system sound names: the Settings sound pickers' option list (blocked-status and
@@ -32,24 +36,39 @@ final class StatusSoundPlayer {
 
     /// Resolve a `session.status` sound value to its one-shot play action, or nil when a named sound can't
     /// be found. `default`/`beep` plays the system alert sound; anything else plays the named system sound.
-    func action(for name: String) -> (() -> Void)? {
+    /// Cache misses resolve on the playback queue; cache hits never wait for that queue.
+    func action(for name: String) async -> (() -> Void)? {
         if name == "default" || name == "beep" { return { Self.playQueue.async { NSSound.beep() } } }
         if let cached = cache[name] { return Self.playAction(for: cached) }
-        guard let sound = NSSound(named: NSSound.Name(name)) else { return nil }
+        let resolved = await withCheckedContinuation { continuation in
+            Self.playQueue.async { [resolve] in
+                continuation.resume(returning: resolve(name))
+            }
+        }
+        guard let sound = resolved else { return nil }
         cache[name] = sound
         return Self.playAction(for: sound)
     }
 
-    /// Resolve and play `name`, suppressing a replay of the SAME sound within the throttle window so a burst
-    /// of rapid status sets doesn't machine-gun an identical clip. Returns false ONLY when the name can't be
-    /// resolved (so the caller can surface `unknown sound`); a throttled replay returns true — resolvable,
-    /// just intentionally silent. The control server plays through this; the Settings picker preview calls
-    /// `action(for:)` directly so a deliberate click always sounds.
+    /// Resolve and play `name`, suppressing identical replays within the throttle window.
+    /// False lets callers report an unknown name; true includes a valid sound intentionally silenced by
+    /// throttling, so a suppressed replay is not mistaken for a resolution failure.
     @discardableResult
-    func play(_ name: String) -> Bool {
-        guard let action = action(for: name) else { return false }
-        if throttle.allow(name, at: ContinuousClock().now) { action() }
+    func play(_ name: String) async -> Bool {
+        guard let action = await action(for: name) else { return false }
+        play(name, using: action)
         return true
+    }
+
+    /// Submit an already validated action without another resolution or suspension after the status write.
+    func play(_ name: String, using action: () -> Void) {
+        if throttle.allow(name, at: ContinuousClock().now) { action() }
+    }
+
+    /// Preview only while its selection still applies, bypassing status throttling.
+    func preview(_ name: String, ifCurrent: () -> Bool) async {
+        guard let action = await action(for: name), !Task.isCancelled, ifCurrent() else { return }
+        action()
     }
 
     private static func playAction(for sound: NSSound) -> () -> Void {

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -579,7 +579,11 @@ private struct NotificationsSettingsView: View {
                 set: { name in
                     let value = name == "None" ? nil : name
                     model.setNotificationSoundName(value)
-                    if let value { StatusSoundPlayer.shared.action(for: value)?() }
+                    if let value {
+                        Task {
+                            await StatusSoundPlayer.shared.preview(value, ifCurrent: { model.settings.notificationSoundName == value })
+                        }
+                    }
                 })
     }
 
@@ -749,7 +753,11 @@ private struct AgentStatusSettingsView: View {
                 set: { name in
                     let value = name == "None" ? nil : name
                     model.setBlockedStatusSoundName(value)
-                    if let value { StatusSoundPlayer.shared.action(for: value)?() }
+                    if let value {
+                        Task {
+                            await StatusSoundPlayer.shared.preview(value, ifCurrent: { model.settings.blockedStatusSoundName == value })
+                        }
+                    }
                 })
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -36,7 +36,7 @@ public protocol ControlActions {
     /// means clear.
     func setSessionContext(_ target: String?, window: String?, context: String?) -> ControlResponse
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse
-    func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse
+    func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) async -> ControlResponse
     /// Write a pane's PERSISTED restore-command override (consumed on the NEXT launch, never this run).
     /// The host resolves the target session and the live pane slot, then stores the tri-state value; it
     /// also owns the pane rejections that need a session (`scratch`, `right` without a split, an
@@ -182,7 +182,7 @@ public struct ControlDispatcher {
         case .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .sessionReveal, .sessionMove, .sessionFlag, .sessionContext, .sessionSeen, .sessionStatus,
                 .sessionRestore:
-            return dispatchSessionCommand(request)
+            return await dispatchSessionCommand(request)
         case .sessionSplit, .sessionSplitClose, .sessionSwap, .sessionScratch, .sessionFocus, .sessionResize,
                 .surfaceZoom, .surfaceCursor, .sessionType,
                 .sessionCopy, .sessionPaste, .sessionSelectAll, .sessionSearch, .sessionOverlayOpen,
@@ -255,7 +255,7 @@ public struct ControlDispatcher {
         return actions.readEvents(ControlEventReadOptions(cursor: cursor, kinds: kinds, limit: limit))
     }
 
-    private func dispatchSessionCommand(_ request: ControlRequest) -> ControlResponse {
+    private func dispatchSessionCommand(_ request: ControlRequest) async -> ControlResponse {
         switch request.cmd {
         case .sessionNew:
             let args = request.args
@@ -385,7 +385,7 @@ public struct ControlDispatcher {
                                                     sound: request.args?.sound, color: request.args?.color,
                                                     shape: shape,
                                                     pane: pane, paneID: request.args?.paneID)
-            return actions.setSessionStatus(request.target, window: request.args?.window, update: update)
+            return await actions.setSessionStatus(request.target, window: request.args?.window, update: update)
         case .sessionRestore:
             return dispatchSessionRestore(request)
         default:

--- a/agtermTests/ControlServerStatusSoundTests.swift
+++ b/agtermTests/ControlServerStatusSoundTests.swift
@@ -1,0 +1,176 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+@MainActor
+final class ControlServerStatusSoundTests: XCTestCase {
+    private final class Surface: TerminalSurface {
+        let paneToken: String
+        var isRealized = true
+        init(_ token: String) { paneToken = token }
+        func teardown() {}
+        func promoteToPrimaryPane() {}
+    }
+
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var settings: SettingsModel!
+    private var server: ControlServer!
+    private var player: StatusSoundPlayer!
+    private var sound: RecordingSound!
+    private var gate: StatusSoundResolutionGate!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        stateDir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-status-\(UUID().uuidString)")
+        library = WindowLibrary(directory: stateDir)
+        settings = SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir))
+        sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+    }
+
+    override func tearDown() async throws {
+        gate?.release.signal()
+        server = nil
+        player = nil
+        settings = nil
+        library = nil
+        sound = nil
+        gate = nil
+        try? FileManager.default.removeItem(at: stateDir)
+        try await super.tearDown()
+    }
+
+    func testUnknownSoundDoesNotMutateAndWinsOverMissingTarget() async throws {
+        makeServer(resolvedSound: nil)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let before = session.agentIndicator
+        let pending = Task { await self.update() }
+        await fulfillment(of: [gate.started], timeout: 2)
+        XCTAssertEqual(session.agentIndicator, before)
+        gate.release.signal()
+        let response = await pending.value
+        XCTAssertFalse(response.ok)
+        XCTAssertTrue(response.error?.hasPrefix("unknown sound: held") == true)
+        XCTAssertEqual(session.agentIndicator, before)
+
+        let missing = await update(target: UUID().uuidString, soundName: "missing")
+        XCTAssertTrue(missing.error?.hasPrefix("unknown sound: missing") == true)
+        XCTAssertTrue(sound.log.calls.isEmpty)
+    }
+
+    func testActiveTargetStaysBoundDuringSelectionChange() async throws {
+        makeServer(resolvedSound: sound)
+        let store = try XCTUnwrap(library.activeStore)
+        let original = try XCTUnwrap(store.activeSession)
+        let other = try XCTUnwrap(store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/tmp"))
+        store.selectSession(original.id)
+        let pending = Task { await self.update() }
+        await fulfillment(of: [gate.started], timeout: 2)
+        store.selectSession(other.id)
+        gate.release.signal()
+        let response = await pending.value
+        XCTAssertTrue(response.ok)
+        XCTAssertEqual(response.result?.id, original.id.uuidString)
+        XCTAssertEqual(original.agentIndicator.status, .blocked)
+        XCTAssertEqual(other.agentIndicator.status, .idle)
+        await fulfillment(of: [sound.log.playCalled], timeout: 2)
+        XCTAssertEqual(sound.log.calls.map(\.selector), ["stop", "play"])
+    }
+
+    func testClosedSessionDoesNotSucceedOrPlay() async throws {
+        makeServer(resolvedSound: sound)
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        let pending = Task { await self.update() }
+        await fulfillment(of: [gate.started], timeout: 2)
+        store.closeSession(session.id)
+        gate.release.signal()
+        let response = await pending.value
+        XCTAssertFalse(response.ok)
+        _ = await player.action(for: "barrier")
+        XCTAssertTrue(sound.log.calls.isEmpty)
+    }
+
+    func testClosedWindowDoesNotMutateRetainedStoreOrPlay() async throws {
+        makeServer(resolvedSound: sound)
+        let window = try XCTUnwrap(library.activeWindowID)
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        let pending = Task { await self.update() }
+        await fulfillment(of: [gate.started], timeout: 2)
+        library.closeWindow(window)
+        gate.release.signal()
+        let response = await pending.value
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(session.agentIndicator.status, .idle)
+        _ = await player.action(for: "barrier")
+        XCTAssertTrue(sound.log.calls.isEmpty)
+    }
+
+    func testPaneRefusalUsesStateAfterResolutionAndDoesNotPlay() async throws {
+        makeServer(resolvedSound: sound)
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        session.hasSplit = true
+        let pending = Task { await self.update(status: .completed, pane: .left) }
+        await fulfillment(of: [gate.started], timeout: 2)
+        store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
+        gate.release.signal()
+        let response = await pending.value
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.error, "blocked status owned by pane right (write from that pane to change it)")
+        XCTAssertEqual(session.agentIndicator.status, .blocked)
+        _ = await player.action(for: "barrier")
+        XCTAssertTrue(sound.log.calls.isEmpty)
+    }
+
+    func testInvalidBlockedDefaultDoesNotRejectOrDelayMutation() async throws {
+        makeServer(resolvedSound: nil)
+        settings.setBlockedStatusSoundName("held")
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let response = await update(soundName: nil)
+        XCTAssertTrue(response.ok)
+        XCTAssertEqual(session.agentIndicator.status, .blocked)
+        await fulfillment(of: [gate.started], timeout: 2)
+        XCTAssertFalse(gate.onMainThread)
+        gate.release.signal()
+        _ = await player.action(for: "barrier")
+        XCTAssertTrue(sound.log.calls.isEmpty)
+    }
+
+    func testPaneTokenUsesRolesAfterResolution() async throws {
+        makeServer(resolvedSound: sound)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let left = Surface("left-token")
+        let right = Surface("right-token")
+        session.surface = left
+        session.splitSurface = right
+        session.hasSplit = true
+        let pending = Task { await self.update(pane: .right, paneID: "right-token") }
+        await fulfillment(of: [gate.started], timeout: 2)
+        session.surface = right
+        session.splitSurface = left
+        gate.release.signal()
+        let response = await pending.value
+        XCTAssertTrue(response.ok)
+        XCTAssertEqual(session.agentIndicator.statusPane, .left)
+        await fulfillment(of: [sound.log.playCalled], timeout: 2)
+    }
+
+    private func makeServer(resolvedSound: NSSound?) {
+        let gate = StatusSoundResolutionGate(sound: resolvedSound)
+        self.gate = gate
+        player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : resolvedSound })
+        server = ControlServer(library: library, actions: AppActions(library: library), settingsModel: settings,
+                               identity: AppIdentity(version: "test", commit: "test"),
+                               statusSoundPlayer: player,
+                               socketPath: stateDir.appendingPathComponent("control.sock").path)
+    }
+
+    private func update(target: String? = nil, soundName: String? = "held", status: AgentStatus = .blocked,
+                        pane: StatusPane? = nil, paneID: String? = nil) async -> ControlResponse {
+        let update = ControlSessionStatusUpdate(status: status, blink: nil, autoReset: nil, sound: soundName, pane: pane, paneID: paneID)
+        return await server.setSessionStatus(target, window: nil, update: update)
+    }
+}

--- a/agtermTests/ControlServerStatusSoundTests.swift
+++ b/agtermTests/ControlServerStatusSoundTests.swift
@@ -19,6 +19,7 @@ final class ControlServerStatusSoundTests: XCTestCase {
     private var server: ControlServer!
     private var player: StatusSoundPlayer!
     private var sound: RecordingSound!
+    private var playbackBarrier: RecordingSound!
     private var gate: StatusSoundResolutionGate!
 
     override func setUp() async throws {
@@ -27,6 +28,7 @@ final class ControlServerStatusSoundTests: XCTestCase {
         library = WindowLibrary(directory: stateDir)
         settings = SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir))
         sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+        playbackBarrier = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
     }
 
     override func tearDown() async throws {
@@ -36,6 +38,7 @@ final class ControlServerStatusSoundTests: XCTestCase {
         settings = nil
         library = nil
         sound = nil
+        playbackBarrier = nil
         gate = nil
         try? FileManager.default.removeItem(at: stateDir)
         try await super.tearDown()
@@ -56,7 +59,6 @@ final class ControlServerStatusSoundTests: XCTestCase {
 
         let missing = await update(target: UUID().uuidString, soundName: "missing")
         XCTAssertTrue(missing.error?.hasPrefix("unknown sound: missing") == true)
-        XCTAssertTrue(sound.log.calls.isEmpty)
     }
 
     func testActiveTargetStaysBoundDuringSelectionChange() async throws {
@@ -88,8 +90,7 @@ final class ControlServerStatusSoundTests: XCTestCase {
         gate.release.signal()
         let response = await pending.value
         XCTAssertFalse(response.ok)
-        _ = await player.action(for: "barrier")
-        XCTAssertTrue(sound.log.calls.isEmpty)
+        await assertNoPlayback()
     }
 
     func testClosedWindowDoesNotMutateRetainedStoreOrPlay() async throws {
@@ -104,8 +105,7 @@ final class ControlServerStatusSoundTests: XCTestCase {
         let response = await pending.value
         XCTAssertFalse(response.ok)
         XCTAssertEqual(session.agentIndicator.status, .idle)
-        _ = await player.action(for: "barrier")
-        XCTAssertTrue(sound.log.calls.isEmpty)
+        await assertNoPlayback()
     }
 
     func testPaneRefusalUsesStateAfterResolutionAndDoesNotPlay() async throws {
@@ -121,8 +121,7 @@ final class ControlServerStatusSoundTests: XCTestCase {
         XCTAssertFalse(response.ok)
         XCTAssertEqual(response.error, "blocked status owned by pane right (write from that pane to change it)")
         XCTAssertEqual(session.agentIndicator.status, .blocked)
-        _ = await player.action(for: "barrier")
-        XCTAssertTrue(sound.log.calls.isEmpty)
+        await assertNoPlayback()
     }
 
     func testInvalidBlockedDefaultDoesNotRejectOrDelayMutation() async throws {
@@ -134,9 +133,9 @@ final class ControlServerStatusSoundTests: XCTestCase {
         XCTAssertEqual(session.agentIndicator.status, .blocked)
         await fulfillment(of: [gate.started], timeout: 2)
         XCTAssertFalse(gate.onMainThread)
+        XCTAssertFalse(gate.finished, "the response must arrive before default sound resolution finishes")
         gate.release.signal()
-        _ = await player.action(for: "barrier")
-        XCTAssertTrue(sound.log.calls.isEmpty)
+        await fulfillment(of: [gate.completed], timeout: 2)
     }
 
     func testPaneTokenUsesRolesAfterResolution() async throws {
@@ -161,11 +160,22 @@ final class ControlServerStatusSoundTests: XCTestCase {
     private func makeServer(resolvedSound: NSSound?) {
         let gate = StatusSoundResolutionGate(sound: resolvedSound)
         self.gate = gate
-        player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : resolvedSound })
+        let barrier = playbackBarrier
+        player = StatusSoundPlayer(resolve: { name in
+            if name == "barrier" { return barrier }
+            return name == "held" ? gate.resolve() : resolvedSound
+        })
         server = ControlServer(library: library, actions: AppActions(library: library), settingsModel: settings,
                                identity: AppIdentity(version: "test", commit: "test"),
                                statusSoundPlayer: player,
                                socketPath: stateDir.appendingPathComponent("control.sock").path)
+    }
+
+    private func assertNoPlayback(file: StaticString = #filePath, line: UInt = #line) async {
+        let action = await player.action(for: "barrier")
+        action?()
+        await fulfillment(of: [playbackBarrier.log.playCalled], timeout: 2)
+        XCTAssertTrue(sound.log.calls.isEmpty, file: file, line: line)
     }
 
     private func update(target: String? = nil, soundName: String? = "held", status: AgentStatus = .blocked,

--- a/agtermTests/StatusSoundPlayerTests.swift
+++ b/agtermTests/StatusSoundPlayerTests.swift
@@ -67,7 +67,7 @@ final class StatusSoundPlayerTests: XCTestCase {
         XCTAssertFalse(resolved)
     }
 
-    func testCachedResolutionDoesNotWaitForBusyWorker() async throws {
+    func testCachedPlaybackDoesNotWaitForResolution() async throws {
         let sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
         let gate = StatusSoundResolutionGate(sound: nil)
         let player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : sound })
@@ -78,26 +78,55 @@ final class StatusSoundPlayerTests: XCTestCase {
         let lookup = Task {
             let action = await player.action(for: "cached")
             XCTAssertNotNil(action)
+            action?()
             cached.fulfill()
         }
-        await fulfillment(of: [cached], timeout: 2)
+        await fulfillment(of: [cached, sound.log.playCalled], timeout: 2)
         gate.release.signal()
         await lookup.value
         _ = await pending.value
     }
 
+    func testResolutionDoesNotWaitForBusyPlayback() async throws {
+        let busy = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+        let fresh = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+        let release = DispatchSemaphore(value: 0)
+        // a stuck playback queue outlives the test and would hang every later one
+        defer { release.signal() }
+        busy.log.holdPlay(until: release)
+        let player = StatusSoundPlayer(resolve: { name in name == "busy" ? busy : fresh })
+
+        let occupyAction = await player.action(for: "busy")
+        let occupy = try XCTUnwrap(occupyAction)
+        occupy()
+        await fulfillment(of: [busy.log.playCalled], timeout: 2)
+
+        let resolved = expectation(description: "a fresh name resolves while playback is held")
+        let lookup = Task {
+            let action = await player.action(for: "fresh")
+            XCTAssertNotNil(action)
+            resolved.fulfill()
+        }
+        await fulfillment(of: [resolved], timeout: 2)
+        release.signal()
+        await lookup.value
+    }
+
     func testPreviewDiscardsSelectionChangedDuringResolution() async throws {
         for replacement: String? in ["newer", nil] {
             let sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+            let barrier = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
             let gate = StatusSoundResolutionGate(sound: sound)
-            let player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : sound })
+            let player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : barrier })
             var selected: String? = "held"
             let pending = Task { await player.preview("held", ifCurrent: { selected == "held" }) }
             await fulfillment(of: [gate.started], timeout: 2)
             selected = replacement
             gate.release.signal()
             await pending.value
-            _ = await player.action(for: "barrier")
+            let action = await player.action(for: "barrier")
+            action?()
+            await fulfillment(of: [barrier.log.playCalled], timeout: 2)
             XCTAssertTrue(sound.log.calls.isEmpty)
         }
     }
@@ -148,19 +177,31 @@ final class PlaybackLog: @unchecked Sendable {
 
     private let lock = NSLock()
     private var recorded: [Call] = []
+    private var playHold: DispatchSemaphore?
 
     var calls: [Call] {
         lock.withLock { recorded }
     }
 
+    /// Block the caller's queue inside `play()` until `semaphore` is signalled, so a test can hold the
+    /// playback queue occupied while it exercises something that must not wait on it.
+    func holdPlay(until semaphore: DispatchSemaphore) {
+        lock.withLock { playHold = semaphore }
+    }
+
     func record(_ selector: String) {
-        lock.withLock { recorded.append(Call(selector: selector, onMainThread: Thread.isMainThread)) }
+        let hold = lock.withLock { () -> DispatchSemaphore? in
+            recorded.append(Call(selector: selector, onMainThread: Thread.isMainThread))
+            return selector == "play" ? playHold : nil
+        }
         if selector == "play" { playCalled.fulfill() }
+        if let hold { _ = hold.wait(timeout: .now() + 10) }
     }
 }
 
 final class StatusSoundResolutionGate: @unchecked Sendable {
     let started = XCTestExpectation(description: "resolver entered")
+    let completed = XCTestExpectation(description: "resolver finished")
     let release = DispatchSemaphore(value: 0)
     private let sound: NSSound?
     private let lock = NSLock()
@@ -173,6 +214,7 @@ final class StatusSoundResolutionGate: @unchecked Sendable {
     var finished: Bool { lock.withLock { didFinish } }
 
     func resolve() -> NSSound? {
+        defer { completed.fulfill() }
         lock.withLock { recordedMainThread = Thread.isMainThread }
         started.fulfill()
         if !Thread.isMainThread { _ = release.wait(timeout: .now() + 10) }

--- a/agtermTests/StatusSoundPlayerTests.swift
+++ b/agtermTests/StatusSoundPlayerTests.swift
@@ -14,39 +14,103 @@ final class StatusSoundPlayerTests: XCTestCase {
         await MainActor.run { player = StatusSoundPlayer() }
     }
 
-    func testUnknownSoundNameResolvesToNoAction() {
-        XCTAssertNil(player.action(for: "NoSuchSoundXYZ"), "an unresolvable name must report itself as such")
-        XCTAssertFalse(player.play("NoSuchSoundXYZ"), "play must fail so the control server can say 'unknown sound'")
+    func testUnknownSoundNameResolvesToNoAction() async {
+        let action = await player.action(for: "NoSuchSoundXYZ")
+        let played = await player.play("NoSuchSoundXYZ")
+        XCTAssertNil(action, "an unresolvable name must report itself as such")
+        XCTAssertFalse(played, "play must fail so the control server can say 'unknown sound'")
     }
 
-    func testEveryOfferedSoundNameResolves() {
+    func testEveryOfferedSoundNameResolves() async {
         for name in ["default", "beep"] + StatusSoundPlayer.standardNames {
-            XCTAssertNotNil(player.action(for: name), "the Settings picker offers \(name), so it must resolve")
+            let action = await player.action(for: name)
+            XCTAssertNotNil(action, "the Settings picker offers \(name), so it must resolve")
         }
     }
 
-    func testStartingAClipLeavesTheMainThread() throws {
+    func testStartingAClipLeavesTheMainThread() async throws {
         // #575: the first NSSound.play() of a process took ~0.9s, on the main actor
         let fixture = try registerRecordingSound()
-        let action = try XCTUnwrap(player.action(for: fixture.name))
+        let resolved = await player.action(for: fixture.name)
+        let action = try XCTUnwrap(resolved)
 
         action()
 
-        wait(for: [fixture.sound.log.playCalled], timeout: 2)
+        await fulfillment(of: [fixture.sound.log.playCalled], timeout: 2)
         let calls = fixture.sound.log.calls
         XCTAssertEqual(calls.map(\.selector), ["stop", "play"], "a replay must stop the clip before starting it")
         XCTAssertEqual(calls.filter(\.onMainThread), [], "neither call may run on the main thread")
     }
 
-    func testStartingACachedClipLeavesTheMainThread() throws {
+    func testStartingACachedClipLeavesTheMainThread() async throws {
         let fixture = try registerRecordingSound()
-        _ = player.action(for: fixture.name)
-        let cached = try XCTUnwrap(player.action(for: fixture.name))
+        _ = await player.action(for: fixture.name)
+        let resolved = await player.action(for: fixture.name)
+        let cached = try XCTUnwrap(resolved)
 
         cached()
 
-        wait(for: [fixture.sound.log.playCalled], timeout: 2)
+        await fulfillment(of: [fixture.sound.log.playCalled], timeout: 2)
+        XCTAssertEqual(fixture.sound.log.calls.map(\.selector), ["stop", "play"])
         XCTAssertEqual(fixture.sound.log.calls.filter(\.onMainThread), [], "the cached branch must hop off the main thread too")
+    }
+
+    func testResolutionLeavesMainActorFreeWhileWorkerIsHeld() async {
+        let gate = StatusSoundResolutionGate(sound: nil)
+        let player = StatusSoundPlayer(resolve: { _ in gate.resolve() })
+        let pending = Task { await player.action(for: "held") != nil }
+        await fulfillment(of: [gate.started], timeout: 2)
+        XCTAssertFalse(gate.onMainThread)
+        XCTAssertFalse(gate.finished)
+        gate.release.signal()
+        let resolved = await pending.value
+        XCTAssertFalse(resolved)
+    }
+
+    func testCachedResolutionDoesNotWaitForBusyWorker() async throws {
+        let sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+        let gate = StatusSoundResolutionGate(sound: nil)
+        let player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : sound })
+        _ = await player.action(for: "cached")
+        let pending = Task { await player.action(for: "held") != nil }
+        await fulfillment(of: [gate.started], timeout: 2)
+        let cached = expectation(description: "cache bypasses busy worker")
+        let lookup = Task {
+            let action = await player.action(for: "cached")
+            XCTAssertNotNil(action)
+            cached.fulfill()
+        }
+        await fulfillment(of: [cached], timeout: 2)
+        gate.release.signal()
+        await lookup.value
+        _ = await pending.value
+    }
+
+    func testPreviewDiscardsSelectionChangedDuringResolution() async throws {
+        for replacement: String? in ["newer", nil] {
+            let sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+            let gate = StatusSoundResolutionGate(sound: sound)
+            let player = StatusSoundPlayer(resolve: { name in name == "held" ? gate.resolve() : sound })
+            var selected: String? = "held"
+            let pending = Task { await player.preview("held", ifCurrent: { selected == "held" }) }
+            await fulfillment(of: [gate.started], timeout: 2)
+            selected = replacement
+            gate.release.signal()
+            await pending.value
+            _ = await player.action(for: "barrier")
+            XCTAssertTrue(sound.log.calls.isEmpty)
+        }
+    }
+
+    func testCurrentPreviewBypassesStatusThrottle() async throws {
+        let sound = try XCTUnwrap(RecordingSound(contentsOfFile: "/System/Library/Sounds/Tink.aiff", byReference: true))
+        sound.log.playCalled.expectedFulfillmentCount = 2
+        let player = StatusSoundPlayer(resolve: { _ in sound })
+        let played = await player.play("preview")
+        XCTAssertTrue(played)
+        await player.preview("preview", ifCurrent: { true })
+        await fulfillment(of: [sound.log.playCalled], timeout: 2)
+        XCTAssertEqual(sound.log.calls.map(\.selector), ["stop", "play", "stop", "play"])
     }
 
     /// A sound that records its own playback instead of making noise, published under a name unique to the
@@ -60,7 +124,7 @@ final class StatusSoundPlayerTests: XCTestCase {
     }
 }
 
-private final class RecordingSound: NSSound {
+final class RecordingSound: NSSound {
     let log = PlaybackLog()
 
     override func stop() -> Bool {
@@ -74,7 +138,7 @@ private final class RecordingSound: NSSound {
     }
 }
 
-private final class PlaybackLog: @unchecked Sendable {
+final class PlaybackLog: @unchecked Sendable {
     struct Call: Equatable {
         let selector: String
         let onMainThread: Bool
@@ -92,5 +156,27 @@ private final class PlaybackLog: @unchecked Sendable {
     func record(_ selector: String) {
         lock.withLock { recorded.append(Call(selector: selector, onMainThread: Thread.isMainThread)) }
         if selector == "play" { playCalled.fulfill() }
+    }
+}
+
+final class StatusSoundResolutionGate: @unchecked Sendable {
+    let started = XCTestExpectation(description: "resolver entered")
+    let release = DispatchSemaphore(value: 0)
+    private let sound: NSSound?
+    private let lock = NSLock()
+    private var recordedMainThread = false
+    private var didFinish = false
+
+    init(sound: NSSound?) { self.sound = sound }
+
+    var onMainThread: Bool { lock.withLock { recordedMainThread } }
+    var finished: Bool { lock.withLock { didFinish } }
+
+    func resolve() -> NSSound? {
+        lock.withLock { recordedMainThread = Thread.isMainThread }
+        started.fulfill()
+        if !Thread.isMainThread { _ = release.wait(timeout: .now() + 10) }
+        lock.withLock { didFinish = true }
+        return sound
     }
 }


### PR DESCRIPTION
finishes #575. The merged half moved status-sound playback off the main actor; `NSSound(named:)` was still resolving there, so a sound file on slow storage blocked keystroke delivery even though playback no longer did. The reporter showed that with a WebDAV mount at three seconds.

cache misses now resolve on a worker queue. Cache hits and `default`/`beep` still answer without suspending, so validation never queues behind an in-flight `play()`.

`session.status` becomes async, which is the part worth reviewing. It previously ran straight through, so making it suspend opens a window that did not exist before. The target is bound before the await, so a slow lookup racing a UI selection change cannot redirect an implicit `active` target. `unknown sound` still outranks a missing target. Session liveness is revalidated on resume, and pane ownership and `wasBlocked` are read at the mutation with no suspension in between. A session that moves windows during resolution is now rejected rather than written to, which is a behavior change.

an invalid Settings blocked default still does not reject the status update, refused writes still play no sound, and Settings previews drop a stale selection instead of sounding after a newer choice.

lookups have their own queue, separate from playback. Serial rather than concurrent, and that one is a judgement call: parallel lookups would let a slow blocked default overlap a later command's first lookup, which is a real if narrow benefit, but `NSSound(named:)` reads a shared registry with no documented concurrency guarantee and this app has never called it concurrently. The unverified assumption looked like the worse bet.

one limitation stays, and it is inherent rather than an oversight. Answering `unknown sound` in the response means the handler awaits a cold lookup, and the accept loop is inline, so that lookup still occupies it. Removing that would mean giving up synchronous validation. `.claude/rules/control-api.md` records the contract.

the tests pin the failure boundary rather than timing: an injected resolver held on the worker while the main actor makes progress, and silence proved by playing a barrier sound through the same queue instead of asserting an untouched fixture that the player never received.

Fix #575
