### PR TITLE
feat(titlebar): custom-commands button with a popover of keymap commands

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -230,8 +230,10 @@ paths:
   close and sidebar row close; skip under XCUITest. Control `session.close` must never prompt.
 - `hiddenInterfaceElements` stores raw names and preserves unknown values while toggling known ones; empty
   maps nil. Titlebar cases are `sidebarToggle`, `sessionName`, `windowName`, `remoteHost`, `sessionContext`,
-  `recentSessions`, `scratch`, `split`, `dashboard`, `quickTerminal`; sidebar cases are `newWorkspace`,
-  `newSession`, `flaggedView`, `focusFilter`, and row-level `workspaceAddSession`. Attention has its
+  `recentSessions`, `scratch`, `split`, `dashboard`, `quickTerminal`, `customCommands`; sidebar cases are
+  `newWorkspace`, `newSession`, `flaggedView`, `focusFilter`, and row-level `workspaceAddSession`.
+  A `hiddenByDefault` case (`customCommands` alone) is governed by `shownInterfaceElements` instead, the
+  same shape with the opposite sense, and its name in the hidden list is ignored. Attention has its
   separate default-off setting.
 - `InterfaceElement` owns section/display name; the tab iterates `allCases`. Mutate the raw set, then push
   resolved known values to `GhosttyApp`. SwiftUI gates with `shows(_:)`; the AppKit row "+" checks the

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -192,17 +192,20 @@ extension AppActions {
         return items
     }
 
-    /// The user-defined keymap commands as palette items with their bound chord; running one delegates to the
-    /// runner, which resolves the active session's context and spawns the shell line. `badge` tags each entry.
+    /// The user-defined keymap commands as palette items with their bound chord. `badge` tags each entry.
     private func customCommandItems(badge: String?) -> [PaletteItem] {
         (settingsModel?.keymap.commands ?? []).map { command in
             PaletteItem(id: "custom-\(command.id)", title: command.name,
                         shortcut: command.shortcut.isEmpty ? nil : command.shortcut,
-                        badge: badge) { [weak self] in
-                guard self?.uiActionsEnabled == true else { return }
-                self?.customCommandRunner?.run(command)
-            }
+                        badge: badge) { [weak self] in self?.runCustomCommand(command) }
         }
+    }
+
+    /// Run a keymap command picked from the palette or the title-bar popover, behind the same modal gate as
+    /// every UI action; the runner resolves the active session's context and spawns the shell line.
+    func runCustomCommand(_ command: CustomCommand) {
+        guard uiActionsEnabled else { return }
+        customCommandRunner?.run(command)
     }
 
     /// The user-defined keymap commands alone, for the `.customCommands` palette: unbadged, all are custom.

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -255,9 +255,15 @@ final class SettingsModel {
     /// window re-gates live. Mutates the RAW string set: `resolvedHiddenInterfaceElements` drops unknown
     /// names, which would erase an element a newer build hid.
     func setInterfaceElementVisible(_ element: InterfaceElement, visible: Bool) {
-        var hidden = Set(settings.hiddenInterfaceElements ?? [])
-        if visible { hidden.remove(element.rawValue) } else { hidden.insert(element.rawValue) }
-        settings.hiddenInterfaceElements = hidden.isEmpty ? nil : hidden.sorted()
+        if element.hiddenByDefault {
+            var shown = Set(settings.shownInterfaceElements ?? [])
+            if visible { shown.insert(element.rawValue) } else { shown.remove(element.rawValue) }
+            settings.shownInterfaceElements = shown.isEmpty ? nil : shown.sorted()
+        } else {
+            var hidden = Set(settings.hiddenInterfaceElements ?? [])
+            if visible { hidden.remove(element.rawValue) } else { hidden.insert(element.rawValue) }
+            settings.hiddenInterfaceElements = hidden.isEmpty ? nil : hidden.sorted()
+        }
         persistAndApply()
     }
 

--- a/agterm/Views/WindowContentView+CustomCommands.swift
+++ b/agterm/Views/WindowContentView+CustomCommands.swift
@@ -1,0 +1,133 @@
+import agtermCore
+import AppKit
+import SwiftUI
+
+/// Title-bar custom-commands button and its popover, the mouse form of the ⌃⇧O palette (#570): every
+/// `keymap.conf` command as a clickable row with its chord, in file order so a row never moves under a
+/// learned mouse position. Split out of `WindowContentView` like `+RecentSessions`, whose button it mirrors.
+extension WindowContentView {
+    /// Title-bar button opening the custom-commands popover. Disabled/dimmed with no parsed command or no
+    /// active session: the runner ignores a command fired without one, so every row would silently no-op.
+    /// Opening a popover is interactive-only, so it is control-API keep-in-sync exempt like the clock and bell.
+    var customCommandsButton: some View {
+        let commands = actions.settingsModel?.keymap.commands ?? []
+        let enabled = !commands.isEmpty && store.activeSession != nil && !pick.modalPending
+        return Button {
+            guard !pick.modalPending else { return }
+            customCommandsShown.toggle()
+        } label: {
+            Label("Custom commands", systemImage: "ellipsis.circle")
+        }
+        .help(helpHint("Custom commands", .customCommandPalette))
+        .foregroundStyle(chromeText)
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.35)
+        .accessibilityIdentifier("custom-commands-button")
+        .popover(isPresented: $customCommandsShown, arrowEdge: .bottom) {
+            customCommandsPopover(commands)
+        }
+        .onChange(of: customCommandsShown) { _, shown in
+            // suppress auto-follow while open, counted like the clock and bell popovers so it stays balanced.
+            if shown { store.suppressAutoFollow() } else { store.resumeAutoFollow() }
+        }
+        .onChange(of: enabled) { _, isEnabled in
+            // a keymap reload emptying the list, or the last session exiting, fires no outside-click dismiss;
+            // close so no sliver lingers under the now-disabled button.
+            if !isEnabled { customCommandsShown = false }
+        }
+    }
+
+    /// The popover body: the commands in keymap order, in a list that scrolls past a cap since the keymap
+    /// has none, as wide as its longest row between a floor and the recent-sessions popover's width. Tinted
+    /// like that popover.
+    private func customCommandsPopover(_ commands: [CustomCommand]) -> some View {
+        let metrics = GhosttyApp.shared.interfaceMetrics
+        return ScrollView {
+            VStack(spacing: 2) {
+                ForEach(commands) { customCommandRow($0) }
+            }
+            .padding(6)
+        }
+        .frame(width: CustomCommandPopoverRow.fittedWidth(for: commands, metrics: metrics))
+        .frame(maxHeight: metrics.scaled(400))
+        .background(terminalColor)
+        .presentationBackground(terminalColor)
+    }
+
+    private func customCommandRow(_ command: CustomCommand) -> some View {
+        CustomCommandPopoverRow(title: command.name, shortcut: command.shortcut.isEmpty ? nil : command.shortcut,
+                                foreground: chromeText, hoverColor: popoverHoverColor) { runFromPopover(command) }
+    }
+
+    /// Commit a row click: note activity (so auto-follow can't pull the selection away), run the command
+    /// through the palette's gate, return focus to the terminal and close the popover.
+    private func runFromPopover(_ command: CustomCommand) {
+        guard !pick.modalPending else { return }
+        store.noteUserActivity()
+        actions.runCustomCommand(command)
+        actions.focusActiveSession()
+        customCommandsShown = false
+    }
+}
+
+/// One clickable command row for the custom-commands popover: the name at the palette's title size, the raw
+/// kitty chord right-aligned like the palette's shortcut hint, a pointer-hover highlight and a full-row hit
+/// area. Kept a `Button` so it reads as an actionable control to VoiceOver.
+private struct CustomCommandPopoverRow: View {
+    let title: String
+    let shortcut: String?
+    let foreground: Color
+    let hoverColor: Color
+    let onSelect: () -> Void
+    @State private var hovering = false
+    private let metrics = GhosttyApp.shared.interfaceMetrics
+
+    /// The gap between a name and its chord, and the row's side padding, shared with `fittedWidth`.
+    private static let gap: CGFloat = 12
+    private static let sidePadding: Double = 12
+
+    /// The popover width that fits the widest row (name, gap, chord, paddings) between a floor and the
+    /// recent-sessions popover's 320, measured with the row fonts so nothing truncates below the cap.
+    static func fittedWidth(for commands: [CustomCommand], metrics: InterfaceMetrics) -> CGFloat {
+        let title = NSFont.systemFont(ofSize: metrics.base)
+        let chord = NSFont.systemFont(ofSize: metrics.shortcut)
+        // each text is rounded up on its own, as SwiftUI lays it out; the spacer sits in every row, chord
+        // or not, so its minimum always counts.
+        let widest = commands.map { command -> CGFloat in
+            var width = (command.name as NSString).size(withAttributes: [.font: title]).width.rounded(.up) + gap
+            if !command.shortcut.isEmpty {
+                width += (command.shortcut as NSString).size(withAttributes: [.font: chord]).width.rounded(.up)
+            }
+            return width
+        }.max() ?? 0
+        // the row's own side padding twice, plus the list's 6-point inset on each side.
+        let chrome = CGFloat(metrics.scaled(sidePadding)) * 2 + 12
+        return min(CGFloat(metrics.scaled(320)), max(CGFloat(metrics.scaled(180)), widest + chrome))
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack {
+                Text(title)
+                    .font(.system(size: metrics.base))
+                    .foregroundStyle(foreground)
+                    .lineLimit(1).truncationMode(.middle)
+                Spacer(minLength: Self.gap)
+                if let shortcut {
+                    Text(shortcut)
+                        .font(.system(size: metrics.shortcut))
+                        .foregroundStyle(foreground.opacity(0.6))
+                }
+            }
+            .padding(.horizontal, metrics.scaled(Self.sidePadding))
+            .padding(.vertical, metrics.scaled(6))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(hovering ? hoverColor : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .accessibilityIdentifier("custom-command-row")
+    }
+}

--- a/agterm/Views/WindowContentView+RecentSessions.swift
+++ b/agterm/Views/WindowContentView+RecentSessions.swift
@@ -80,15 +80,16 @@ extension WindowContentView {
                 statusColorHex: nil,
                 statusShape: nil,
                 foreground: chromeText,
-                hoverColor: recentSelectionColor,
+                hoverColor: popoverHoverColor,
                 accessibilityID: "recent-session-row"
             ) { selectRecent(id) }
         }
     }
 
-    /// The hover-highlight color for a popover row: the terminal theme's selection background (the color the
-    /// selected sidebar row uses), or a subtle wash of the foreground when the theme sets no selection color.
-    private var recentSelectionColor: Color {
+    /// The hover-highlight color for a title-bar popover row: the terminal theme's selection background (the
+    /// color the selected sidebar row uses), or a subtle wash of the foreground when the theme sets no
+    /// selection color. Shared with the custom-commands popover.
+    var popoverHoverColor: Color {
         if let sel = GhosttyApp.shared.terminalSelectionBackgroundColor {
             return Color(nsColor: sel).opacity(0.5)
         }
@@ -158,7 +159,7 @@ extension WindowContentView {
                     statusColorHex: session.agentIndicator.color,
                     statusShape: session.agentIndicator.shape,
                     foreground: chromeText,
-                    hoverColor: recentSelectionColor,
+                    hoverColor: popoverHoverColor,
                     accessibilityID: "attention-session-row"
                 ) { selectAttention(session.id) }
             }

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -42,8 +42,8 @@ extension WindowContentView {
 
     /// Custom titlebar row replacing the system toolbar: the sidebar toggle pinned to the sidebar's trailing
     /// edge (by the divider), the title at the terminal's start, and the trailing cluster (recent-sessions /
-    /// attention popovers, divider, scratch / split controls, divider, dashboard / quick terminal). Positions
-    /// track `sidebarWidth`; the left inset clears the system traffic lights.
+    /// attention popovers, divider, scratch / split controls, divider, dashboard / quick terminal / custom
+    /// commands). Positions track `sidebarWidth`; the left inset clears the system traffic lights.
     private var titlebarRow: some View {
         HStack(spacing: 0) {
             Color.clear.frame(width: 78).allowsHitTesting(false) // system traffic lights
@@ -87,9 +87,10 @@ extension WindowContentView {
     }
 
     /// The title bar's trailing action cluster, each button gated by its Interface toggle: recent-sessions /
-    /// attention popovers, per-session scratch / split controls, window-overlay dashboard / quick terminal.
-    /// A separator sits ONLY where two groups that each still show 2+ buttons meet, so a group reduced to one
-    /// button flows in unbracketed and an empty group lets its neighbors meet directly.
+    /// attention popovers, per-session scratch / split controls, window-overlay dashboard / quick terminal
+    /// and the custom-commands popover. A separator sits ONLY where two groups that each still show 2+
+    /// buttons meet, so a group reduced to one button flows in unbracketed and an empty group lets its
+    /// neighbors meet directly.
     private var titlebarTrailingActions: some View {
         let showRecent = shows(.recentSessions)
         let showAttention = attentionButtonEnabled // the bell keeps its own separate Notifications setting
@@ -97,9 +98,10 @@ extension WindowContentView {
         let showSplit = shows(.split)
         let showDashboard = shows(.dashboard)
         let showQuick = shows(.quickTerminal)
+        let showCustom = shows(.customCommands)
         let countA = (showRecent ? 1 : 0) + (showAttention ? 1 : 0)
         let countB = (showScratch ? 1 : 0) + (showSplit ? 1 : 0)
-        let countC = (showDashboard ? 1 : 0) + (showQuick ? 1 : 0)
+        let countC = (showDashboard ? 1 : 0) + (showQuick ? 1 : 0) + (showCustom ? 1 : 0)
         // a separator only between two 2+-button groups (the host-free rule, unit-tested in agtermCore).
         let dividers = InterfaceElement.titlebarGroupDividers(countA: countA, countB: countB, countC: countC)
         return HStack(spacing: 14) {
@@ -111,6 +113,7 @@ extension WindowContentView {
             if dividers.afterB { titlebarDivider }
             if showDashboard { dashboardButton.labelStyle(.iconOnly) }
             if showQuick { quickTerminalButton.labelStyle(.iconOnly) }
+            if showCustom { customCommandsButton.labelStyle(.iconOnly) }
         }
         .padding(.trailing, 14)
     }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -87,6 +87,9 @@ struct WindowContentView: View {
     /// Whether the attention popover (the mouse equivalent of the ⌃⇧I attention palette) is shown, anchored
     /// on the title-bar bell. Non-private so the `+RecentSessions` extension's bell/rows can toggle it.
     @State var attentionPopoverShown = false
+    /// Whether the custom-commands popover (the mouse form of the ⌃⇧O palette) is shown, anchored on its
+    /// title-bar button. Non-private so the `+CustomCommands` extension's button/rows can toggle it.
+    @State var customCommandsShown = false
     /// Sidebar width and visibility live on the per-window `AppStore`, persisted in `Snapshot` and shared
     /// with the toolbar button, View menu, palette and the `sidebar` control command.
     /// Height of the custom titlebar row: title + cwd normal, one short line compact, zero hidden (an
@@ -192,14 +195,15 @@ struct WindowContentView: View {
         // return first responder to this window's terminal after every resolution path.
         .onChange(of: pick.modalPending) { old, new in
             if !old, new, !pickSuppressesAutoFollow {
-                // a socket-driven picker may arrive with either title-bar popover already open; dismiss
-                // both so no second interactive surface remains above the modal picker. The quick-terminal
+                // a socket-driven picker may arrive with a title-bar popover already open; dismiss them
+                // all so no second interactive surface remains above the modal picker. The quick-terminal
                 // panel is now exactly that surface and the worst of them: it floats above every window and
                 // holds key, so the picker would open under it with neither the screen nor the keyboard.
                 // `canShow` stops the reverse order; this is the same class from the other direction.
                 QuickTerminalController.shared.hide()
                 recentSessionsShown = false
                 attentionPopoverShown = false
+                customCommandsShown = false
                 store.suppressAutoFollow()
                 pickSuppressesAutoFollow = true
             } else if old, !new, pickSuppressesAutoFollow {

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -21,9 +21,10 @@ public enum DockBounce: String, Codable, Sendable, CaseIterable {
     case untilFocused
 }
 
-/// A toggleable title-bar or sidebar chrome element, persisted by raw name in
-/// `AppSettings.hiddenInterfaceElements` (an unknown stored name is dropped, not fatal). Shown by
-/// default; hiding adds its raw name.
+/// A toggleable title-bar or sidebar chrome element, persisted by raw name (an unknown stored name is
+/// dropped, not fatal). Shown by default, and hiding adds its raw name to
+/// `AppSettings.hiddenInterfaceElements`; a `hiddenByDefault` element inverts that, and showing it adds
+/// its raw name to `AppSettings.shownInterfaceElements`.
 public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     // title bar
     case sidebarToggle
@@ -36,6 +37,7 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     case split
     case dashboard
     case quickTerminal
+    case customCommands
     // sidebar
     case newWorkspace
     case newSession
@@ -54,6 +56,9 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
         }
     }
 
+    /// Whether the element starts hidden, so its toggle reads off until the user opts in.
+    public var hiddenByDefault: Bool { self == .customCommands }
+
     /// The human-facing toggle label shown in the Interface settings tab.
     public var displayName: String {
         switch self {
@@ -67,6 +72,7 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
         case .split: return "Split view"
         case .dashboard: return "Dashboard"
         case .quickTerminal: return "Quick terminal"
+        case .customCommands: return "Custom commands"
         case .newWorkspace: return "New workspace"
         case .newSession: return "New session"
         case .flaggedView: return "Flagged view"
@@ -76,8 +82,9 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     }
 
     /// Which of the two title-bar trailing-cluster separators to draw, from each group's visible button
-    /// count (A = recent-sessions + attention, B = scratch + split, C = dashboard + quick-terminal): one
-    /// sits ONLY where two groups that each still show 2+ buttons meet. Host-free so it is unit-testable.
+    /// count (A = recent-sessions + attention, B = scratch + split, C = dashboard + quick-terminal +
+    /// custom-commands): one sits ONLY where two groups that each still show 2+ buttons meet. Host-free so
+    /// it is unit-testable.
     public static func titlebarGroupDividers(countA: Int, countB: Int, countC: Int) -> (afterA: Bool, afterB: Bool) {
         let afterA = countA >= 2 && countB >= 2
         let afterB = (countB >= 2 && countC >= 2) || (countA >= 2 && countC >= 2 && countB == 0)
@@ -290,9 +297,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// The share of the focused screen the quick-terminal panel takes, as a percentage; nil keeps the
     /// built-in size. `QuickTerminalMetrics.panelSize` resolves and clamps it.
     public var quickTerminalSizePercent: Int?
-    /// Raw names of the chrome elements the user has HIDDEN (see `InterfaceElement`); nil/empty shows
-    /// everything. Unknown names are dropped by `resolvedHiddenInterfaceElements`.
+    /// Raw names of the default-shown chrome elements the user has HIDDEN (see `InterfaceElement`);
+    /// nil/empty shows them all. Unknown names are dropped by `resolvedHiddenInterfaceElements`.
     public var hiddenInterfaceElements: [String]?
+    /// Raw names of the `hiddenByDefault` chrome elements the user has SHOWN; nil/empty keeps them hidden.
+    public var shownInterfaceElements: [String]?
     /// Whether, with more than one window open, only the frontmost shows its sidebar and every other
     /// collapses its own; nil = off. Visibility then follows window focus, so a manual per-window hide is
     /// transient — the frontmost window re-shows its sidebar on refocus.
@@ -322,7 +331,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 autoFollowAttention: String? = nil,
                 autoFollowStayOnActive: Bool? = nil, sidebarFontSize: Double? = nil,
                 interfaceFontSize: Double? = nil, quickTerminalSizePercent: Int? = nil,
-                hiddenInterfaceElements: [String]? = nil,
+                hiddenInterfaceElements: [String]? = nil, shownInterfaceElements: [String]? = nil,
                 autoHideSidebarInactiveWindows: Bool? = nil, welcomeShown: Bool? = nil) {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
@@ -366,6 +375,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.interfaceFontSize = interfaceFontSize
         self.quickTerminalSizePercent = quickTerminalSizePercent
         self.hiddenInterfaceElements = hiddenInterfaceElements
+        self.shownInterfaceElements = shownInterfaceElements
         self.autoHideSidebarInactiveWindows = autoHideSidebarInactiveWindows
         self.welcomeShown = welcomeShown
     }
@@ -383,10 +393,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
 
     /// The hidden chrome elements, unknown (future-written) raw names dropped. The single read point.
     public var resolvedHiddenInterfaceElements: Set<InterfaceElement> {
-        Set((hiddenInterfaceElements ?? []).compactMap(InterfaceElement.init(rawValue:)))
+        let hidden = Set((hiddenInterfaceElements ?? []).compactMap(InterfaceElement.init(rawValue:)))
+        let shown = Set((shownInterfaceElements ?? []).compactMap(InterfaceElement.init(rawValue:)))
+        return Set(InterfaceElement.allCases.filter { $0.hiddenByDefault ? !shown.contains($0) : hidden.contains($0) })
     }
 
-    /// Whether a chrome element is hidden; anything absent from the persisted list reads as visible.
+    /// Whether a chrome element is hidden; an element absent from both persisted lists is at its default.
     public func isInterfaceElementHidden(_ element: InterfaceElement) -> Bool {
         resolvedHiddenInterfaceElements.contains(element)
     }

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -624,12 +624,13 @@ struct AppSettingsTests {
         #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
-    @Test func hiddenInterfaceElementsDefaultsNilAndShowsEverything() {
+    @Test func hiddenInterfaceElementsDefaultsNilAndShowsEverythingNotHiddenByDefault() {
         let settings = AppSettings()
         #expect(settings.hiddenInterfaceElements == nil)
-        #expect(settings.resolvedHiddenInterfaceElements.isEmpty)
+        #expect(settings.shownInterfaceElements == nil)
+        #expect(settings.resolvedHiddenInterfaceElements == [.customCommands])
         for element in InterfaceElement.allCases {
-            #expect(!settings.isInterfaceElementHidden(element))
+            #expect(settings.isInterfaceElementHidden(element) == element.hiddenByDefault)
         }
     }
 
@@ -681,6 +682,23 @@ struct AppSettingsTests {
         #expect(!hidden.isInterfaceElementHidden(.flaggedView))
     }
 
+    @Test func customCommandsIsAHiddenByDefaultTitleBarInterfaceElement() throws {
+        #expect(InterfaceElement.customCommands.section == .titleBar)
+        #expect(InterfaceElement.customCommands.displayName == "Custom commands")
+        #expect(InterfaceElement.allCases.filter(\.hiddenByDefault) == [.customCommands])
+        let shown = AppSettings(shownInterfaceElements: ["customCommands"])
+        #expect(!shown.isInterfaceElementHidden(.customCommands))
+        #expect(!shown.isInterfaceElementHidden(.dashboard))
+        #expect(shown.resolvedHiddenInterfaceElements.isEmpty)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(shown))
+        #expect(decoded == shown)
+        // the shown list alone governs a hidden-by-default element; an unknown name there is dropped too.
+        let hidden = AppSettings(hiddenInterfaceElements: ["customCommands", "dashboard"], shownInterfaceElements: ["teleporter"])
+        #expect(hidden.isInterfaceElementHidden(.customCommands))
+        #expect(hidden.isInterfaceElementHidden(.dashboard))
+        #expect(hidden.resolvedHiddenInterfaceElements == [.customCommands, .dashboard])
+    }
+
     @Test func unknownInterfaceElementDecodesTolerantly() throws {
         // forward-compat rule: an unknown name is dropped from the resolved set and must not fail the
         // whole decode.
@@ -688,7 +706,7 @@ struct AppSettingsTests {
             AppSettings.self,
             from: Data(#"{ "hiddenInterfaceElements": ["scratch", "teleporter"], "fontSize": 16 }"#.utf8))
         #expect(decoded.fontSize == 16)
-        #expect(decoded.resolvedHiddenInterfaceElements == [.scratch])
+        #expect(decoded.resolvedHiddenInterfaceElements == [.scratch, .customCommands])
         #expect(decoded.isInterfaceElementHidden(.scratch))
     }
 
@@ -709,6 +727,8 @@ struct AppSettingsTests {
         (2, 0, 2, false, true),  // empty B: a full A and a full C meet directly
         (2, 1, 2, false, false), // lone B between two full groups: no bridge, no dividers
         (2, 2, 1, true, false),  // lone C: divider only between the two full A/B groups
+        (1, 2, 3, false, true),  // full three-button C: the same single divider as the two-button default
+        (2, 1, 3, false, false), // lone B before a full three-button C: still no bridge
         (0, 2, 2, false, true),  // empty A: divider only between B and C
         (0, 0, 2, false, false), // only C present: no dividers at the leading edge
         (2, 2, 0, true, false),  // empty C: divider only between A and B

--- a/agtermUITests/CustomCommandsButtonUITests.swift
+++ b/agtermUITests/CustomCommandsButtonUITests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+/// End-to-end tests for the title-bar custom-commands button, the mouse form of ⌃⇧O (#570). It is off by
+/// default and opts in through `shownInterfaceElements`; it enables only with parsed commands and an active
+/// session; its popover lists every command with its chord in keymap order.
+///
+/// SCOPE NOTE: as for the recent-sessions button, a synthesized click on a row inside the `NSPopover` fires
+/// nothing, so the row → run glue is verified by hand.
+@MainActor
+final class CustomCommandsButtonUITests: ControlAPITestCase {
+    override var seededSettings: [String: Any]? {
+        name.contains("HiddenByDefault") ? nil : ["shownInterfaceElements": ["customCommands"]]
+    }
+
+    func testButtonIsHiddenByDefault() {
+        XCTAssertTrue(app.buttons["dashboard-toggle-button"].waitForExistence(timeout: 10), "the title bar should render")
+        XCTAssertFalse(app.buttons["custom-commands-button"].exists,
+                       "the custom-commands button should stay off until Settings ▸ Interface opts in")
+    }
+
+    func testButtonEnablesWithCommandsAndListsThemWithChords() throws {
+        let button = app.buttons["custom-commands-button"]
+        XCTAssertTrue(button.waitForExistence(timeout: 10), "opting in should render the custom-commands button")
+        XCTAssertFalse(button.isEnabled, "an empty keymap should disable the custom-commands button")
+
+        try relaunch(withKeymap: """
+        command "Touch One" cmd+shift+e touch '\(markerDir.path)/one'
+        command "Touch Two" touch '\(markerDir.path)/two'
+
+        """)
+        XCTAssertTrue(pollEnabled(button, true, timeout: 10), "parsed commands should enable the button")
+
+        let rows = app.buttons.matching(identifier: "custom-command-row")
+        openPopover(button, until: rows.firstMatch, timeout: 10)
+        XCTAssertEqual(rows.count, 2, "the popover should list both commands")
+        let first = rows.element(boundBy: 0).label
+        XCTAssertTrue(first.contains("Touch One"), "rows keep keymap order, got: \(first)")
+        XCTAssertTrue(first.contains("cmd+shift+e"), "a bound command shows its chord, got: \(first)")
+        XCTAssertTrue(rows.element(boundBy: 1).label.contains("Touch Two"), "an unbound command lists too")
+    }
+
+    /// (Re)opens the popover until `row` appears. The transient popover can dismiss before the first
+    /// snapshot, so retry the open; a click is only issued while no row is showing, so it never toggles an
+    /// already-open popover shut.
+    private func openPopover(_ button: XCUIElement, until row: XCUIElement, timeout: TimeInterval) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, !row.exists {
+            button.click()
+            if row.waitForExistence(timeout: 1) { return }
+        }
+        XCTAssertTrue(row.exists, "clicking the button should open the popover with its rows")
+    }
+
+    /// Polls until `element`'s enabled state matches `expected` (the live observation lag after a relaunch
+    /// or a keymap change), bounded by `timeout`.
+    private func pollEnabled(_ element: XCUIElement, _ expected: Bool, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if element.exists, element.isEnabled == expected { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        return element.exists && element.isEnabled == expected
+    }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -642,7 +642,10 @@
               <strong style="color: #e6e1d7">Navigate &#9656; Custom Commands</strong> palette,
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ctrl+a&gt;o</span> is the chord that
               fires it &mdash; Ctrl-A, then O &mdash; and everything after that is an ordinary shell line. The chord is
-              optional: leave it out and the action exists in the palette only.
+              optional: leave it out and the action exists in the palette only. For a mouse path, turn on the
+              <strong style="color: #e6e1d7">Custom commands</strong> title-bar button in Settings &#9656; Interface: it
+              lists the same commands with their chords in a popover, in the order of the file, so put the ones
+              you reach for most first.
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 16px 0 0">
               The building block is <strong style="color: #e6e1d7">session context</strong>. Every custom command is handed the
@@ -1454,7 +1457,8 @@
                   >›</span
                 ><strong style="color: #e6e1d7">Interface</strong> — turn individual chrome controls on or off (each shown by
                 default): in the title bar the sidebar toggle, the session name, the window name, the remote host, the
-                session context, and the recent-sessions, scratch, split, dashboard, and quick-terminal buttons; in the sidebar the new-workspace, new-session,
+                session context, the recent-sessions, scratch, split, dashboard, and quick-terminal buttons, and the custom-commands
+                button (the one control off by default); in the sidebar the new-workspace, new-session,
                 flagged-view, and workspace-filter footer buttons plus the per-workspace add-session + revealed on hover. A
                 <strong style="color: #e6e1d7">Multiple Windows</strong> option (off by default) shows the sidebar only in
                 the frontmost window and collapses it on every other, so switching windows moves the sidebar with focus.


### PR DESCRIPTION
adds a hidden-by-default title-bar button that lists every `keymap.conf` command with its chord in a popover, the mouse form of Navigate ▸ Custom Commands. Switch it on in Settings ▸ Interface. Rows keep the file's order and do not reorder with use; the popover fits its longest row up to the recent-sessions popover's width and scrolls past a height cap. A row runs through the same modal gate as a palette pick and returns focus to the terminal. The button is disabled with no commands or no active session.

`InterfaceElement` gets its first hidden-by-default case, stored in a new `shownInterfaceElements` settings list, so the Interface toggle reads off until opted in. Opening a popover is interactive-only, control-API exempt like the recent-sessions and attention buttons.

https://github.com/umputun/agterm/discussions/570 asked for keymap-defined toolbar buttons, which I declined. This is the app-owned button that gives mouse access to custom commands without a toolbar the keymap can edit.
