### PR TITLE
cookbook: window-switcher, jump to a window by number or pick one with its waiting sessions in view

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -18,6 +18,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [project-launcher](project-launcher/) | pick a project anywhere — or type "project + prompt" — and get a session in its workspace | 0.19.0, jq |
 | [project-switcher](project-switcher/) | show only one project's workspaces in the sidebar | 0.18.0, jq |
 | [window-per-project](window-per-project/) | park every other window in the Dock and raise one | 0.17.1, jq |
+| [window-switcher](window-switcher/) | jump to a window by number, or pick one with its waiting sessions in view | 0.28.0, jq |
 | [workspace-sets](workspace-sets/) | switch the sidebar between named groups of workspaces, one chord each | 0.18.0, jq |
 
 ### Sessions across restarts

--- a/cookbook/window-switcher/README.md
+++ b/cookbook/window-switcher/README.md
@@ -1,0 +1,91 @@
+# Window switcher
+
+Jump straight to a window by number, or pick one from a list that shows which windows have sessions waiting for you.
+
+Grew out of [discussion #592](https://github.com/umputun/agterm/discussions/592).
+
+## What it does
+
+`window-switcher.sh goto 3` raises window number 3. One keymap line per number turns ⌘1…⌘9 into addresses: a window's number is its position in `agtermctl window list`, the library order File ▸ Open Window shows, closed windows included. So ⌘3 is always the same window no matter which one is frontmost, the numbers do not shift when a window closes, and ⌘N on a closed window opens it again. They move only when a bundle is deleted for good.
+
+`window-switcher.sh pick` opens a native picker over every window. Each row carries its ⌘N shortcut on the left, a ● in place of the number on the window you are in, the window name, and a `◆ N` badge when the window has sessions needing attention. The subtitle says where the window stands, `general › api` for the workspace and the session selected there, or spells out up to two of the attention sessions with how long they have waited, `◆ api blocked 2m, worker done 5m, +1`. Type to filter by name, Return raises the window.
+
+Nothing is closed or changed. The only thing either command does is raise a window.
+
+## Requirements
+
+- agterm 0.28.0 or later. The picker marks the current window with `window list`'s `active` flag, and 0.28.0 is where that flag stopped naming the previous window after another one was revealed; everything else the script uses, `window select`, `tree --window`, `pick` with subtitles and `statusChangedAt` on the tree, is older. With the release that ships `pick --select` (after 0.29.1) the picker opens on the current window; until then it opens on the first row.
+- `jq`
+
+## Setup
+
+Copy the script somewhere on your `PATH` and make it executable:
+
+```sh
+mkdir -p ~/bin
+cp window-switcher.sh ~/bin/
+chmod +x ~/bin/window-switcher.sh
+```
+
+Add the picker and one line per number to `~/.config/agterm/keymap.conf`:
+
+```
+command "Pick Window"  cmd+opt+=  ~/bin/window-switcher.sh pick
+command "Window 1"     cmd+1      ~/bin/window-switcher.sh goto 1
+command "Window 2"     cmd+2      ~/bin/window-switcher.sh goto 2
+command "Window 3"     cmd+3      ~/bin/window-switcher.sh goto 3
+command "Window 4"     cmd+4      ~/bin/window-switcher.sh goto 4
+command "Window 5"     cmd+5      ~/bin/window-switcher.sh goto 5
+command "Window 6"     cmd+6      ~/bin/window-switcher.sh goto 6
+command "Window 7"     cmd+7      ~/bin/window-switcher.sh goto 7
+command "Window 8"     cmd+8      ~/bin/window-switcher.sh goto 8
+command "Window 9"     cmd+9      ~/bin/window-switcher.sh goto 9
+```
+
+Bind as many numbers as you have windows; the picker shows ⌘N for the first nine either way, so a number without a line is a shortcut that does nothing. Apply the file with File ▸ Reload Keymap or `agtermctl keymap reload`.
+
+Fired from a key chord or the palette, the script runs under the app's `PATH` rather than your shell's. That is the launchd default: `/usr/local/bin` plus the system directories, with no `/opt/homebrew/bin` and nothing else your profile adds. Every binary the script calls has to resolve there or be written in full, `jq` as much as `agtermctl`. `agtermctl` normally does, because **Help ▸ Install Command Line Tool…** symlinks it into `/usr/local/bin`. `jq` does only if it is a system one; recent macOS ships `/usr/bin/jq`, but a Homebrew `jq` is out of reach and needs its absolute path written into the script. Set `AGTERMCTL` to the binary's full path if yours sits somewhere unusual.
+
+The gutter before the window name is made of spaces, since the picker has no columns, and the counts are tuned for the default palette font. If the names do not line up on your setup, set `PAD_SHORTCUT` (after `⌘N`), `PAD_CURRENT` (after `●`) and `PAD_NONE` (windows past the ninth) in the keymap line, `PAD_CURRENT='    ' ~/bin/window-switcher.sh pick`, and check the rows with `window-switcher.sh items` until they do.
+
+## Usage
+
+Press ⌘3 and window 3 comes forward, or comes back on screen if you had closed it. Press ⌘⌥= for the list, type part of a name or just look at the badges, Return raises the row, Escape leaves everything as it was.
+
+From a shell:
+
+```sh
+window-switcher.sh goto 3
+window-switcher.sh pick
+window-switcher.sh items | jq .
+```
+
+`items` prints the rows the picker would show, so you can read the attention summary without opening it, or check the gutter after changing the padding.
+
+The picker is for looking before you leap. For stepping, `previous_window` and `next_window` are built in since 0.29.0, keyless in the keymap and in Navigate ▸ Previous Window and Next Window. For going straight to a session that asked for you, ⌃⇧I is the attention list, and in the release after 0.29.1 it covers every open window.
+
+## How it works
+
+`agtermctl window list --json` returns every window with its `id`, `name`, `open` and `active`, in library order. The index in that array is the window's number, and `goto` is a lookup followed by `window select`, which raises an open window and opens a closed one, the same verb either way.
+
+For the picker the script reads `agtermctl tree --window <id> --json` for each open window. A session node's `status` is `blocked`, `completed` or `active` when an agent has reported one, and `statusChangedAt` is the epoch second it was last written, so `now - statusChangedAt` is the age shown in the subtitle. Sessions in `blocked` or `completed` make up the badge, the same set ⌃⌥↑/↓ walk within a window; `active` is not waiting for anyone and is left out. The session on screen in the current window is left out of its window's badge too, since you can already see it. Closed windows have no tree and get no round trip. An auto-named session is named after its working directory, which does not fit a picker row, so a path-like name is cut down to its last component.
+
+The rows go to `agtermctl pick` as JSON with `id`, `label` and `subtitle`. The picker matches the query against labels only, so the attention text in a subtitle never filters a row in or out, and an empty query keeps the supplied order, which is what makes the row order the window order. When the CLI knows `--select`, the picker opens on the current window's row, so Return on an untouched list stays put and ↑/↓ read as the window above and below. The script checks for the flag with `agtermctl pick open --help`, because an older CLI rejects an unknown option before it opens anything; the check costs no socket round trip and lets the same script run on either side of that release.
+
+`pick` has no columns, so the shortcut gutter is spaces, counted so that `⌘N` plus its padding, `●` plus its padding and the no-shortcut padding come out the same width in the palette font. The subtitle is set in a smaller font, so no whole number of spaces would line it up with the name, and it is deliberately not indented; a near miss looks worse than none.
+
+From a chord the script's output goes nowhere, so a missing `jq` shows up as a picker that never opens rather than as an error. Run the script from a shell to see what it says.
+
+## Limits
+
+Nothing here closes or deletes anything. The one thing to know before pressing a number is that ⌘N on a closed window opens it again, exactly as File ▸ Open Window would, and its sessions start along with it.
+
+Numbers are stable across closing and reopening but not across deletion: `delete_window` on a bundle shifts every window after it down by one. Nine chords cover nine windows; the rest are in the picker without a shortcut.
+
+The gutter is tuned by hand for the default palette font. Change the font size in Settings and the names stop lining up until the padding is retuned. The subtitle line cannot be aligned at all.
+
+Until the release that ships `pick --select`, the picker opens on the first row, so Return on an untouched list goes to window 1 rather than staying where you are.
+
+Attention is the agent status as reported over `session status`, so only sessions whose agent reports it get a badge. The age is the age of the last write, not of the first: a hook that re-asserts `blocked` on every event keeps the counter fresh. Status is never persisted, so right after a restart every badge is gone. The notification badge on the sidebar row is a different thing and is not counted.
+
+The picker opens after one `tree` read per open window. With a handful of windows that is not noticeable; with a couple of dozen it is a pause before the list appears.

--- a/cookbook/window-switcher/window-switcher.sh
+++ b/cookbook/window-switcher/window-switcher.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# window-switcher.sh - jump to an agterm window by number, or pick one from a list that
+# shows which windows have sessions waiting for you.
+#
+#   goto N   raise window number N. A window's number is its position in
+#            `agtermctl window list`, i.e. the library order, closed windows included,
+#            so the number does not depend on which window is frontmost and does not
+#            shift when a window is closed. `goto` on a closed window reopens it.
+#   pick     a native picker over every window: the ⌘N shortcut on the left, ● in place
+#            of the number on the current window, a "◆ N" badge on windows with sessions
+#            needing attention and up to two of them spelled out in the subtitle. Opens
+#            on the current window when the CLI knows `pick --select`.
+#   items    print the picker rows as JSON, for reading them or tuning the gutter without
+#            opening the picker.
+#
+# "Attention" is agterm's own notion: a session whose agent status is `blocked` (waiting
+# for input) or `completed` (finished, not yet looked at), the set ⌃⌥↑/↓ walk within a
+# window. The session on screen in the current window is left out of that window's badge:
+# you can already see it, and the badge is for what you can't.
+set -eu
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+sock=${AGT_SOCKET:-}
+TAB=$(printf '\t')
+
+# Gutter padding for the first line, where ⌘N or ● sits before the window name. `pick`
+# has no columns, so the gutter is made of spaces, measured against the default palette
+# font: "⌘N" plus PAD_SHORTCUT, ● plus PAD_CURRENT and PAD_NONE alone come out the same
+# width. The subtitle is set in a smaller font, so no whole number of spaces lines it up
+# with the name and it is deliberately not indented.
+PAD_SHORTCUT=${PAD_SHORTCUT:-'   '}   # after ⌘N
+PAD_CURRENT=${PAD_CURRENT:-'     '}   # after ●, which replaces the shortcut on the current window
+PAD_NONE=${PAD_NONE:-'          '}    # windows past the ninth, which get no shortcut
+
+agt() {
+	if [ -n "$sock" ]; then
+		"$AGTERMCTL" "$@" --socket "$sock"
+	else
+		"$AGTERMCTL" "$@"
+	fi
+}
+
+# Every window in `window list` order; the position in this array is the window number.
+all_windows() {
+	agt window list --json | jq -c '.result.windows'
+}
+
+# One object per window, on top of its `window list` entry: `where`, the workspace and
+# the session selected there ("closed" for a closed window), and `attn`, the sessions
+# needing attention, freshest status first, each as {name, status, at}. A closed window
+# has no tree to read, so it gets an empty list without a round trip.
+windows_info() {
+	windows=$(all_windows)
+	now=$(date +%s)
+	extra=$(printf '%s' "$windows" | jq -r '.[] | "\(.open)\t\(.active)\t\(.id)"' |
+		while IFS="$TAB" read -r open active id; do
+			if [ "$open" != "true" ]; then
+				printf '{"where":"closed","attn":[]}\n'
+				continue
+			fi
+			agt tree --window "$id" --json 2>/dev/null | jq -c --argjson current "$active" '
+				# an auto-named session is its working directory, which the picker row
+				# has no room for, so a path-like name is cut down to its last component
+				def short: if test("^(…|~|\\.)?/")
+				           then (split("/") | map(select(. != "")) | last) // .
+				           else . end;
+				[.result.tree.workspaces[]? | .name as $ws | .sessions[]?
+				 | . + {ws: $ws, name: (.name | short)}] as $sessions
+				| {
+				    where: ([$sessions[] | select(.active) | "\(.ws) › \(.name)"] | first // ""),
+				    attn: ([$sessions[]
+				            | select(.status == "blocked" or .status == "completed")
+				            | select(($current and .active) | not)
+				            | {name, status, at: (.statusChangedAt // 0)}]
+				           | sort_by(-.at))
+				  }' 2>/dev/null || printf '{"where":"","attn":[]}\n'
+		done | jq -s .)
+	printf '%s' "$windows" | jq -c --argjson extra "$extra" --argjson now "$now" '
+		to_entries | map(.value + ($extra[.key] // {where: "", attn: []}) + {slot: .key, now: $now})'
+}
+
+# Picker rows in window order. The subtitle is one line the picker truncates in the
+# middle when it overflows, so at most two attention sessions are spelled out and the
+# rest fold into "+N".
+items() {
+	windows_info | jq -c \
+		--arg pad "$PAD_SHORTCUT" --arg padCur "$PAD_CURRENT" --arg padNone "$PAD_NONE" '
+		def age: [.now - .at, 0] | max | floor
+		  | if . < 60 then "\(.)s"
+		    elif . < 3600 then "\(. / 60 | floor)m"
+		    elif . < 86400 then "\(. / 3600 | floor)h"
+		    else "\(. / 86400 | floor)d" end;
+		def word: if . == "blocked" then "blocked" else "done" end;
+		map(. as $w
+		  | {
+		      id: .id,
+		      label: ((if .active then "●" + $padCur
+		               elif .slot < 9 then "⌘\(.slot + 1)" + $pad
+		               else $padNone end)
+		              + .name
+		              + (if (.attn | length) > 0 then "  ◆ \(.attn | length)" else "" end)),
+		      subtitle: (if (.attn | length) == 0 then .where
+		                 else ((if .where == "" then "" else .where + "  " end)
+		                       + "◆ "
+		                       + (([.attn[:2][] | "\(.name) \(.status | word) \({now: $w.now, at: .at} | age)"]
+		                           + (if (.attn | length) > 2 then ["+\(.attn | length - 2)"] else [] end))
+		                          | join(", ")))
+		                 end)
+		    })
+		| map(if .subtitle == "" then del(.subtitle) else . end)'
+}
+
+# `pick --select` shipped after 0.29.1. An older CLI rejects the option before it opens
+# anything, and its `--help` does not list it, so the check costs no socket round trip.
+supports_select() {
+	"$AGTERMCTL" pick open --help 2>&1 | grep -q -- '--select'
+}
+
+case "${1:-pick}" in
+goto)
+	n=${2:-}
+	case "$n" in '' | *[!0-9]*)
+		echo "usage: ${0##*/} goto N" >&2
+		exit 64
+		;;
+	esac
+	id=$(all_windows | jq -r --argjson n "$n" 'if $n >= 1 and $n <= length then .[$n - 1].id else "" end')
+	[ -n "$id" ] || exit 0
+	agt window select "$id"
+	;;
+items)
+	items
+	;;
+pick)
+	rows=$(items)
+	current=$(printf '%s' "$rows" | jq -r '[.[] | select(.label | startswith("●")) | .id] | first // ""')
+	if [ -n "$current" ] && supports_select; then
+		set -- --select "$current"
+	else
+		set --
+	fi
+	result=$(printf '%s' "$rows" | agt pick --prompt "Select a window..." "$@") || exit 0
+	id=$(printf '%s' "$result" | jq -r 'if .result == "picked" then .id else "" end')
+	[ -n "$id" ] || exit 0
+	agt window select "$id"
+	;;
+*)
+	echo "usage: ${0##*/} goto N | pick | items" >&2
+	exit 64
+	;;
+esac


### PR DESCRIPTION
Two custom commands over window list / window select: goto N raises the window at slot N of the library order, closed windows included, so a number stays an address after the window closes; pick opens a native picker with the ⌘N gutter, a ● on the current window and a ◆ N badge with the blocked/completed sessions of each window in the subtitle. From discussion #592.