### PR TITLE
fix(settings): fit the Interface and Agent Status tabs in the window

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -88,7 +88,7 @@ paths:
   contract, so freeing it risks a crash and the rare leak is accepted.
 - `.agtermAppearanceChanged` is required because terminal color is not observable; it updates
   `terminalColor`, quick-terminal backing, title/window appearance, and non-observable chrome mirrors.
-- Settings is a 540x640 six-tab SwiftUI scene with explicit selection defaulting General, preventing
+- Settings is a 540x680 six-tab SwiftUI scene with explicit selection defaulting General, preventing
   `com_apple_SwiftUI_Settings_selectedTabIndex` persistence. General holds Mouse, Sessions, and Ghostty
   Config. Appearance holds Terminal and Window. Interface groups `InterfaceElement`s two per row, plus
   Multiple Windows and the quick terminal's panel size, which sits there rather than under Appearance's

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -39,7 +39,7 @@ struct SettingsView: View {
                 .tabItem { Label("Key Mapping", systemImage: "keyboard") }
                 .tag(Tab.keyMapping)
         }
-        .frame(width: 540, height: 640)
+        .frame(width: 540, height: 680)
         // without this a process-launch reopen (see agtermApp's FB11763863 workaround) resurrects a stale
         // Settings window on its last tab, stealing key focus from the real launch window.
         .background(NonRestorableWindow())
@@ -446,7 +446,7 @@ private struct AppearanceSettingsView: View {
 }
 
 /// Interface tab: per-element title-bar and sidebar chrome visibility, grouped by surface, two toggles per
-/// row so the tab keeps fitting the fixed 540×640 window as the element set grows, plus the quick terminal's
+/// row so the tab keeps fitting the fixed 540×680 window as the element set grows, plus the quick terminal's
 /// panel size — that panel belongs to no window, so it is not a Window setting. Everything shows by
 /// default; a toggle off adds it to `AppSettings.hiddenInterfaceElements` and live-applies — title-bar and
 /// footer elements re-gate in open windows on `.agtermAppearanceChanged`, the add-session "+" on hover.
@@ -631,7 +631,6 @@ private struct AgentStatusSettingsView: View {
                     Text("Disabled").tag(StatusReset.never)
                 }
                 .accessibilityIdentifier("settings-status-clear")
-                SettingHint("When typing into a blocked or completed session clears its status.")
             }
 
             Section("Auto-follow") {


### PR DESCRIPTION
0.29.0 added controls to both tabs: the Custom commands toggle (#582) made the title-bar group six rows and the Typing section (#585) added a picker with a hint. Both tabs overflowed the fixed 540x640 frame and scrolled. Raise the shared frame to 540x680 and drop the Typing hint. The header and the picker's choices carry the context.
