### PR TITLE
fix(sessions): widen close reselection when local history is empty

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -6,6 +6,7 @@ paths:
   - "agterm/Views/Palette.swift"
   - "agterm/Views/PaneShortcuts.swift"
   - "agterm/Views/SessionSwitcher.swift"
+  - "agtermCore/Sources/agtermCore/AppStore+CloseReselection.swift"
   - "agtermCore/Sources/agtermCore/PaletteCatalog.swift"
   - "agtermCore/Sources/agtermCore/RecencyStack.swift"
   - "agtermCore/Sources/agtermCore/Fuzzy.swift"
@@ -170,15 +171,25 @@ paths:
   no-op. The divert is gated on `close_session` still holding ⌘W, the same condition
   `applyCloseSessionChord` splits on: rebound off it, the stock item takes the chord back and the
   auxiliary window closes itself, so the new chord keeps its labelled meaning.
-- All active-session close paths use host-free `closeReselectionTarget` (Discussion #147). Prefer the most
-  recent survivor in three widening scopes: same workspace intersected with `navigableSessions`, all
-  navigable sessions, then the whole tree. Build scopes from the post-removal tree; soft close retains
-  recency until grace finalization for undo.
-- This preserves the current workspace when possible, remains inside flagged/focused views while they
-  contain survivors, and lets `disableFocusIfSelectionOutsideSet` reveal a whole-tree fallback while
-  preserving membership.
-- If MRU is empty, narrowed modes use `nearestInScopeTarget` over flattened sidebar order; unfiltered tree
-  uses the sole `reselectionTarget` caller. Do not choose the first flagged row because it destroys locality.
+- All active-session close paths use host-free `closeReselectionTarget` (Discussion #147). Ask recency per
+  level, narrowest first: same workspace intersected with `navigableSessions`, then `navigableSessions`,
+  then the whole tree ONLY while nothing is navigable. Build every level from the post-removal tree; soft
+  close retains recency until grace finalization for undo, and only the tree-derived sets keep the closing
+  session out of the pick.
+- This keeps the current workspace while it holds a REMEMBERED survivor, and stays inside flagged/focused
+  views while they hold one. A workspace whose survivors were never visited MAY yield, and only when
+  `navigableSessions` holds a remembered session elsewhere: under a single-workspace focus the two levels
+  are the same set, so the walk still takes it even with a remembered session outside the filter.
+  `session new --no-select` leaves tabs unremembered until first visit, so a script-filled workspace is
+  normally in that state.
+- The whole-tree level stays gated on an empty navigable set, because outside it a pick strands the
+  selection off the navigation set in `.flagged` (`disableFocusIfSelectionOutsideSet` returns early there)
+  and drops the user's focus filter in `.tree` (that same net fires and reveals the pick).
+- If no level remembers anyone, narrowed modes use `nearestInScopeTarget` over flattened sidebar order;
+  unfiltered tree uses the sole `reselectionTarget` caller. Do not choose the first flagged row because it
+  destroys locality.
+- The selection moves `currentWorkspaceID` with it (`selectedSessionID.didSet` clears `freshWorkspaceID`),
+  so a cross-workspace pick retargets workspace-scoped `--target active` (`session new`, `workspace focus`).
   Closing the last flagged session widens to the whole tree rather than leaving no terminal.
 - Workspace removal uses `workspaceRemovalTarget`: most recent visible, then first visible, then positional.
   Preserve `softCloseSessions.removedBeforeActive` for fallback index adjustment. The named

--- a/agtermCore/Sources/agtermCore/AppStore+CloseReselection.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+CloseReselection.swift
@@ -3,28 +3,30 @@ import Foundation
 extension AppStore {
     /// Picks the next selection after CLOSING the active session at `location`: the most-recently-active
     /// surviving session, else a positional walk.
-    /// The MRU scope narrows to the closing session's own workspace ∩ the VISIBLE set (`navigableSessions`,
-    /// so both the flagged list and the focus filter apply) — an unscoped survivor could yank the user into
-    /// another workspace, and a pick the sidebar isn't rendering would strand the selection. Exhausting a
-    /// scope widens through three levels: that workspace's visible sessions, everything visible, the whole
-    /// tree. Only a widened scope with no recency falls to a positional walk, and while any narrowing is
-    /// applied that is the flattened in-scope walk over the widened scope, not `reselectionTarget` —
-    /// `narrowed` keys on the MODE, so it stays true after the widening.
-    /// A pick outside the marked set meets each caller's `disableFocusIfSelectionOutsideSet`. The scope is
-    /// built from the TREE, so a session already removed cannot come back even while it survives in
-    /// `sessionRecency` (the soft-close paths keep it there for undo).
+    /// Recency is asked per level, narrowest first - the closing session's workspace ∩ the VISIBLE set
+    /// (`navigableSessions`, so flagged and focus both apply), then that visible set - so a REMEMBERED
+    /// local survivor wins, and a workspace that remembers nobody yields only when the visible set holds a
+    /// remembered session elsewhere - under a single-workspace narrowing the two levels coincide, so the
+    /// walk still takes it. The whole tree is asked only while nothing is visible, because outside the visible set a
+    /// pick has no good end in either mode: in `.flagged` it sits off the navigation set with
+    /// `disableFocusIfSelectionOutsideSet` returning early, and in `.tree` that same net drops the user's
+    /// focus filter to reveal it.
+    /// Remembering nobody anywhere falls to the positional walk - in-scope over `walkScope` while a
+    /// narrowing applies (`narrowed` keys on the MODE, so it holds however wide `walkScope` ends up), else
+    /// `reselectionTarget`. Every set here is built from the TREE, so a session already removed cannot come
+    /// back while it survives in `sessionRecency` for undo.
     func closeReselectionTarget(after location: (workspaceIndex: Int, sessionIndex: Int)) -> UUID? {
         let visible = Set(navigableSessions.map(\.id))
         let everything = Set(workspaces.flatMap(\.sessions).map(\.id))
         let inWorkspace = Set(workspaces[location.workspaceIndex].sessions.map(\.id))
         let sameWorkspace = inWorkspace.intersection(visible)
-        // the whole-tree level is what makes "widen when exhausted" mean widen: without it an emptied
-        // visible scope falls to a positional jump into the first workspace.
-        let scope = sameWorkspace.isEmpty ? (visible.isEmpty ? everything : visible) : sameWorkspace
-        if let recent = sessionRecency.top(1, in: scope).first { return recent }
-        // reachable with no recency at all, e.g. the first close after a restore.
+        if let recent = sessionRecency.top(1, in: sameWorkspace).first { return recent }
+        if let recent = sessionRecency.top(1, in: visible).first { return recent }
+        if visible.isEmpty, let recent = sessionRecency.top(1, in: everything).first { return recent }
+        // reachable with recency that names nothing at any level, e.g. the first close after a restore.
         let narrowed = sidebarMode == .flagged || focusEnabled
-        if narrowed, let inScope = nearestInScopeTarget(after: location, scope: scope) {
+        let walkScope = sameWorkspace.isEmpty ? (visible.isEmpty ? everything : visible) : sameWorkspace
+        if narrowed, let inScope = nearestInScopeTarget(after: location, scope: walkScope) {
             return inScope
         }
         return reselectionTarget(after: location)

--- a/agtermCore/Tests/agtermCoreTests/AppStoreCloseReselectionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreCloseReselectionTests.swift
@@ -2,10 +2,11 @@ import Foundation
 import Testing
 @testable import agtermCore
 
-/// Closing the ACTIVE session returns to the most-recently-active SURVIVING session, scoped to the
-/// closing session's workspace ∩ the VISIBLE set — the flagged list in `.flagged` mode, the marked
-/// workspaces' sessions while the focus filter applies — widening through everything visible and then
-/// the whole tree, with a positional walk as the last fallback (GitHub Discussion #147).
+/// Closing the ACTIVE session returns to the most-recently-active SURVIVING session, with recency asked
+/// per level, narrowest first: the closing session's workspace ∩ the VISIBLE set — the flagged list in
+/// `.flagged` mode, the marked workspaces' sessions while the focus filter applies — then that visible
+/// set, then the whole tree only while nothing is visible. A positional walk runs when no level
+/// remembers anyone (GitHub Discussion #147).
 @MainActor
 struct AppStoreCloseReselectionTests {
     @Test func closeActiveSessionInsertedAfterCurrentReturnsToTheSessionItCameFrom() throws {
@@ -277,6 +278,147 @@ struct AppStoreCloseReselectionTests {
         store.closeSession(closing.id)
         #expect(store.flaggedSessions.isEmpty)
         #expect(store.selectedSessionID == recentSurvivor.id)
+    }
+
+    // the workspace holds a survivor, but one that was never selected - `session new --no-select` leaves
+    // every tab it opens in that state until the first visit, so a script-filled workspace is normally in
+    // it. With no remembered local destination, a session visited elsewhere in the navigation set beats a
+    // neighbour the user has never opened.
+    @Test func closeWithNoRecencyInTheWorkspaceReturnsToTheVisitedSessionElsewhere() throws {
+        let store = makeStore()
+        let wsClosing = UUID(), wsOther = UUID()
+        let closing = UUID(), never = UUID(), visited = UUID()
+        store.restore(from: Snapshot(selectedSessionID: visited, workspaces: [
+            WorkspaceSnapshot(id: wsClosing, name: "work", sessions: [
+                SessionSnapshot(id: closing, customName: nil, cwd: "/closing"),
+                SessionSnapshot(id: never, customName: nil, cwd: "/never"),
+            ]),
+            WorkspaceSnapshot(id: wsOther, name: "other", sessions: [
+                SessionSnapshot(id: visited, customName: nil, cwd: "/visited"),
+            ]),
+        ]))
+        store.selectSession(closing)
+        #expect(store.sessionRecency.items == [closing, visited])
+
+        store.closeSession(closing)
+        #expect(store.selectedSessionID == visited)
+    }
+
+    // the visible level is the one the filters change: with TWO marked workspaces it spans both, so the
+    // pick crosses while the filter survives. Without this the rule can be re-tightened to "locality only
+    // while a filter applies" and the rest of the suite stays green.
+    @Test func closeUnderAFocusFilterCrossesToARememberedSessionInAnotherMarkedWorkspace() throws {
+        let store = makeStore()
+        let wsClosing = UUID(), wsOther = UUID()
+        let closing = UUID(), never = UUID(), visited = UUID()
+        store.restore(from: Snapshot(selectedSessionID: visited, workspaces: [
+            WorkspaceSnapshot(id: wsClosing, name: "work", sessions: [
+                SessionSnapshot(id: closing, customName: nil, cwd: "/closing"),
+                SessionSnapshot(id: never, customName: nil, cwd: "/never"),
+            ]),
+            WorkspaceSnapshot(id: wsOther, name: "other", sessions: [
+                SessionSnapshot(id: visited, customName: nil, cwd: "/visited"),
+            ]),
+        ], focusedWorkspaceIDs: [wsClosing, wsOther], focusEnabled: true))
+        store.selectSession(closing)
+        #expect(store.sessionRecency.items == [closing, visited])
+
+        store.closeSession(closing)
+        #expect(store.selectedSessionID == visited)
+        #expect(store.focusEnabled && store.focusedWorkspaceIDs == [wsClosing, wsOther])
+    }
+
+    // the flagged twin: the flagged list is itself cross-workspace, so the visible level crosses inside it
+    // and the pick stays inside the navigation set.
+    @Test func closeInFlaggedModeCrossesToARememberedFlaggedSessionInAnotherWorkspace() throws {
+        let store = makeStore()
+        let wsClosing = UUID(), wsOther = UUID()
+        let closing = UUID(), never = UUID(), visited = UUID()
+        store.restore(from: Snapshot(selectedSessionID: visited, workspaces: [
+            WorkspaceSnapshot(id: wsClosing, name: "work", sessions: [
+                SessionSnapshot(id: closing, customName: nil, cwd: "/closing", flagged: true),
+                SessionSnapshot(id: never, customName: nil, cwd: "/never", flagged: true),
+            ]),
+            WorkspaceSnapshot(id: wsOther, name: "other", sessions: [
+                SessionSnapshot(id: visited, customName: nil, cwd: "/visited", flagged: true),
+            ]),
+        ], sidebarMode: .flagged))
+        store.selectSession(closing)
+        #expect(store.sessionRecency.items == [closing, visited])
+
+        store.closeSession(closing)
+        #expect(store.selectedSessionID == visited)
+        #expect(store.flaggedSessions.map(\.id).contains(try #require(store.selectedSessionID)))
+    }
+
+    // the soft paths keep the closing session in recency for undo, so only the tree-derived sets keep it
+    // out of the new visible level - and the soft path is what the GUI takes by default.
+    @Test func softCloseWithNoRecencyInTheWorkspaceCrossesWithoutPickingTheClosingSession() throws {
+        let store = makeStore()
+        let wsClosing = UUID(), wsOther = UUID()
+        let closing = UUID(), never = UUID(), visited = UUID()
+        store.restore(from: Snapshot(selectedSessionID: visited, workspaces: [
+            WorkspaceSnapshot(id: wsClosing, name: "work", sessions: [
+                SessionSnapshot(id: closing, customName: nil, cwd: "/closing"),
+                SessionSnapshot(id: never, customName: nil, cwd: "/never"),
+            ]),
+            WorkspaceSnapshot(id: wsOther, name: "other", sessions: [
+                SessionSnapshot(id: visited, customName: nil, cwd: "/visited"),
+            ]),
+        ]))
+        store.selectSession(closing)
+
+        #expect(store.softCloseSession(closing, grace: 60))
+        #expect(store.sessionRecency.items.contains(closing), "undo needs the closing session in recency")
+        #expect(store.selectedSessionID == visited)
+    }
+
+    // the widening stops at the VISIBLE set: a visited session outside the focus filter must not win, or
+    // the pick silently drops the user's focus filter on close - the safety net reveals it by switching
+    // the filter off, which is the hazard here rather than an unreachable row.
+    @Test func closeUnderAFocusFilterPrefersTheInScopePickOverAVisitedSessionOutsideIt() throws {
+        let store = makeStore()
+        let wsClosing = UUID(), wsOther = UUID()
+        let closing = UUID(), never = UUID(), visited = UUID()
+        store.restore(from: Snapshot(selectedSessionID: visited, workspaces: [
+            WorkspaceSnapshot(id: wsClosing, name: "work", sessions: [
+                SessionSnapshot(id: closing, customName: nil, cwd: "/closing"),
+                SessionSnapshot(id: never, customName: nil, cwd: "/never"),
+            ]),
+            WorkspaceSnapshot(id: wsOther, name: "other", sessions: [
+                SessionSnapshot(id: visited, customName: nil, cwd: "/visited"),
+            ]),
+        ], focusedWorkspaceIDs: [wsClosing], focusEnabled: true))
+        // `restore` selects `closing` itself: `visited` is outside the filter, so its closing
+        // `reselectIfSelectionHidden` moves off it - which is also what leaves `visited` in recency.
+        #expect(store.sessionRecency.items == [closing, visited])
+
+        store.closeSession(closing)
+        #expect(store.selectedSessionID == never)
+        #expect(store.focusEnabled && store.focusedWorkspaceIDs == [wsClosing])
+    }
+
+    // same stop in flagged mode, where it matters more: `disableFocusIfSelectionOutsideSet` returns early
+    // there, so a pick outside the flagged list would sit outside the navigation set with nothing to
+    // bring it back.
+    @Test func closeInFlaggedModePrefersTheInScopePickOverAVisitedSessionOutsideTheList() throws {
+        let store = makeStore()
+        let wsClosing = UUID(), wsOther = UUID()
+        let closing = UUID(), never = UUID(), visited = UUID()
+        store.restore(from: Snapshot(selectedSessionID: visited, workspaces: [
+            WorkspaceSnapshot(id: wsClosing, name: "work", sessions: [
+                SessionSnapshot(id: closing, customName: nil, cwd: "/closing", flagged: true),
+                SessionSnapshot(id: never, customName: nil, cwd: "/never", flagged: true),
+            ]),
+            WorkspaceSnapshot(id: wsOther, name: "other", sessions: [
+                SessionSnapshot(id: visited, customName: nil, cwd: "/visited"),
+            ]),
+        ], sidebarMode: .flagged))
+        #expect(store.sessionRecency.items == [closing, visited])
+
+        store.closeSession(closing)
+        #expect(store.selectedSessionID == never)
+        #expect(store.flaggedSessions.map(\.id).contains(try #require(store.selectedSessionID)))
     }
 
     @Test func closeActiveSessionWithAnEmptyScopedRecencyFallsBackToThePositionalTarget() throws {

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -315,7 +315,10 @@ omitted when expanded).
   off its primary pane, where `tree.cwd` reports the primary, or a remote session, where it can read as
   home).
 - `session close [--target T ...]` — close one session, or repeat `--target` to close a batch with one
-  grace-period undo.
+  grace-period undo. Closing the SELECTED session moves the selection to the most recently used survivor,
+  which can be in another workspace when the closing one holds nothing the user has visited and that
+  survivor is in the same navigable set; that also moves what workspace-scoped `--target active` resolves
+  to, so read `tree` back before relying on it.
 - `session select` · `session rename <name>` · `session reveal` (select the focused pane's cwd in Finder).
 - `session go --to next|prev|first|last|next-attention|prev-attention` — move the selection between sessions.
 - `session move <workspace>` (relocate) or `session move --to up|down|top|bottom` (reorder within the

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -415,7 +415,15 @@ buys nothing. A caller with no tree uses `version`.
   (single-selection only).
 - `session close [--target T ...] [--window W]` — close one session, or repeat `--target` to close
   several sessions in the same window/store. Batch close honors the GUI grace-undo setting: one grouped
-  undo/reopen record when enabled, immediate close when disabled. Returns `result.affected`.
+  undo/reopen record when enabled, immediate close when disabled. Returns `result.affected`. Closing the
+  SELECTED session moves the selection to the most recently used surviving session, preferring one in the
+  closing session's workspace; when that workspace holds none the user has visited, the pick MAY leave it,
+  but only for a remembered session inside the same navigable set (so a single-workspace focus filter
+  keeps the pick local even with a remembered session outside it). Everything opened with `--no-select`
+  counts as unvisited until its first visit. The new selection is what
+  `tree` reports as `active`, and it carries `currentWorkspaceID` with it, so workspace-scoped
+  `--target active` (`session new`, `workspace focus`, `workspace rename`) follows it too — read `tree`
+  back after a close rather than assuming the workspace stayed.
 - `session select [--target] [--window W]`.
 - `session rename <name> [--target] [--window W]`.
 - `session reveal [--target] [--window W]` — select the target session's focused-pane working

--- a/site/docs.html
+++ b/site/docs.html
@@ -1144,12 +1144,13 @@
               Dashboard, recent sessions, and sessions needing attention for the last-active window; those lists and actions stay
               scoped to that window even if another window comes forward while the menu is open, apart from New Window, which
               belongs to no existing window and stays available whatever the last-active one is doing. That same recently-used history decides where you land when you close
-              the session you are in — agterm returns you to the session you were most recently working in, not to whichever row
-              happens to sit next to the one that closed. The pick stays inside the closing session's workspace, and in the flagged
-              view stays within the flagged set, while in the tree with the workspace filter applied it stays within the marked
-              workspaces. It widens
-              beyond the workspace only when the close leaves nothing there to return to, and beyond what is on screen only when
-              that too is exhausted. If no recent session qualifies at all, it falls back to the adjacent row, kept inside the
+              the session you are in — agterm returns you to a session you were recently working in, not to whichever row
+              happens to sit next to the one that closed. The pick prefers a session inside the closing session's workspace that you have
+              actually worked in, and in the flagged view stays within the flagged set, while in the tree with the workspace filter
+              applied it stays within the marked workspaces. It can leave the workspace when nothing there is a session you have
+              visited, even if sessions remain there - but only for one you have visited within those same bounds, so a
+              filter narrowed to a single workspace keeps you inside it either way. It looks outside those bounds only
+              when they hold no session at all. If no recent session qualifies at all, it falls back to the adjacent row, kept inside the
               narrowed view while one is applied, and to the first session of another workspace when the closed session was the
               last one in its own.
             </p>


### PR DESCRIPTION
Closing the active session in a workspace that holds no session you have ever visited puts you on the
positional neighbour rather than on the last session you actually used. So the question first, because
the answer is a product call and it is yours: **when the visible survivors in the closing workspace were
never visited, should locality still win over a session you did visit elsewhere?**

This branch is what "no" looks like, ready to merge or to close.

`closeReselectionTarget` picked one scope and asked recency once, widening only when the narrower set was
EMPTY. A workspace whose survivors were opened but never selected has nothing to recall, so the walk took
over. `session new --no-select` leaves every tab it opens in exactly that state until its first visit,
which makes a script-filled workspace normally in it - mine is one tab per Jira event, I read one of them,
and closing it lands me on a ticket I have never opened.

**Recency is now asked per level, narrowest first**: the closing session's workspace ∩ the visible set,
then that visible set. A remembered local survivor still wins, and a workspace that remembers nobody
yields only to a remembered session inside the same visible set - under a single-workspace narrowing the
two levels are one set, so the walk still takes it even when a remembered session sits outside the
filter. The change is the empty-local-history case, not locality itself.

**The whole tree stays gated on an empty visible set.** Outside the visible set a pick has no good end in
either mode: in `.flagged` it sits off the navigation set with `disableFocusIfSelectionOutsideSet`
returning early, and in `.tree` that same net fires and drops your focus filter to reveal it. Two of the
tests exist only to hold that gate.

**Two things worth knowing before you decide.** With no filter on, `navigableSessions` is every session,
so the second level is the whole tree in practice: this does let a close cross workspaces in the default
configuration, which is where the §2 objection below actually bites. And the selection carries `currentWorkspaceID`, so `session close` followed by a
target-less `session new` or `workspace focus` now resolves to a different workspace. The bundled skill, the website and `menu-actions.md` say so
now.

**This reverses half of one call in the plan.** `20260714-mru-reselection-on-close.md` §2 rejected an
unscoped most-recent survivor as "more disorienting than the positional neighbor", on two grounds: it
could pull you into another workspace, and it could silently drop a focus filter. The second ground is
preserved by the gate above, and the first changes only where the workspace remembers nobody and the
visible set remembers someone else.
`workspaceRemovalTarget` and the Ctrl-Tab switcher already prefer recency across workspaces, though
neither faces this choice; they are why it looked worth trying, not proof that §2 was wrong.

If you would rather keep the workspace term, close this and I will drop it.

Tested with `swift test` (3156) and `swiftlint --strict`. Six cases cover the crossing, both filters held
in scope with one marked workspace, both crossing with a filter spanning two, and a soft close where the
closing session stays in recency for undo and only the tree-derived sets keep it out.

Mutation-checked, each mutant dying to the tests meant to catch it. Worth naming one: consulting the
visible level only while no filter applies passed the whole suite before review, which is why the
spanning tests exist.

Related to #147
